### PR TITLE
Update device code unit test to reflect service changes

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/DeviceCodeAuthorizationGrant.java
+++ b/src/main/java/com/microsoft/aad/msal4j/DeviceCodeAuthorizationGrant.java
@@ -59,7 +59,7 @@ class DeviceCodeAuthorizationGrant extends AbstractMsalAuthorizationGrant {
         final Map<String, List<String>> outParams = new LinkedHashMap<>();
         outParams.put(SCOPE_PARAM_NAME, Collections.singletonList(COMMON_SCOPES_PARAM + SCOPES_DELIMITER + scopes));
         outParams.put("grant_type", Collections.singletonList(GRANT_TYPE));
-        outParams.put("code", Collections.singletonList(deviceCode.deviceCode()));
+        outParams.put("device_code", Collections.singletonList(deviceCode.deviceCode()));
         outParams.put("client_info", Collections.singletonList("1"));
 
         return outParams;

--- a/src/test/java/com/microsoft/aad/msal4j/DeviceCodeFlowTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/DeviceCodeFlowTest.java
@@ -73,8 +73,8 @@ public class DeviceCodeFlowTest extends PowerMockTestCase {
             "  \"user_code\": \"DW83JNP2P\",\n" +
             "  \"device_code\": \"DAQABAAEAAADRNYRQ3dhRFEeqWvq-yi6QodK2pb1iAA\",\n" +
             "  \"verification_uri\": \"https://aka.ms/devicelogin\",\n" +
-            "  \"expires_in\": \"900\",\n" +
-            "  \"interval\": \"5\",\n" +
+            "  \"expires_in\": 900,\n" +
+            "  \"interval\": 5,\n" +
             "  \"message\": \"To sign in, use a web browser to open the page https://aka.ms/devicelogin and enter the code DW83JNP2P to authenticate.\"\n" +
             "}";
 


### PR DESCRIPTION
Service will start returning integers instead of strings for expires_in and interval. No changes needed for deserialization, but updating unit test to reflect this. 