### PR TITLE
Make Builder constructor private 

### DIFF
--- a/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenSilentIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenSilentIT.java
@@ -51,7 +51,7 @@ public class AcquireTokenSilentIT {
         String password = labUserProvider.getUserPassword(labResponse.getUser());
         String labAuthority = TestConstants.MICROSOFT_AUTHORITY_HOST + labResponse.getUser().getTenantId();
 
-        PublicClientApplication pca = new PublicClientApplication.Builder(
+        PublicClientApplication pca = PublicClientApplication.builder(
                 labResponse.getAppId()).
                 authority(labAuthority).
                 build();
@@ -85,7 +85,7 @@ public class AcquireTokenSilentIT {
                 false);
         String password = labUserProvider.getUserPassword(labResponse.getUser());
 
-        PublicClientApplication pca = new PublicClientApplication.Builder(
+        PublicClientApplication pca = PublicClientApplication.builder(
                 labResponse.getAppId()).
                 authority(TestConstants.ORGANIZATIONS_AUTHORITY).
                 build();
@@ -158,7 +158,7 @@ public class AcquireTokenSilentIT {
                 false);
         String password = labUserProvider.getUserPassword(labResponse.getUser());
 
-        PublicClientApplication pca = new PublicClientApplication.Builder(
+        PublicClientApplication pca = PublicClientApplication.builder(
                 labResponse.getAppId()).
                 authority(TestConstants.ORGANIZATIONS_AUTHORITY).
                 build();
@@ -194,7 +194,7 @@ public class AcquireTokenSilentIT {
                 false);
         String password = labUserProvider.getUserPassword(labResponse.getUser());
 
-        PublicClientApplication pca = new PublicClientApplication.Builder(
+        PublicClientApplication pca = PublicClientApplication.builder(
                 labResponse.getAppId()).
                 authority(authority).
                 build();

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/ClientCredentialsIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/ClientCredentialsIT.java
@@ -41,7 +41,7 @@ public class ClientCredentialsIT {
     }
 
     private void assertAcquireTokenCommon(String clientId, IClientCredential credential) throws Exception{
-        ConfidentialClientApplication cca = new ConfidentialClientApplication.Builder(
+        ConfidentialClientApplication cca = ConfidentialClientApplication.builder(
                 clientId, credential).
                 authority(TestConstants.MICROSOFT_AUTHORITY).
                 build();

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
@@ -42,7 +42,7 @@ public class DeviceCodeIT {
                 false);
         labUserProvider.getUserPassword(labResponse.getUser());
 
-        PublicClientApplication pca = new PublicClientApplication.Builder(
+        PublicClientApplication pca = PublicClientApplication.builder(
                 labResponse.getAppId()).
                 authority(TestConstants.ORGANIZATIONS_AUTHORITY).
                 build();

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/NationalCloudIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/NationalCloudIT.java
@@ -41,7 +41,7 @@ public class NationalCloudIT {
                 false);
         String password = labUserProvider.getUserPassword(labResponse.getUser());
 
-        PublicClientApplication pca = new PublicClientApplication.Builder(
+        PublicClientApplication pca = PublicClientApplication.builder(
                 labResponse.getAppId()).
                 authority(TestConstants.ORGANIZATIONS_AUTHORITY).
                 build();

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/RefreshTokenIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/RefreshTokenIT.java
@@ -26,7 +26,7 @@ public class RefreshTokenIT {
                 NationalCloud.AZURE_CLOUD,
                 false);
         String password = labUserProvider.getUserPassword(labResponse.getUser());
-        pca = new PublicClientApplication.Builder(
+        pca = PublicClientApplication.builder(
                 labResponse.getAppId()).
                 authority(TestConstants.ORGANIZATIONS_AUTHORITY).
                 build();

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/TokenCacheIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/TokenCacheIT.java
@@ -30,7 +30,7 @@ public class TokenCacheIT {
                 false);
         String password = labUserProvider.getUserPassword(labResponse.getUser());
 
-        PublicClientApplication pca = new PublicClientApplication.Builder(
+        PublicClientApplication pca = PublicClientApplication.builder(
                 labResponse.getAppId()).
                 authority(TestConstants.ORGANIZATIONS_AUTHORITY).
                 build();
@@ -62,7 +62,7 @@ public class TokenCacheIT {
                 false);
         String password = labUserProvider.getUserPassword(labResponse1.getUser());
 
-        PublicClientApplication pca = new PublicClientApplication.Builder(
+        PublicClientApplication pca = PublicClientApplication.builder(
                 labResponse1.getAppId()).
                 authority(TestConstants.ORGANIZATIONS_AUTHORITY).
                 build();
@@ -125,7 +125,7 @@ public class TokenCacheIT {
         ITokenCacheAccessAspect persistenceAspect = new TokenPersistence(dataToInitCache);
 
         // acquire tokens for home tenant, and serialize cache
-        PublicClientApplication pca = new PublicClientApplication.Builder(
+        PublicClientApplication pca = PublicClientApplication.builder(
                 labResponse.getAppId()).
                 authority(TestConstants.ORGANIZATIONS_AUTHORITY)
                 .setTokenCacheAccessAspect(persistenceAspect)
@@ -141,7 +141,7 @@ public class TokenCacheIT {
         String guestTenantAuthority = TestConstants.MICROSOFT_AUTHORITY_HOST + labResponse.getUser().getTenantId();
 
         // initialize pca with tenant where user is guest, deserialize cache, and acquire second token
-        PublicClientApplication pca2 = new PublicClientApplication.Builder(
+        PublicClientApplication pca2 = PublicClientApplication.builder(
                 labResponse.getAppId()).
                 authority(guestTenantAuthority).
                 setTokenCacheAccessAspect(persistenceAspect).

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/UsernamePasswordIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/UsernamePasswordIT.java
@@ -75,7 +75,7 @@ public class UsernamePasswordIT {
 
     public void assertAcquireTokenCommon(LabResponse labResponse, String password)
             throws Exception{
-        PublicClientApplication pca = new PublicClientApplication.Builder(
+        PublicClientApplication pca = PublicClientApplication.builder(
                 labResponse.getAppId()).
                 authority(TestConstants.ORGANIZATIONS_AUTHORITY).
                 build();
@@ -103,7 +103,7 @@ public class UsernamePasswordIT {
         String b2CAppId = "e3b9ad76-9763-4827-b088-80c7a7888f79";
         String password = labUserProvider.getUserPassword(labResponse.getUser());
 
-        PublicClientApplication pca = new PublicClientApplication.Builder(
+        PublicClientApplication pca = PublicClientApplication.builder(
                 b2CAppId).
                 b2cAuthority(TestConstants.B2C_AUTHORITY_ROPC).
                 build();
@@ -129,7 +129,7 @@ public class UsernamePasswordIT {
         String b2CAppId = "e3b9ad76-9763-4827-b088-80c7a7888f79";
         String password = labUserProvider.getUserPassword(labResponse.getUser());
 
-        PublicClientApplication pca = new PublicClientApplication.Builder(
+        PublicClientApplication pca = PublicClientApplication.builder(
                 b2CAppId).
                 b2cAuthority(TestConstants.B2C_MICROSOFTLOGIN_ROPC).
                 build();

--- a/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
@@ -109,14 +109,7 @@ public class ConfidentialClientApplication extends ClientApplicationBase impleme
 
         private IClientCredential clientCredential;
 
-        /**
-         * Constructor to create instance of Builder of ConfidentialClientApplication
-         *
-         * @param clientId         Client ID (Application ID) of the application as registered
-         *                         in the application registration portal (portal.azure.com)
-         * @param clientCredential The client credential to use for token acquisition.
-         */
-        Builder(String clientId, IClientCredential clientCredential) {
+        private Builder(String clientId, IClientCredential clientCredential) {
             super(clientId);
             this.clientCredential = clientCredential;
         }

--- a/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
+++ b/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
@@ -97,13 +97,7 @@ public class PublicClientApplication extends ClientApplicationBase implements IP
 
     public static class Builder extends ClientApplicationBase.Builder<Builder> {
 
-        /**
-         * Constructor to create instance of Builder of PublicClientApplication
-         *
-         * @param clientId Client ID (Application ID) of the application as registered
-         *                 in the application registration portal (portal.azure.com)
-         */
-        Builder(String clientId) {
+        private Builder(String clientId) {
             super(clientId);
         }
 

--- a/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
+++ b/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
@@ -126,7 +126,7 @@ public class CacheFormatTests extends AbstractMsalTests {
 
         String tokenResponse = getTokenResponse(folder);
 
-        PublicClientApplication app = new PublicClientApplication.Builder(CLIENT_ID).build();
+        PublicClientApplication app = PublicClientApplication.builder(CLIENT_ID).build();
 
         AuthorizationCodeParameters parameters =
                 AuthorizationCodeParameters.builder

--- a/src/test/java/com/microsoft/aad/msal4j/ConfidentialClientApplicationTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/ConfidentialClientApplicationTest.java
@@ -35,7 +35,7 @@ public class ConfidentialClientApplicationTest extends PowerMockTestCase {
     public void testAcquireTokenAuthCode_ClientCredential() throws Exception {
         app = PowerMock.createPartialMock(ConfidentialClientApplication.class,
                 new String[] { "acquireTokenCommon" },
-                new ConfidentialClientApplication.Builder(TestConfiguration.AAD_CLIENT_ID,
+                ConfidentialClientApplication.builder(TestConfiguration.AAD_CLIENT_ID,
                 ClientCredentialFactory.create(TestConfiguration.AAD_CLIENT_SECRET))
                         .authority(TestConfiguration.AAD_TENANT_ENDPOINT)
         );
@@ -82,7 +82,7 @@ public class ConfidentialClientApplicationTest extends PowerMockTestCase {
 
         app = PowerMock.createPartialMock(ConfidentialClientApplication.class,
                 new String[] { "acquireTokenCommon" },
-                new ConfidentialClientApplication.Builder(TestConfiguration.AAD_CLIENT_ID, clientCredential)
+                ConfidentialClientApplication.builder(TestConfiguration.AAD_CLIENT_ID, clientCredential)
                         .authority(TestConfiguration.AAD_TENANT_ENDPOINT));
 
         PowerMock.expectPrivate(app, "acquireTokenCommon",
@@ -127,7 +127,7 @@ public class ConfidentialClientApplicationTest extends PowerMockTestCase {
 
         app = PowerMock.createPartialMock(ConfidentialClientApplication.class,
                 new String[] { "acquireTokenCommon" },
-                new ConfidentialClientApplication.Builder(TestConfiguration.AAD_CLIENT_ID, clientCredential)
+                ConfidentialClientApplication.builder(TestConfiguration.AAD_CLIENT_ID, clientCredential)
                         .authority(TestConfiguration.AAD_TENANT_ENDPOINT));
 
         PowerMock.expectPrivate(app, "acquireTokenCommon",

--- a/src/test/java/com/microsoft/aad/msal4j/DeviceCodeFlowTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/DeviceCodeFlowTest.java
@@ -63,7 +63,7 @@ public class DeviceCodeFlowTest extends PowerMockTestCase {
     public void deviceCodeFlowTest() throws Exception {
         app = PowerMock.createPartialMock(PublicClientApplication.class,
                 new String[] { "acquireTokenCommon" },
-                new PublicClientApplication.Builder(TestConfiguration.AAD_CLIENT_ID)
+                PublicClientApplication.builder(TestConfiguration.AAD_CLIENT_ID)
                         .authority(TestConfiguration.AAD_TENANT_ENDPOINT));
 
         Capture<MsalRequest> capturedMsalRequest = Capture.newInstance();
@@ -158,7 +158,7 @@ public class DeviceCodeFlowTest extends PowerMockTestCase {
 //    public void executeAcquireDeviceCode_AdfsAuthorityUsed_IllegalArgumentExceptionThrown()
 //            throws Exception {
 //
-//        app = new PublicClientApplication.Builder("client_id")
+//        app = PublicClientApplication.builder("client_id")
 //                .authority(ADFS_TENANT_ENDPOINT)
 //                .validateAuthority(false).build();
 //
@@ -173,7 +173,7 @@ public class DeviceCodeFlowTest extends PowerMockTestCase {
     public void executeAcquireDeviceCode_B2CAuthorityUsed_IllegalArgumentExceptionThrown()
             throws Exception {
 
-        app = new PublicClientApplication.Builder("client_id")
+        app = PublicClientApplication.builder("client_id")
                 .b2cAuthority(TestConfiguration.B2C_AUTHORITY)
                 .validateAuthority(false).build();
 
@@ -195,7 +195,7 @@ public class DeviceCodeFlowTest extends PowerMockTestCase {
 
         Consumer<DeviceCode> deviceCodeConsumer = (DeviceCode deviceCode) -> { };
 
-        app = new PublicClientApplication.Builder("client_id")
+        app = PublicClientApplication.builder("client_id")
                 .authority(AAD_TENANT_ENDPOINT)
                 .validateAuthority(false)
                 .build();

--- a/src/test/java/com/microsoft/aad/msal4j/OAuthRequestValidationTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/OAuthRequestValidationTest.java
@@ -141,7 +141,7 @@ public class OAuthRequestValidationTest extends PowerMockTestCase {
     @Test
     public void oAuthRequest_for_acquireTokenByUserAssertion() throws Exception {
         ConfidentialClientApplication app =
-                new ConfidentialClientApplication.Builder(CLIENT_ID, ClientCredentialFactory.create(CLIENT_SECRET))
+                ConfidentialClientApplication.builder(CLIENT_ID, ClientCredentialFactory.create(CLIENT_SECRET))
                         .authority(AUTHORITY)
                         .validateAuthority(false).build();
 
@@ -210,7 +210,7 @@ public class OAuthRequestValidationTest extends PowerMockTestCase {
 
             IClientCredential clientCredential = ClientCredentialFactory.create(key, cert);
 
-            ConfidentialClientApplication app = new ConfidentialClientApplication.Builder(CLIENT_ID, clientCredential)
+            ConfidentialClientApplication app = ConfidentialClientApplication.builder(CLIENT_ID, clientCredential)
                     .authority(AUTHORITY)
                     .validateAuthority(false).build();
 
@@ -260,7 +260,7 @@ public class OAuthRequestValidationTest extends PowerMockTestCase {
                     .getCertificate(alias);
 
             ConfidentialClientApplication app =
-                    new ConfidentialClientApplication.Builder(CLIENT_ID, ClientCredentialFactory.create(key, cert))
+                    ConfidentialClientApplication.builder(CLIENT_ID, ClientCredentialFactory.create(key, cert))
                             .authority(AUTHORITY)
                             .validateAuthority(false)
                             .build();

--- a/src/test/java/com/microsoft/aad/msal4j/PublicClientApplicationTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/PublicClientApplicationTest.java
@@ -29,7 +29,7 @@ public class PublicClientApplicationTest extends PowerMockTestCase {
     public void testAcquireToken_Username_Password() throws Exception {
         app = PowerMock.createPartialMock(PublicClientApplication.class,
                 new String[] { "acquireTokenCommon" },
-                new PublicClientApplication.Builder(TestConfiguration.AAD_CLIENT_ID)
+                PublicClientApplication.builder(TestConfiguration.AAD_CLIENT_ID)
                         .authority(TestConfiguration.AAD_TENANT_ENDPOINT));
 
         PowerMock.expectPrivate(app, "acquireTokenCommon",

--- a/src/test/java/com/microsoft/aad/msal4j/TelemetryTests.java
+++ b/src/test/java/com/microsoft/aad/msal4j/TelemetryTests.java
@@ -41,7 +41,7 @@ public class TelemetryTests {
 
     @Test
     public void telemetryConsumerRegistration_ConsumerNotNullTest(){
-        PublicClientApplication app = new PublicClientApplication.Builder("a1b2c3")
+        PublicClientApplication app = PublicClientApplication.builder("a1b2c3")
                 .telemetryConsumer(new MyTelemetryConsumer().telemetryConsumer)
                 .build();
 

--- a/src/test/java/com/microsoft/aad/msal4j/TokenRequestTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/TokenRequestTest.java
@@ -107,7 +107,7 @@ public class TokenRequestTest extends AbstractMsalTests {
     }
 
     private TokenRequest createMockedTokenRequest() throws URISyntaxException, MalformedURLException {
-        PublicClientApplication app = new PublicClientApplication.Builder("id").build();
+        PublicClientApplication app = PublicClientApplication.builder("id").build();
 
         AuthorizationCodeParameters parameters = AuthorizationCodeParameters
                 .builder("code", new URI("http://my.redirect.com"))
@@ -138,7 +138,7 @@ public class TokenRequestTest extends AbstractMsalTests {
     public void testConstructor() throws MalformedURLException,
             URISyntaxException {
 
-        PublicClientApplication app = new PublicClientApplication.Builder("id").build();
+        PublicClientApplication app = PublicClientApplication.builder("id").build();
 
         AuthorizationCodeParameters parameters = AuthorizationCodeParameters
                 .builder("code", new URI("http://my.redirect.com"))
@@ -164,7 +164,7 @@ public class TokenRequestTest extends AbstractMsalTests {
     public void testToOAuthRequestNonEmptyCorrelationId()
             throws MalformedURLException, SerializeException, URISyntaxException {
 
-        PublicClientApplication app = new PublicClientApplication.Builder("id").build();
+        PublicClientApplication app = PublicClientApplication.builder("id").build();
 
         AuthorizationCodeParameters parameters = AuthorizationCodeParameters
                 .builder("code", new URI("http://my.redirect.com"))
@@ -197,7 +197,7 @@ public class TokenRequestTest extends AbstractMsalTests {
             throws MalformedURLException, SerializeException,
             URISyntaxException {
 
-        PublicClientApplication app = new PublicClientApplication.Builder("id").build();
+        PublicClientApplication app = PublicClientApplication.builder("id").build();
 
         AuthorizationCodeParameters parameters = AuthorizationCodeParameters
                 .builder("code", new URI("http://my.redirect.com"))
@@ -225,7 +225,7 @@ public class TokenRequestTest extends AbstractMsalTests {
     public void testExecuteOAuth_Success() throws SerializeException, ParseException, MsalException,
             IOException, URISyntaxException {
 
-        PublicClientApplication app = new PublicClientApplication.Builder("id").build();
+        PublicClientApplication app = PublicClientApplication.builder("id").build();
 
         AuthorizationCodeParameters parameters = AuthorizationCodeParameters
                 .builder("code", new URI("http://my.redirect.com"))
@@ -291,7 +291,7 @@ public class TokenRequestTest extends AbstractMsalTests {
     public void testExecuteOAuth_Failure() throws SerializeException,
             ParseException, MsalException, IOException, URISyntaxException {
 
-        PublicClientApplication app = new PublicClientApplication.Builder("id").build();
+        PublicClientApplication app = PublicClientApplication.builder("id").build();
 
         AuthorizationCodeParameters parameters = AuthorizationCodeParameters
                 .builder("code", new URI("http://my.redirect.com"))


### PR DESCRIPTION
Making the PublicClientApplication and ConfidentialClientApplication Builder constructors private. This will force callers to use the static method `PublicClientApplication.builder()` to create the objects, which is consistent with all of the other Parameter builders  
