### PR TITLE
Add OSGi support via the bnd-maven-plugin

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,1 @@
+Export-Package: com.microsoft.aad.msal4j

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,7 @@
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
             </plugin>
@@ -245,6 +246,18 @@
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>4.3.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
This adds support for deploying MSAL4J to OSGi environments. It ensures that the `com.microsoft.aad.msal4j` is exported, and does so with the version of the project.