### PR TITLE
Sagonzal/remove sun api

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/AsymmetricKeyCredential.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AsymmetricKeyCredential.java
@@ -74,7 +74,7 @@ public final class AsymmetricKeyCredential implements IClientCredential{
         }
         else if("sun.security.mscapi.RSAPrivateKey".equals(key.getClass().getName())){
             try {
-                Method method = key.getClass().getMethod("length", null);
+                Method method = key.getClass().getMethod("length");
                 method.setAccessible(true);
                 if ((int)method.invoke(key)< MIN_KEY_SIZE_IN_BITS) {
                     throw new IllegalArgumentException(


### PR DESCRIPTION
Fix for #11. Removing use of sun.security.util.Length

This change gets tested every time integration tests are run, as we are using Microsoft certificate store for Keyvault credentials. 