### PR TITLE
jackson config switch to older api

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
+++ b/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
@@ -4,19 +4,23 @@
 package com.microsoft.aad.msal4j;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
 class JsonHelper {
+    static ObjectMapper mapper;
 
-    static ObjectMapper mapper = JsonMapper.builder()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            .configure(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS, true)
-            .serializationInclusion(JsonInclude.Include.NON_NULL)
-            .build();
+    static {
+        mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, true);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    }
 
     static <T> T convertJsonToObject(final String json, final Class<T> clazz) {
         try {


### PR DESCRIPTION
Change to address https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/157

Switching to older Jackson api for configuring ObjectMapper to be compatible with mostly used versions of spring framework 