### PR TITLE
support of STS throttling instructions + caching of InteractionRequiredException…

### DIFF
--- a/src/integrationtest/java/com.microsoft.aad.msal4j/ApacheHttpClientAdapter.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/ApacheHttpClientAdapter.java
@@ -84,7 +84,7 @@ class ApacheHttpClientAdapter implements IHttpClient {
         for(Header header: apacheResponse.getAllHeaders()){
             headers.put(header.getName(), Collections.singletonList(header.getValue()));
         }
-        ((HttpResponse) httpResponse).headers(headers);
+        ((HttpResponse) httpResponse).addHeaders(headers);
 
         String responseBody = EntityUtils.toString(apacheResponse.getEntity(), "UTF-8");
         ((HttpResponse) httpResponse).body(responseBody);

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
@@ -218,7 +218,7 @@ public class AuthorizationCodeIT extends SeleniumTest {
 
     private String acquireAuthorizationCodeAutomated(
             User user,
-            ClientApplicationBase app){
+            AbstractClientApplicationBase app){
 
         BlockingQueue<AuthorizationResult> authorizationCodeQueue = new LinkedBlockingQueue<>();
 
@@ -256,7 +256,7 @@ public class AuthorizationCodeIT extends SeleniumTest {
         }
         return result.code();
     }
-    private String buildAuthenticationCodeURL(ClientApplicationBase app) {
+    private String buildAuthenticationCodeURL(AbstractClientApplicationBase app) {
         String scope;
 
         AuthorityType authorityType= app.authenticationAuthority.authorityType;

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/OkHttpClientAdapter.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/OkHttpClientAdapter.java
@@ -76,7 +76,7 @@ class OkHttpClientAdapter implements IHttpClient{
 
         Headers headers = okHttpResponse.headers();
         if(headers != null){
-            ((HttpResponse) httpResponse).headers(headers.toMultimap());
+            ((HttpResponse) httpResponse).addHeaders(headers.toMultimap());
         }
         return httpResponse;
     }

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/SeleniumTest.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/SeleniumTest.java
@@ -36,7 +36,7 @@ abstract class SeleniumTest {
         seleniumDriver = SeleniumExtensions.createDefaultWebDriver();
     }
 
-    void runSeleniumAutomatedLogin(User user, ClientApplicationBase app) {
+    void runSeleniumAutomatedLogin(User user, AbstractClientApplicationBase app) {
         AuthorityType authorityType = app.authenticationAuthority.authorityType;
         if(authorityType == AuthorityType.B2C){
             switch(user.getB2cProvider().toLowerCase()){

--- a/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
@@ -25,7 +25,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
  * Abstract class containing common methods and properties to both {@link PublicClientApplication}
  * and {@link ConfidentialClientApplication}.
  */
-abstract class ClientApplicationBase implements IClientApplicationBase {
+abstract class AbstractClientApplicationBase implements IClientApplicationBase {
 
     protected Logger log;
     protected ClientAuthentication clientAuthentication;
@@ -88,7 +88,7 @@ abstract class ClientApplicationBase implements IClientApplicationBase {
         AuthorizationCodeRequest authorizationCodeRequest = new AuthorizationCodeRequest(
                 parameters,
                 this,
-                createRequestContext(PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE));
+                createRequestContext(PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters));
 
         return this.executeRequest(authorizationCodeRequest);
     }
@@ -101,7 +101,7 @@ abstract class ClientApplicationBase implements IClientApplicationBase {
         RefreshTokenRequest refreshTokenRequest = new RefreshTokenRequest(
                 parameters,
                 this,
-                createRequestContext(PublicApi.ACQUIRE_TOKEN_BY_REFRESH_TOKEN));
+                createRequestContext(PublicApi.ACQUIRE_TOKEN_BY_REFRESH_TOKEN, parameters));
 
         return executeRequest(refreshTokenRequest);
     }
@@ -128,7 +128,7 @@ abstract class ClientApplicationBase implements IClientApplicationBase {
         SilentRequest silentRequest = new SilentRequest(
                 parameters,
                 this,
-                createRequestContext(PublicApi.ACQUIRE_TOKEN_SILENTLY));
+                createRequestContext(PublicApi.ACQUIRE_TOKEN_SILENTLY, parameters));
 
         return executeRequest(silentRequest);
     }
@@ -137,7 +137,7 @@ abstract class ClientApplicationBase implements IClientApplicationBase {
     public CompletableFuture<Set<IAccount>> getAccounts() {
         MsalRequest msalRequest =
                 new MsalRequest(this, null,
-                        createRequestContext(PublicApi.GET_ACCOUNTS)){};
+                        createRequestContext(PublicApi.GET_ACCOUNTS, null)){};
 
         AccountsSupplier supplier = new AccountsSupplier(this, msalRequest);
 
@@ -150,7 +150,7 @@ abstract class ClientApplicationBase implements IClientApplicationBase {
     @Override
     public CompletableFuture removeAccount(IAccount account) {
         MsalRequest msalRequest = new MsalRequest(this, null,
-                        createRequestContext(PublicApi.REMOVE_ACCOUNTS)){};
+                        createRequestContext(PublicApi.REMOVE_ACCOUNTS, null)){};
 
         RemoveAccountRunnable runnable = new RemoveAccountRunnable(msalRequest, account);
 
@@ -227,8 +227,8 @@ abstract class ClientApplicationBase implements IClientApplicationBase {
         return supplier;
     }
 
-    RequestContext createRequestContext(PublicApi publicApi) {
-        return new RequestContext(this, publicApi);
+    RequestContext createRequestContext(PublicApi publicApi, IApiParameters apiParameters) {
+        return new RequestContext(this, publicApi, apiParameters);
     }
 
     ServiceBundle getServiceBundle() {
@@ -281,7 +281,7 @@ abstract class ClientApplicationBase implements IClientApplicationBase {
         /**
          * Set URL of the authenticating authority or security token service (STS) from which MSAL
          * will acquire security tokens.
-         * The default value is {@link ClientApplicationBase#DEFAULT_AUTHORITY}
+         * The default value is {@link AbstractClientApplicationBase#DEFAULT_AUTHORITY}
          *
          * @param val a string value of authority
          * @return instance of the Builder on which method was called
@@ -320,7 +320,7 @@ abstract class ClientApplicationBase implements IClientApplicationBase {
          * Set a boolean value telling the application if the authority needs to be verified
          * against a list of known authorities. Authority is only validated when:
          * 1 - It is an Azure Active Directory authority (not B2C or ADFS)
-         * 2 - Instance discovery metadata is not set via {@link ClientApplicationBase#aadAadInstanceDiscoveryResponse}
+         * 2 - Instance discovery metadata is not set via {@link AbstractClientApplicationBase#aadAadInstanceDiscoveryResponse}
          *
          * The default value is true.
          *
@@ -476,7 +476,7 @@ abstract class ClientApplicationBase implements IClientApplicationBase {
          * Sets instance discovery response data which will be used for determining tenant discovery
          * endpoint and authority aliases.
          *
-         * Note that authority validation is not done even if {@link ClientApplicationBase#validateAuthority}
+         * Note that authority validation is not done even if {@link AbstractClientApplicationBase#validateAuthority}
          * is set to true.
          *
          * For more information, see
@@ -503,10 +503,10 @@ abstract class ClientApplicationBase implements IClientApplicationBase {
             return authority;
         }
 
-        abstract ClientApplicationBase build();
+        abstract AbstractClientApplicationBase build();
     }
 
-    ClientApplicationBase(Builder<?> builder) {
+    AbstractClientApplicationBase(Builder<?> builder) {
         clientId = builder.clientId;
         authority = builder.authority;
         validateAuthority = builder.validateAuthority;

--- a/src/main/java/com/microsoft/aad/msal4j/AccountsSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AccountsSupplier.java
@@ -10,10 +10,10 @@ import java.util.function.Supplier;
 
 class AccountsSupplier implements Supplier<Set<IAccount>> {
 
-    ClientApplicationBase clientApplication;
+    AbstractClientApplicationBase clientApplication;
     MsalRequest msalRequest;
 
-    AccountsSupplier(ClientApplicationBase clientApplication, MsalRequest msalRequest) {
+    AccountsSupplier(AbstractClientApplicationBase clientApplication, MsalRequest msalRequest) {
 
         this.clientApplication = clientApplication;
         this.msalRequest = msalRequest;

--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByAuthorizationGrantSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByAuthorizationGrantSupplier.java
@@ -31,7 +31,7 @@ class AcquireTokenByAuthorizationGrantSupplier extends AuthenticationResultSuppl
 
         if (IsUiRequiredCacheSupported()) {
             MsalInteractionRequiredException cachedEx =
-                    UiRequiredCache.getCachedInteractionRequiredException(
+                    InteractionRequiredCache.getCachedInteractionRequiredException(
                             ((RefreshTokenRequest) msalRequest).getFullThumbprint());
             if (cachedEx != null) {
                 throw cachedEx;
@@ -63,7 +63,7 @@ class AcquireTokenByAuthorizationGrantSupplier extends AuthenticationResultSuppl
             return clientApplication.acquireTokenCommon(msalRequest, requestAuthority);
         } catch (MsalInteractionRequiredException ex) {
             if (IsUiRequiredCacheSupported()) {
-                UiRequiredCache.set(((RefreshTokenRequest) msalRequest).getFullThumbprint(), ex);
+                InteractionRequiredCache.set(((RefreshTokenRequest) msalRequest).getFullThumbprint(), ex);
             }
             throw ex;
         }

--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByAuthorizationGrantSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByAuthorizationGrantSupplier.java
@@ -18,7 +18,7 @@ class AcquireTokenByAuthorizationGrantSupplier extends AuthenticationResultSuppl
     private Authority requestAuthority;
     private MsalRequest msalRequest;
 
-    AcquireTokenByAuthorizationGrantSupplier(ClientApplicationBase clientApplication,
+    AcquireTokenByAuthorizationGrantSupplier(AbstractClientApplicationBase clientApplication,
                                              MsalRequest msalRequest,
                                              Authority authority) {
         super(clientApplication, msalRequest);
@@ -28,6 +28,16 @@ class AcquireTokenByAuthorizationGrantSupplier extends AuthenticationResultSuppl
 
     AuthenticationResult execute() throws Exception {
         AbstractMsalAuthorizationGrant authGrant = msalRequest.msalAuthorizationGrant();
+
+        if (IsUiRequiredCacheSupported()) {
+            MsalInteractionRequiredException cachedEx =
+                    UiRequiredCache.getCachedInteractionRequiredException(
+                            ((RefreshTokenRequest) msalRequest).getFullThumbprint());
+            if (cachedEx != null) {
+                throw cachedEx;
+            }
+        }
+
         if (authGrant instanceof OAuthAuthorizationGrant) {
             msalRequest.msalAuthorizationGrant =
                     processPasswordGrant((OAuthAuthorizationGrant) authGrant);
@@ -41,15 +51,27 @@ class AcquireTokenByAuthorizationGrantSupplier extends AuthenticationResultSuppl
                             integratedAuthGrant.getUserName()), integratedAuthGrant.getScopes());
         }
 
-        if(requestAuthority == null){
+        if (requestAuthority == null) {
             requestAuthority = clientApplication.authenticationAuthority;
         }
 
-        if(requestAuthority.authorityType == AuthorityType.AAD){
+        if (requestAuthority.authorityType == AuthorityType.AAD) {
             requestAuthority = getAuthorityWithPrefNetworkHost(requestAuthority.authority());
         }
 
-        return clientApplication.acquireTokenCommon(msalRequest, requestAuthority);
+        try {
+            return clientApplication.acquireTokenCommon(msalRequest, requestAuthority);
+        } catch (MsalInteractionRequiredException ex) {
+            if (IsUiRequiredCacheSupported()) {
+                UiRequiredCache.set(((RefreshTokenRequest) msalRequest).getFullThumbprint(), ex);
+            }
+            throw ex;
+        }
+    }
+
+    private boolean IsUiRequiredCacheSupported() {
+        return msalRequest instanceof RefreshTokenRequest &&
+                clientApplication instanceof PublicClientApplication;
     }
 
     private OAuthAuthorizationGrant processPasswordGrant(
@@ -59,7 +81,7 @@ class AcquireTokenByAuthorizationGrantSupplier extends AuthenticationResultSuppl
             return authGrant;
         }
 
-        if(msalRequest.application().authenticationAuthority.authorityType != AuthorityType.AAD){
+        if (msalRequest.application().authenticationAuthority.authorityType != AuthorityType.AAD) {
             return authGrant;
         }
 
@@ -131,13 +153,11 @@ class AcquireTokenByAuthorizationGrantSupplier extends AuthenticationResultSuppl
                     this.clientApplication.logPii());
 
             updatedGrant = getSAMLAuthorizationGrant(wsTrustResponse);
-        }
-        else if (userRealmResponse.isAccountManaged()) {
+        } else if (userRealmResponse.isAccountManaged()) {
             throw new MsalClientException(
                     "Password is required for managed user",
                     AuthenticationErrorCode.PASSWORD_REQUIRED_FOR_MANAGED_USER);
-        }
-        else{
+        } else {
             throw new MsalClientException(
                     "User Realm request failed",
                     AuthenticationErrorCode.USER_REALM_DISCOVERY_FAILED);

--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByInteractiveFlowSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByInteractiveFlowSupplier.java
@@ -154,7 +154,7 @@ class AcquireTokenByInteractiveFlowSupplier extends AuthenticationResultSupplier
         AuthorizationCodeRequest authCodeRequest = new AuthorizationCodeRequest(
                 parameters,
                 clientApplication,
-                clientApplication.createRequestContext(PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE));
+                clientApplication.createRequestContext(PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters));
 
         AcquireTokenByAuthorizationGrantSupplier acquireTokenByAuthorizationGrantSupplier =
             new AcquireTokenByAuthorizationGrantSupplier(

--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
@@ -7,7 +7,7 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
 
     private SilentRequest silentRequest;
 
-    AcquireTokenSilentSupplier(ClientApplicationBase clientApplication, SilentRequest silentRequest) {
+    AcquireTokenSilentSupplier(AbstractClientApplicationBase clientApplication, SilentRequest silentRequest) {
         super(clientApplication, silentRequest);
 
         this.silentRequest = silentRequest;
@@ -16,20 +16,19 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
     @Override
     AuthenticationResult execute() throws Exception {
         Authority requestAuthority = silentRequest.requestAuthority();
-        if(requestAuthority.authorityType != AuthorityType.B2C){
+        if (requestAuthority.authorityType != AuthorityType.B2C) {
             requestAuthority =
                     getAuthorityWithPrefNetworkHost(silentRequest.requestAuthority().authority());
         }
 
         AuthenticationResult res;
 
-        if(silentRequest.parameters().account() == null){
+        if (silentRequest.parameters().account() == null) {
             res = clientApplication.tokenCache.getCachedAuthenticationResult(
                     requestAuthority,
                     silentRequest.parameters().scopes(),
                     clientApplication.clientId());
-        }
-        else {
+        } else {
             res = clientApplication.tokenCache.getCachedAuthenticationResult(
                     silentRequest.parameters().account(),
                     requestAuthority,
@@ -37,24 +36,23 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
                     clientApplication.clientId());
 
             if (silentRequest.parameters().forceRefresh() || StringHelper.isBlank(res.accessToken())) {
-
                 if (!StringHelper.isBlank(res.refreshToken())) {
                     RefreshTokenRequest refreshTokenRequest = new RefreshTokenRequest(
                             RefreshTokenParameters.builder(silentRequest.parameters().scopes(), res.refreshToken()).build(),
                             silentRequest.application(),
-                            silentRequest.requestContext());
+                            silentRequest.requestContext(),
+                            silentRequest);
 
                     AcquireTokenByAuthorizationGrantSupplier acquireTokenByAuthorisationGrantSupplier =
                             new AcquireTokenByAuthorizationGrantSupplier(clientApplication, refreshTokenRequest, requestAuthority);
 
                     res = acquireTokenByAuthorisationGrantSupplier.execute();
-                }
-                else{
+                } else {
                     res = null;
                 }
             }
         }
-        if(res == null || StringHelper.isBlank(res.accessToken())){
+        if (res == null || StringHelper.isBlank(res.accessToken())) {
             throw new MsalClientException(AuthenticationErrorMessage.NO_TOKEN_IN_CACHE, AuthenticationErrorCode.CACHE_MISS);
         }
 

--- a/src/main/java/com/microsoft/aad/msal4j/AuthenticationErrorCode.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthenticationErrorCode.java
@@ -90,4 +90,9 @@ public class AuthenticationErrorCode {
      * https://aka.ms/msal4j-interactive-request
      */
     public final static String DESKTOP_BROWSER_NOT_SUPPORTED = "desktop_browser_not_supported";
+
+    /**
+     * Request was throttled according to instructions from STS.
+     */
+    public final static String THROTTLED_REQUEST = "throttled_request";
 }

--- a/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultSupplier.java
@@ -16,10 +16,10 @@ import java.util.function.Supplier;
 
 abstract class AuthenticationResultSupplier implements Supplier<IAuthenticationResult> {
 
-    ClientApplicationBase clientApplication;
+    AbstractClientApplicationBase clientApplication;
     MsalRequest msalRequest;
 
-    AuthenticationResultSupplier(ClientApplicationBase clientApplication, MsalRequest msalRequest) {
+    AuthenticationResultSupplier(AbstractClientApplicationBase clientApplication, MsalRequest msalRequest) {
         this.clientApplication = clientApplication;
         this.msalRequest = msalRequest;
     }

--- a/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeParameters.java
@@ -20,7 +20,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotBlank
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class AuthorizationCodeParameters {
+public class AuthorizationCodeParameters implements IApiParameters {
 
     /**
      * Authorization code acquired in the first step of OAuth2.0 authorization code flow. For more

--- a/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeRequest.java
@@ -6,17 +6,12 @@ package com.microsoft.aad.msal4j;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
 import com.nimbusds.oauth2.sdk.AuthorizationGrant;
-import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
 import com.nimbusds.oauth2.sdk.pkce.CodeVerifier;
-import lombok.Builder;
-
-import java.net.URI;
-import java.util.Set;
 
 class AuthorizationCodeRequest extends MsalRequest {
 
     AuthorizationCodeRequest(AuthorizationCodeParameters parameters,
-                             ClientApplicationBase application,
+                             AbstractClientApplicationBase application,
                              RequestContext requestContext){
         super(application, createMsalGrant(parameters), requestContext);
     }

--- a/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
@@ -19,7 +19,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 /**
- * Parameters for {@link ClientApplicationBase#getAuthorizationRequestUrl(AuthorizationRequestUrlParameters)}
+ * Parameters for {@link AbstractClientApplicationBase#getAuthorizationRequestUrl(AuthorizationRequestUrlParameters)}
  */
 @Accessors(fluent = true)
 @Getter

--- a/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
@@ -18,7 +18,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class ClientCredentialParameters {
+public class ClientCredentialParameters implements IApiParameters {
 
     /**
      * Scopes for which the application is requesting access to.

--- a/src/main/java/com/microsoft/aad/msal4j/ClientInfo.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientInfo.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 
 import java.util.Base64;
 
+import static com.microsoft.aad.msal4j.Constants.POINT_DELIMITER;
+
 @Getter(AccessLevel.PACKAGE)
 class ClientInfo {
 
@@ -29,6 +31,6 @@ class ClientInfo {
     }
 
     String toAccountIdentifier(){
-        return uniqueIdentifier + "." + unqiueTenantIdentifier;
+        return uniqueIdentifier + POINT_DELIMITER + unqiueTenantIdentifier;
     }
 }

--- a/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
@@ -26,7 +26,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
  *
  * Conditionally thread-safe
  */
-public class ConfidentialClientApplication extends ClientApplicationBase implements IConfidentialClientApplication {
+public class ConfidentialClientApplication extends AbstractClientApplicationBase implements IConfidentialClientApplication {
 
     @Override
     public CompletableFuture<IAuthenticationResult> acquireToken(ClientCredentialParameters parameters) {
@@ -37,7 +37,7 @@ public class ConfidentialClientApplication extends ClientApplicationBase impleme
                 new ClientCredentialRequest(
                         parameters,
                         this,
-                        createRequestContext(PublicApi.ACQUIRE_TOKEN_FOR_CLIENT));
+                        createRequestContext(PublicApi.ACQUIRE_TOKEN_FOR_CLIENT, parameters));
 
         return this.executeRequest(clientCredentialRequest);
     }
@@ -50,7 +50,7 @@ public class ConfidentialClientApplication extends ClientApplicationBase impleme
         OnBehalfOfRequest oboRequest = new OnBehalfOfRequest(
                 parameters,
                 this,
-                createRequestContext(PublicApi.ACQUIRE_TOKEN_ON_BEHALF_OF));
+                createRequestContext(PublicApi.ACQUIRE_TOKEN_ON_BEHALF_OF, parameters));
 
         return this.executeRequest(oboRequest);
     }
@@ -110,7 +110,7 @@ public class ConfidentialClientApplication extends ClientApplicationBase impleme
         return new Builder(clientId, clientCredential);
     }
 
-    public static class Builder extends ClientApplicationBase.Builder<Builder> {
+    public static class Builder extends AbstractClientApplicationBase.Builder<Builder> {
 
         private IClientCredential clientCredential;
 

--- a/src/main/java/com/microsoft/aad/msal4j/Constants.java
+++ b/src/main/java/com/microsoft/aad/msal4j/Constants.java
@@ -7,6 +7,7 @@ final class Constants {
 
     static final String CACHE_KEY_SEPARATOR = "-";
     static final String SCOPES_SEPARATOR = " ";
+    static final String POINT_DELIMITER = ".";
 
     static final int AAD_JWT_TOKEN_LIFETIME_SECONDS = 60 * 10;
 }

--- a/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClient.java
+++ b/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClient.java
@@ -99,14 +99,14 @@ class DefaultHttpClient implements IHttpClient {
             if (responseCode != HttpURLConnection.HTTP_OK) {
                 is = conn.getErrorStream();
                 if (is != null) {
-                    httpResponse.headers(conn.getHeaderFields());
+                    httpResponse.addHeaders(conn.getHeaderFields());
                     httpResponse.body(inputStreamToString(is));
                 }
                 return httpResponse;
             }
 
             is = conn.getInputStream();
-            httpResponse.headers(conn.getHeaderFields());
+            httpResponse.addHeaders(conn.getHeaderFields());
             httpResponse.body(inputStreamToString(is));
             return httpResponse;
         }

--- a/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowParameters.java
@@ -20,7 +20,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class DeviceCodeFlowParameters {
+public class DeviceCodeFlowParameters implements IApiParameters {
 
     /**
      * Scopes to which the application is requesting access to.

--- a/src/main/java/com/microsoft/aad/msal4j/HttpHeaders.java
+++ b/src/main/java/com/microsoft/aad/msal4j/HttpHeaders.java
@@ -34,6 +34,9 @@ final class HttpHeaders {
     private  final static String REQUEST_CORRELATION_ID_IN_RESPONSE_HEADER_NAME = "return-client-request-id";
     private final static String REQUEST_CORRELATION_ID_IN_RESPONSE_HEADER_VALUE = "true";
 
+    private  final static String X_MS_LIB_CAPABILITY_NAME = "x-ms-lib-capability";
+    private final static String X_MS_LIB_CAPABILITY_VALUE = "retry-after, h429";
+
     private final String headerValues;
     private final Map<String, String> headerMap = new HashMap<>();
 
@@ -66,6 +69,8 @@ final class HttpHeaders {
         if(!StringHelper.isBlank(this.applicationVersionHeaderValue)){
             init.accept(APPLICATION_VERSION_HEADER_NAME, this.applicationVersionHeaderValue);
         }
+
+        init.accept(X_MS_LIB_CAPABILITY_NAME, this.X_MS_LIB_CAPABILITY_VALUE);
 
         return sb.toString();
     }

--- a/src/main/java/com/microsoft/aad/msal4j/HttpHelper.java
+++ b/src/main/java/com/microsoft/aad/msal4j/HttpHelper.java
@@ -6,32 +6,55 @@ package com.microsoft.aad.msal4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 class HttpHelper {
 
     private final static Logger log = LoggerFactory.getLogger(HttpHelper.class);
+    public static final String RETRY_AFTER_HEADER = "Retry-After";
 
-    static IHttpResponse executeHttpRequest(final HttpRequest httpRequest,
-                                            final RequestContext requestContext,
-                                            final ServiceBundle serviceBundle) {
+    private static String getRequestThumbprint(RequestContext requestContext) {
+        String DELIMITER = ".";
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(requestContext.clientId() + DELIMITER);
+        sb.append(requestContext.authority() + DELIMITER);
+
+        IApiParameters apiParameters = requestContext.apiParameters();
+
+        if (apiParameters instanceof SilentParameters) {
+            IAccount account = ((SilentParameters) apiParameters).account();
+            if (account != null) {
+                sb.append(account.homeAccountId() + DELIMITER);
+            }
+        }
+
+        Set<String> sortedScopes = new TreeSet<>(apiParameters.scopes());
+        sb.append(String.join(" ", sortedScopes));
+
+        return StringHelper.createSha256Hash(sb.toString());
+    }
+
+    static IHttpResponse executeHttpRequest(HttpRequest httpRequest,
+                                            RequestContext requestContext,
+                                            ServiceBundle serviceBundle) {
+        checkForThrottling(requestContext);
 
         HttpEvent httpEvent = new HttpEvent(); // for tracking http telemetry
         IHttpResponse httpResponse;
 
-        try(TelemetryHelper telemetryHelper = serviceBundle.getTelemetryManager().createTelemetryHelper(
+        try (TelemetryHelper telemetryHelper = serviceBundle.getTelemetryManager().createTelemetryHelper(
                 requestContext.telemetryRequestId(),
                 requestContext.clientId(),
                 httpEvent,
-                false)){
+                false)) {
 
             addRequestInfoToTelemetry(httpRequest, httpEvent);
 
-            try{
+            try {
                 IHttpClient httpClient = serviceBundle.getHttpClient();
                 httpResponse = httpClient.send(httpRequest);
-            } catch(Exception e){
+            } catch (Exception e) {
                 httpEvent.setOauthErrorCode(AuthenticationErrorCode.UNKNOWN);
                 throw new MsalClientException(e);
             }
@@ -42,17 +65,66 @@ class HttpHelper {
                 HttpHelper.verifyReturnedCorrelationId(httpRequest, httpResponse);
             }
         }
+        processThrottlingInstructions(httpResponse, requestContext);
+
         return httpResponse;
     }
 
-    private static void addRequestInfoToTelemetry(final HttpRequest httpRequest, HttpEvent httpEvent){
-        try{
+    private static void checkForThrottling(RequestContext requestContext) {
+        if (requestContext.clientApplication() instanceof PublicClientApplication &&
+                requestContext.apiParameters() != null) {
+            String requestThumbprint = getRequestThumbprint(requestContext);
+
+            long retryInMs = ThrottlingCache.retryInMs(requestThumbprint);
+
+            if (retryInMs > 0) {
+                throw new MsalThrottlingException(retryInMs);
+            }
+        }
+    }
+
+    private static void processThrottlingInstructions(IHttpResponse httpResponse, RequestContext requestContext) {
+        if (requestContext.clientApplication() instanceof PublicClientApplication) {
+            Long expirationTimestamp = null;
+
+            Integer retryAfterHeaderVal = getRetryAfterHeader(httpResponse);
+            if (retryAfterHeaderVal != null) {
+                expirationTimestamp = System.currentTimeMillis() + retryAfterHeaderVal * 1000;
+            } else if (httpResponse.statusCode() == 429 ||
+                    (httpResponse.statusCode() >= 500 && httpResponse.statusCode() < 600)) {
+
+                expirationTimestamp = System.currentTimeMillis() + ThrottlingCache.DEFAULT_THROTTLING_TIME_SEC * 1000;
+            }
+            if (expirationTimestamp != null) {
+                ThrottlingCache.set(getRequestThumbprint(requestContext), expirationTimestamp);
+            }
+        }
+    }
+
+    private static Integer getRetryAfterHeader(IHttpResponse httpResponse) {
+
+        if (httpResponse.headers() != null) {
+            TreeMap<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+            headers.putAll(httpResponse.headers());
+
+            if (headers.containsKey(RETRY_AFTER_HEADER) && headers.get(RETRY_AFTER_HEADER).size() == 1) {
+                int headerValue = Integer.parseInt(headers.get(RETRY_AFTER_HEADER).get(0));
+                if (headerValue > 0 && headerValue <= ThrottlingCache.MAX_THROTTLING_TIME_SEC) {
+                    return headerValue;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static void addRequestInfoToTelemetry(final HttpRequest httpRequest, HttpEvent httpEvent) {
+        try {
             httpEvent.setHttpPath(httpRequest.url().toURI());
             httpEvent.setHttpMethod(httpRequest.httpMethod().toString());
-            if(!StringHelper.isBlank(httpRequest.url().getQuery())){
+            if (!StringHelper.isBlank(httpRequest.url().getQuery())) {
                 httpEvent.setQueryParameters(httpRequest.url().getQuery());
             }
-        } catch(Exception ex){
+        } catch (Exception ex) {
             String correlationId = httpRequest.headerValue(
                     HttpHeaders.CORRELATION_ID_HEADER_NAME);
 
@@ -62,28 +134,28 @@ class HttpHelper {
         }
     }
 
-    private static void addResponseInfoToTelemetry(IHttpResponse httpResponse, HttpEvent httpEvent){
+    private static void addResponseInfoToTelemetry(IHttpResponse httpResponse, HttpEvent httpEvent) {
 
         httpEvent.setHttpResponseStatus(httpResponse.statusCode());
 
         Map<String, List<String>> headers = httpResponse.headers();
 
         String userAgent = HttpUtils.headerValue(headers, "User-Agent");
-        if(!StringHelper.isBlank(userAgent)){
+        if (!StringHelper.isBlank(userAgent)) {
             httpEvent.setUserAgent(userAgent);
         }
 
         String xMsRequestId = HttpUtils.headerValue(headers, "x-ms-request-id");
-        if(!StringHelper.isBlank(xMsRequestId)){
+        if (!StringHelper.isBlank(xMsRequestId)) {
             httpEvent.setRequestIdHeader(xMsRequestId);
         }
 
-        String xMsClientTelemetry = HttpUtils.headerValue(headers,"x-ms-clitelem");
-        if(xMsClientTelemetry != null){
+        String xMsClientTelemetry = HttpUtils.headerValue(headers, "x-ms-clitelem");
+        if (xMsClientTelemetry != null) {
             XmsClientTelemetryInfo xmsClientTelemetryInfo =
                     XmsClientTelemetryInfo.parseXmsTelemetryInfo(xMsClientTelemetry);
 
-            if(xmsClientTelemetryInfo != null){
+            if (xmsClientTelemetryInfo != null) {
                 httpEvent.setXmsClientTelemetryInfo(xmsClientTelemetryInfo);
             }
         }

--- a/src/main/java/com/microsoft/aad/msal4j/HttpResponse.java
+++ b/src/main/java/com/microsoft/aad/msal4j/HttpResponse.java
@@ -39,7 +39,7 @@ public class HttpResponse implements IHttpResponse {
     /**
      * @param responseHeaders Map of HTTP headers returned from HTTP client
      */
-    public void headers(Map<String, List<String>> responseHeaders) {
+    public void addHeaders(Map<String, List<String>> responseHeaders) {
         for(Map.Entry<String, List<String>> entry: responseHeaders.entrySet()){
             if(entry.getKey() == null){
                 continue;
@@ -50,11 +50,11 @@ public class HttpResponse implements IHttpResponse {
                 continue;
             }
 
-            header(entry.getKey(), values.toArray(new String[]{}));
+            addHeader(entry.getKey(), values.toArray(new String[]{}));
         }
     }
 
-    private void header(final String name, final String ... values){
+    private void addHeader(final String name, final String ... values){
         if (values != null && values.length > 0) {
             headers.put(name, Arrays.asList(values));
         } else {

--- a/src/main/java/com/microsoft/aad/msal4j/IApiParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IApiParameters.java
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import java.util.Set;
+
+interface IApiParameters {
+    Set<String> scopes();
+}

--- a/src/main/java/com/microsoft/aad/msal4j/IClientApplicationBase.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IClientApplicationBase.java
@@ -9,7 +9,6 @@ import java.net.Proxy;
 import java.net.URL;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 
 /**
  * Interface representing an application for which tokens can be acquired.
@@ -73,7 +72,7 @@ interface IClientApplicationBase {
      * application object.
      *
      * Once the user successfully authenticates, the response should contain an authorization code,
-     * which can then be passed in to{@link ClientApplicationBase#acquireToken(AuthorizationCodeParameters)}
+     * which can then be passed in to{@link AbstractClientApplicationBase#acquireToken(AuthorizationCodeParameters)}
      * to be exchanged for a token
      * @param parameters {@link AuthorizationRequestUrlParameters}
      * @return url of the authorization endpoint where the user can sign-in and consent to the application.

--- a/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthenticationParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthenticationParameters.java
@@ -21,7 +21,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class IntegratedWindowsAuthenticationParameters {
+public class IntegratedWindowsAuthenticationParameters implements IApiParameters {
 
     /**
      * Scopes that the application is requesting access to

--- a/src/main/java/com/microsoft/aad/msal4j/InteractionRequiredCache.java
+++ b/src/main/java/com/microsoft/aad/msal4j/InteractionRequiredCache.java
@@ -9,7 +9,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Cache to hold MsalInteractionRequiredException responses for Silent and RefreshToken API requests
  */
-class UiRequiredCache {
+class InteractionRequiredCache {
 
     static int DEFAULT_CACHING_TIME_SEC = 120;
     static final int CACHE_SIZE_LIMIT_TO_TRIGGER_EXPIRED_ENTITIES_REMOVAL = 10;

--- a/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
@@ -26,7 +26,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class InteractiveRequestParameters {
+public class InteractiveRequestParameters implements IApiParameters {
 
     /**
      * Redirect URI where MSAL will listen to for the authorization code returned by Azure AD.

--- a/src/main/java/com/microsoft/aad/msal4j/MsalInteractionRequiredException.java
+++ b/src/main/java/com/microsoft/aad/msal4j/MsalInteractionRequiredException.java
@@ -21,7 +21,7 @@ public class MsalInteractionRequiredException extends MsalServiceException{
      */
     @Accessors(fluent = true)
     @Getter
-    private InteractionRequiredExceptionReason reason;
+    private final InteractionRequiredExceptionReason reason;
 
     /**
      * Initializes a new instance of the exception class

--- a/src/main/java/com/microsoft/aad/msal4j/MsalRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/MsalRequest.java
@@ -15,14 +15,14 @@ abstract class MsalRequest {
 
     AbstractMsalAuthorizationGrant msalAuthorizationGrant;
 
-    private final ClientApplicationBase application;
+    private final AbstractClientApplicationBase application;
 
     private final RequestContext requestContext;
 
     @Getter(value = AccessLevel.PACKAGE, lazy = true)
     private final HttpHeaders headers = new HttpHeaders(requestContext);
 
-    MsalRequest(ClientApplicationBase clientApplicationBase,
+    MsalRequest(AbstractClientApplicationBase clientApplicationBase,
                 AbstractMsalAuthorizationGrant abstractMsalAuthorizationGrant,
                 RequestContext requestContext){
 

--- a/src/main/java/com/microsoft/aad/msal4j/MsalServiceException.java
+++ b/src/main/java/com/microsoft/aad/msal4j/MsalServiceException.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -72,7 +73,7 @@ public class MsalServiceException extends MsalException {
         this.subError = errorResponse.subError();
         this.correlationId = errorResponse.correlation_id();
         this.claims = errorResponse.claims();
-        this.headers =  httpHeaders;
+        this.headers = Collections.unmodifiableMap(httpHeaders);
     }
 
     /**

--- a/src/main/java/com/microsoft/aad/msal4j/MsalServiceExceptionFactory.java
+++ b/src/main/java/com/microsoft/aad/msal4j/MsalServiceExceptionFactory.java
@@ -11,13 +11,13 @@ import java.util.Set;
 
 class MsalServiceExceptionFactory {
 
-    private MsalServiceExceptionFactory(){
+    private MsalServiceExceptionFactory() {
     }
 
-    static MsalServiceException fromHttpResponse(HTTPResponse httpResponse){
+    static MsalServiceException fromHttpResponse(HTTPResponse httpResponse, boolean isRefreshTokenGrantRequest) {
 
         String responseContent = httpResponse.getContent();
-        if(responseContent == null || StringHelper.isBlank(responseContent)){
+        if (responseContent == null || StringHelper.isBlank(responseContent)) {
             return new MsalServiceException(
                     "Unknown Service Exception",
                     AuthenticationErrorCode.UNKNOWN);
@@ -30,10 +30,11 @@ class MsalServiceExceptionFactory {
         errorResponse.statusCode(httpResponse.getStatusCode());
         errorResponse.statusMessage(httpResponse.getStatusMessage());
 
-        if(errorResponse.error() != null &&
+        if (isRefreshTokenGrantRequest &&
+                errorResponse.error() != null &&
                 errorResponse.error().equalsIgnoreCase(AuthenticationErrorCode.INVALID_GRANT)) {
 
-            if(isInteractionRequired(errorResponse.subError)){
+            if (isInteractionRequired(errorResponse.subError)) {
                 return new MsalInteractionRequiredException(errorResponse, httpResponse.getHeaderMap());
             }
         }
@@ -41,14 +42,14 @@ class MsalServiceExceptionFactory {
         return new MsalServiceException(
                 errorResponse,
                 httpResponse.getHeaderMap());
-        }
+    }
 
-    private static boolean isInteractionRequired(String subError){
+    private static boolean isInteractionRequired(String subError) {
 
         String[] nonUiSubErrors = {"client_mismatch", "protection_policy_required"};
         Set<String> set = new HashSet<>(Arrays.asList(nonUiSubErrors));
 
-        if(StringHelper.isBlank(subError)){
+        if (StringHelper.isBlank(subError)) {
             return true;
         }
 

--- a/src/main/java/com/microsoft/aad/msal4j/MsalServiceExceptionFactory.java
+++ b/src/main/java/com/microsoft/aad/msal4j/MsalServiceExceptionFactory.java
@@ -14,7 +14,7 @@ class MsalServiceExceptionFactory {
     private MsalServiceExceptionFactory() {
     }
 
-    static MsalServiceException fromHttpResponse(HTTPResponse httpResponse, boolean isRefreshTokenGrantRequest) {
+    static MsalServiceException fromHttpResponse(HTTPResponse httpResponse) {
 
         String responseContent = httpResponse.getContent();
         if (responseContent == null || StringHelper.isBlank(responseContent)) {
@@ -30,8 +30,7 @@ class MsalServiceExceptionFactory {
         errorResponse.statusCode(httpResponse.getStatusCode());
         errorResponse.statusMessage(httpResponse.getStatusMessage());
 
-        if (isRefreshTokenGrantRequest &&
-                errorResponse.error() != null &&
+        if (errorResponse.error() != null &&
                 errorResponse.error().equalsIgnoreCase(AuthenticationErrorCode.INVALID_GRANT)) {
 
             if (isInteractionRequired(errorResponse.subError)) {

--- a/src/main/java/com/microsoft/aad/msal4j/MsalThrottlingException.java
+++ b/src/main/java/com/microsoft/aad/msal4j/MsalThrottlingException.java
@@ -1,0 +1,29 @@
+package com.microsoft.aad.msal4j;
+
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+/**
+ * Exception type thrown when service returns throttling instruction:
+ * Retry-After header, 429 or 5xx statuses.
+ */
+@Accessors(fluent = true)
+@Getter
+public class MsalThrottlingException extends MsalServiceException {
+
+    /**
+     * how long to wait before repeating request
+     */
+    private long retryInMs;
+
+    /**
+     * Constructor for MsalThrottlingException class
+     * @param retryInMs
+     */
+    public MsalThrottlingException(long retryInMs) {
+        super("Request was throttled according to instructions from STS. Retry in " + retryInMs + " ms.",
+                AuthenticationErrorCode.THROTTLED_REQUEST);
+
+        this.retryInMs = retryInMs;
+    }
+}

--- a/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfParameters.java
@@ -20,7 +20,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class OnBehalfOfParameters {
+public class OnBehalfOfParameters implements IApiParameters {
 
     @NonNull
     private Set<String> scopes;

--- a/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
+++ b/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
@@ -5,9 +5,6 @@ package com.microsoft.aad.msal4j;
 
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.oauth2.sdk.id.ClientID;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
@@ -22,7 +19,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
  * 
  * Conditionally thread-safe
  */
-public class PublicClientApplication extends ClientApplicationBase implements IPublicClientApplication {
+public class PublicClientApplication extends AbstractClientApplicationBase implements IPublicClientApplication {
 
     @Override
     public CompletableFuture<IAuthenticationResult> acquireToken(UserNamePasswordParameters parameters) {
@@ -32,7 +29,7 @@ public class PublicClientApplication extends ClientApplicationBase implements IP
         UserNamePasswordRequest userNamePasswordRequest =
                 new UserNamePasswordRequest(parameters,
                         this,
-                        createRequestContext(PublicApi.ACQUIRE_TOKEN_BY_USERNAME_PASSWORD));
+                        createRequestContext(PublicApi.ACQUIRE_TOKEN_BY_USERNAME_PASSWORD, parameters));
 
         return this.executeRequest(userNamePasswordRequest);
     }
@@ -47,7 +44,7 @@ public class PublicClientApplication extends ClientApplicationBase implements IP
                         parameters,
                         this,
                         createRequestContext(
-                                PublicApi.ACQUIRE_TOKEN_BY_INTEGRATED_WINDOWS_AUTH));
+                                PublicApi.ACQUIRE_TOKEN_BY_INTEGRATED_WINDOWS_AUTH, parameters));
 
         return this.executeRequest(integratedWindowsAuthenticationRequest);
     }
@@ -69,7 +66,7 @@ public class PublicClientApplication extends ClientApplicationBase implements IP
                 parameters,
                 futureReference,
                 this,
-                createRequestContext(PublicApi.ACQUIRE_TOKEN_BY_DEVICE_CODE_FLOW));
+                createRequestContext(PublicApi.ACQUIRE_TOKEN_BY_DEVICE_CODE_FLOW, parameters));
 
         CompletableFuture<IAuthenticationResult> future = executeRequest(deviceCodeRequest);
         futureReference.set(future);
@@ -87,7 +84,7 @@ public class PublicClientApplication extends ClientApplicationBase implements IP
                 parameters,
                 futureReference,
                 this,
-                createRequestContext(PublicApi.ACQUIRE_TOKEN_INTERACTIVE));
+                createRequestContext(PublicApi.ACQUIRE_TOKEN_INTERACTIVE, parameters));
 
         CompletableFuture<IAuthenticationResult> future = executeRequest(interactiveRequest);
         futureReference.set(future);
@@ -119,7 +116,7 @@ public class PublicClientApplication extends ClientApplicationBase implements IP
         return new Builder(clientId);
     }
 
-    public static class Builder extends ClientApplicationBase.Builder<Builder> {
+    public static class Builder extends AbstractClientApplicationBase.Builder<Builder> {
 
         private Builder(String clientId) {
             super(clientId);

--- a/src/main/java/com/microsoft/aad/msal4j/RefreshTokenParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/RefreshTokenParameters.java
@@ -17,13 +17,13 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty
  * {@link ConfidentialClientApplication#acquireToken(RefreshTokenParameters)}
  *
  *  RefreshTokenParameters should only be used for migration scenarios (when moving from ADAL to
- *  MSAL). To acquire tokens silently, use {@link ClientApplicationBase#acquireTokenSilently(SilentParameters)}
+ *  MSAL). To acquire tokens silently, use {@link AbstractClientApplicationBase#acquireTokenSilently(SilentParameters)}
  */
 @Builder
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class RefreshTokenParameters {
+public class RefreshTokenParameters implements IApiParameters {
 
     /**
      * Scopes the application is requesting access to

--- a/src/main/java/com/microsoft/aad/msal4j/RefreshTokenRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/RefreshTokenRequest.java
@@ -9,6 +9,8 @@ import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import java.util.Set;
 import java.util.TreeSet;
 
+import static com.microsoft.aad.msal4j.Constants.POINT_DELIMITER;
+
 class RefreshTokenRequest extends MsalRequest {
 
     private SilentRequest parentSilentRequest;
@@ -37,14 +39,12 @@ class RefreshTokenRequest extends MsalRequest {
     }
 
     private String getRefreshTokenRequestFullThumbprint() {
-        String DELIMITER = ".";
-
         StringBuilder sb = new StringBuilder();
-        sb.append(application().clientId() + DELIMITER);
-        sb.append(application().authority() + DELIMITER);
+        sb.append(application().clientId() + POINT_DELIMITER);
+        sb.append(application().authority() + POINT_DELIMITER);
 
         Set<String> sortedScopes = new TreeSet<>(parameters.scopes());
-        sb.append(String.join(" ", sortedScopes) + DELIMITER);
+        sb.append(String.join(" ", sortedScopes) + POINT_DELIMITER);
 
         return StringHelper.createSha256Hash(sb.toString());
     }

--- a/src/main/java/com/microsoft/aad/msal4j/RefreshTokenRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/RefreshTokenRequest.java
@@ -6,18 +6,54 @@ package com.microsoft.aad.msal4j;
 import com.nimbusds.oauth2.sdk.RefreshTokenGrant;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 
+import java.util.Set;
+import java.util.TreeSet;
+
 class RefreshTokenRequest extends MsalRequest {
 
+    private SilentRequest parentSilentRequest;
+    private RefreshTokenParameters parameters;
+
     RefreshTokenRequest(RefreshTokenParameters parameters,
-                        ClientApplicationBase application,
-                        RequestContext requestContext){
+                        AbstractClientApplicationBase application,
+                        RequestContext requestContext) {
         super(application, createAuthenticationGrant(parameters), requestContext);
+        this.parameters = parameters;
+    }
+
+    RefreshTokenRequest(RefreshTokenParameters parameters,
+                        AbstractClientApplicationBase application,
+                        RequestContext requestContext,
+                        SilentRequest silentRequest) {
+        this(parameters, application, requestContext);
+        this.parentSilentRequest = silentRequest;
     }
 
     private static AbstractMsalAuthorizationGrant createAuthenticationGrant(
-            RefreshTokenParameters parameters){
+            RefreshTokenParameters parameters) {
 
         RefreshTokenGrant refreshTokenGrant = new RefreshTokenGrant(new RefreshToken(parameters.refreshToken()));
         return new OAuthAuthorizationGrant(refreshTokenGrant, parameters.scopes());
+    }
+
+    private String getRefreshTokenRequestFullThumbprint() {
+        String DELIMITER = ".";
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(application().clientId() + DELIMITER);
+        sb.append(application().authority() + DELIMITER);
+
+        Set<String> sortedScopes = new TreeSet<>(parameters.scopes());
+        sb.append(String.join(" ", sortedScopes) + DELIMITER);
+
+        return StringHelper.createSha256Hash(sb.toString());
+    }
+
+    String getFullThumbprint() {
+        if (parentSilentRequest != null) {
+            return parentSilentRequest.getFullThumbprint();
+        } else {
+            return getRefreshTokenRequestFullThumbprint();
+        }
     }
 }

--- a/src/main/java/com/microsoft/aad/msal4j/RefreshTokenRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/RefreshTokenRequest.java
@@ -38,22 +38,24 @@ class RefreshTokenRequest extends MsalRequest {
         return new OAuthAuthorizationGrant(refreshTokenGrant, parameters.scopes());
     }
 
-    private String getRefreshTokenRequestFullThumbprint() {
+    String getFullThumbprint() {
         StringBuilder sb = new StringBuilder();
+
         sb.append(application().clientId() + POINT_DELIMITER);
-        sb.append(application().authority() + POINT_DELIMITER);
+
+        String authority = (parentSilentRequest != null && parentSilentRequest.requestAuthority() != null)
+                ? parentSilentRequest.requestAuthority().authority() : application().authority();
+        sb.append(authority + POINT_DELIMITER);
+
+        if(parentSilentRequest != null && parentSilentRequest.parameters().account() != null){
+            sb.append(parentSilentRequest.parameters().account().homeAccountId() + POINT_DELIMITER);
+        }
+
+        sb.append(parameters.refreshToken() + POINT_DELIMITER);
 
         Set<String> sortedScopes = new TreeSet<>(parameters.scopes());
         sb.append(String.join(" ", sortedScopes) + POINT_DELIMITER);
 
         return StringHelper.createSha256Hash(sb.toString());
-    }
-
-    String getFullThumbprint() {
-        if (parentSilentRequest != null) {
-            return parentSilentRequest.getFullThumbprint();
-        } else {
-            return getRefreshTokenRequestFullThumbprint();
-        }
     }
 }

--- a/src/main/java/com/microsoft/aad/msal4j/RemoveAccountRunnable.java
+++ b/src/main/java/com/microsoft/aad/msal4j/RemoveAccountRunnable.java
@@ -9,7 +9,7 @@ import java.util.concurrent.CompletionException;
 class RemoveAccountRunnable implements Runnable {
 
     private RequestContext requestContext;
-    private ClientApplicationBase clientApplication;
+    private AbstractClientApplicationBase clientApplication;
     IAccount account;
 
     RemoveAccountRunnable(MsalRequest msalRequest, IAccount account) {

--- a/src/main/java/com/microsoft/aad/msal4j/RequestContext.java
+++ b/src/main/java/com/microsoft/aad/msal4j/RequestContext.java
@@ -21,8 +21,15 @@ class RequestContext {
     private PublicApi publicApi;
     private String applicationName;
     private String applicationVersion;
+    private String authority;
+    private IApiParameters apiParameters;
+    private IClientApplicationBase clientApplication;
 
-    public RequestContext(ClientApplicationBase clientApplication, PublicApi publicApi){
+    public RequestContext(AbstractClientApplicationBase clientApplication,
+                          PublicApi publicApi,
+                          IApiParameters apiParameters) {
+        this.clientApplication = clientApplication;
+
         this.clientId = StringHelper.isBlank(clientApplication.clientId()) ?
                 "unset_client_id" :
                 clientApplication.clientId();
@@ -33,9 +40,11 @@ class RequestContext {
         this.applicationVersion = clientApplication.applicationVersion();
         this.applicationName = clientApplication.applicationName();
         this.publicApi = publicApi;
+        this.authority = clientApplication.authority();
+        this.apiParameters = apiParameters;
     }
 
-    private static String generateNewCorrelationId(){
+    private static String generateNewCorrelationId() {
         return UUID.randomUUID().toString();
     }
 }

--- a/src/main/java/com/microsoft/aad/msal4j/SilentParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/SilentParameters.java
@@ -21,7 +21,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class SilentParameters {
+public class SilentParameters implements IApiParameters {
 
     @NonNull
     private Set<String> scopes;

--- a/src/main/java/com/microsoft/aad/msal4j/SilentRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/SilentRequest.java
@@ -8,6 +8,8 @@ import lombok.experimental.Accessors;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Set;
+import java.util.TreeSet;
 
 @Accessors(fluent = true)
 @Getter
@@ -18,7 +20,7 @@ class SilentRequest extends MsalRequest {
     private Authority requestAuthority;
 
     SilentRequest(SilentParameters parameters,
-                  ClientApplicationBase application,
+                  AbstractClientApplicationBase application,
                   RequestContext requestContext) throws MalformedURLException {
 
         super(application, null, requestContext);
@@ -30,5 +32,21 @@ class SilentRequest extends MsalRequest {
 
         application.getServiceBundle().getServerSideTelemetry().getCurrentRequest().forceRefresh(
                 parameters.forceRefresh());
+    }
+
+    String getFullThumbprint(){
+        String DELIMITER = ".";
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(application().clientId() + DELIMITER);
+        sb.append(application().authority() + DELIMITER);
+
+        Set<String> sortedScopes = new TreeSet<>(parameters.scopes());
+        sb.append(String.join(" ", sortedScopes) + DELIMITER);
+
+        sb.append(parameters.account().homeAccountId() + DELIMITER);
+        sb.append(parameters.authorityUrl());
+
+        return StringHelper.createSha256Hash(sb.toString());
     }
 }

--- a/src/main/java/com/microsoft/aad/msal4j/SilentRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/SilentRequest.java
@@ -11,6 +11,8 @@ import java.net.URL;
 import java.util.Set;
 import java.util.TreeSet;
 
+import static com.microsoft.aad.msal4j.Constants.POINT_DELIMITER;
+
 @Accessors(fluent = true)
 @Getter
 class SilentRequest extends MsalRequest {
@@ -35,16 +37,14 @@ class SilentRequest extends MsalRequest {
     }
 
     String getFullThumbprint(){
-        String DELIMITER = ".";
-
         StringBuilder sb = new StringBuilder();
-        sb.append(application().clientId() + DELIMITER);
-        sb.append(application().authority() + DELIMITER);
+        sb.append(application().clientId() + POINT_DELIMITER);
+        sb.append(application().authority() + POINT_DELIMITER);
 
         Set<String> sortedScopes = new TreeSet<>(parameters.scopes());
-        sb.append(String.join(" ", sortedScopes) + DELIMITER);
+        sb.append(String.join(" ", sortedScopes) + POINT_DELIMITER);
 
-        sb.append(parameters.account().homeAccountId() + DELIMITER);
+        sb.append(parameters.account().homeAccountId() + POINT_DELIMITER);
         sb.append(parameters.authorityUrl());
 
         return StringHelper.createSha256Hash(sb.toString());

--- a/src/main/java/com/microsoft/aad/msal4j/SilentRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/SilentRequest.java
@@ -8,10 +8,6 @@ import lombok.experimental.Accessors;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Set;
-import java.util.TreeSet;
-
-import static com.microsoft.aad.msal4j.Constants.POINT_DELIMITER;
 
 @Accessors(fluent = true)
 @Getter
@@ -34,19 +30,5 @@ class SilentRequest extends MsalRequest {
 
         application.getServiceBundle().getServerSideTelemetry().getCurrentRequest().forceRefresh(
                 parameters.forceRefresh());
-    }
-
-    String getFullThumbprint(){
-        StringBuilder sb = new StringBuilder();
-        sb.append(application().clientId() + POINT_DELIMITER);
-        sb.append(application().authority() + POINT_DELIMITER);
-
-        Set<String> sortedScopes = new TreeSet<>(parameters.scopes());
-        sb.append(String.join(" ", sortedScopes) + POINT_DELIMITER);
-
-        sb.append(parameters.account().homeAccountId() + POINT_DELIMITER);
-        sb.append(parameters.authorityUrl());
-
-        return StringHelper.createSha256Hash(sb.toString());
     }
 }

--- a/src/main/java/com/microsoft/aad/msal4j/StringHelper.java
+++ b/src/main/java/com/microsoft/aad/msal4j/StringHelper.java
@@ -16,28 +16,26 @@ final class StringHelper {
         return str == null || str.trim().length() == 0;
     }
 
-    static String createBase64EncodedSha256Hash(String stringToHash){
-        String base64EncodedSha256Hash;
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hashedString = digest.digest(stringToHash.getBytes(StandardCharsets.UTF_8));
-            base64EncodedSha256Hash = Base64.getUrlEncoder().withoutPadding().encodeToString(hashedString);
-        } catch(NoSuchAlgorithmException e){
-            base64EncodedSha256Hash = null;
-        }
-        return base64EncodedSha256Hash;
+    static String createBase64EncodedSha256Hash(String stringToHash) {
+        return createSha256Hash(stringToHash, true);
     }
 
-    static String createSha256Hash(String stringToHash){
+    static String createSha256Hash(String stringToHash) {
+        return createSha256Hash(stringToHash, false);
+    }
+
+    static private String createSha256Hash(String stringToHash, boolean base64Encode) {
         String res;
         try {
             MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = messageDigest.digest(stringToHash.getBytes(StandardCharsets.UTF_8));
 
-            res = new String(
-                    messageDigest.digest(stringToHash.getBytes(StandardCharsets.UTF_8)),
-                    StandardCharsets.UTF_8);
-
-        } catch(NoSuchAlgorithmException e){
+            if (base64Encode) {
+                res = Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+            } else {
+                res = new String(hash, StandardCharsets.UTF_8);
+            }
+        } catch (NoSuchAlgorithmException e) {
             res = null;
         }
         return res;

--- a/src/main/java/com/microsoft/aad/msal4j/StringHelper.java
+++ b/src/main/java/com/microsoft/aad/msal4j/StringHelper.java
@@ -27,4 +27,19 @@ final class StringHelper {
         }
         return base64EncodedSha256Hash;
     }
+
+    static String createSha256Hash(String stringToHash){
+        String res;
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+
+            res = new String(
+                    messageDigest.digest(stringToHash.getBytes(StandardCharsets.UTF_8)),
+                    StandardCharsets.UTF_8);
+
+        } catch(NoSuchAlgorithmException e){
+            res = null;
+        }
+        return res;
+    }
 }

--- a/src/main/java/com/microsoft/aad/msal4j/ThrottlingCache.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ThrottlingCache.java
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Cache to hold requests to be throttled
+ */
+class ThrottlingCache {
+
+    static final int MAX_THROTTLING_TIME_SEC = 3600;
+    static int DEFAULT_THROTTLING_TIME_SEC = 120;
+    static final int CACHE_SIZE_LIMIT_TO_TRIGGER_EXPIRED_ENTITIES_REMOVAL = 100;
+
+    // request hash to expiration timestamp
+    static Map<String, Long> requestsToThrottle = new ConcurrentHashMap<>();
+
+    static void set(String requestHash, Long expirationTimestamp) {
+        removeInvalidCacheEntities();
+
+        requestsToThrottle.put(requestHash, expirationTimestamp);
+    }
+
+    static long retryInMs(String requestHash) {
+        removeInvalidCacheEntities();
+
+        if (requestsToThrottle.containsKey(requestHash)) {
+            long expirationTimestamp = requestsToThrottle.get(requestHash);
+            long currentTimestamp = System.currentTimeMillis();
+
+            if (isCacheEntryValid(currentTimestamp, expirationTimestamp)) {
+                return expirationTimestamp - currentTimestamp;
+            } else {
+                requestsToThrottle.remove(requestHash);
+            }
+        }
+        return 0;
+    }
+
+    private static boolean isCacheEntryValid(long currentTimestamp, long expirationTimestamp) {
+        if (currentTimestamp < expirationTimestamp &&
+                currentTimestamp >= expirationTimestamp - MAX_THROTTLING_TIME_SEC * 1000) {
+            return true;
+        }
+        return false;
+    }
+
+    private static void removeInvalidCacheEntities() {
+        long currentTimestamp = System.currentTimeMillis();
+
+        if (requestsToThrottle.size() > CACHE_SIZE_LIMIT_TO_TRIGGER_EXPIRED_ENTITIES_REMOVAL) {
+            requestsToThrottle.values().removeIf(value -> !isCacheEntryValid(value, currentTimestamp));
+        }
+    }
+
+    static void clear() {
+        requestsToThrottle.clear();
+    }
+}

--- a/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -41,7 +41,8 @@ class TokenRequestExecutor {
 
         OAuthHttpRequest oAuthHttpRequest = createOauthHttpRequest();
         HTTPResponse oauthHttpResponse = oAuthHttpRequest.send();
-        return createAuthenticationResultFromOauthHttpResponse(oauthHttpResponse);
+        return createAuthenticationResultFromOauthHttpResponse(oauthHttpResponse,
+                getMsalRequest() instanceof RefreshTokenRequest);
     }
 
     OAuthHttpRequest createOauthHttpRequest() throws SerializeException, MalformedURLException {
@@ -68,7 +69,7 @@ class TokenRequestExecutor {
     }
 
     private AuthenticationResult createAuthenticationResultFromOauthHttpResponse(
-            HTTPResponse oauthHttpResponse) throws ParseException{
+            HTTPResponse oauthHttpResponse, boolean isRefreshTokenGrantRequest) throws ParseException{
         AuthenticationResult result;
 
         if (oauthHttpResponse.getStatusCode() == HTTPResponse.SC_OK) {
@@ -127,7 +128,7 @@ class TokenRequestExecutor {
                         serviceBundle.getServerSideTelemetry().previousRequestInProgress);
             }
 
-            throw MsalServiceExceptionFactory.fromHttpResponse(oauthHttpResponse);
+            throw MsalServiceExceptionFactory.fromHttpResponse(oauthHttpResponse, isRefreshTokenGrantRequest);
         }
         return result;
     }

--- a/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -41,8 +41,7 @@ class TokenRequestExecutor {
 
         OAuthHttpRequest oAuthHttpRequest = createOauthHttpRequest();
         HTTPResponse oauthHttpResponse = oAuthHttpRequest.send();
-        return createAuthenticationResultFromOauthHttpResponse(oauthHttpResponse,
-                getMsalRequest() instanceof RefreshTokenRequest);
+        return createAuthenticationResultFromOauthHttpResponse(oauthHttpResponse);
     }
 
     OAuthHttpRequest createOauthHttpRequest() throws SerializeException, MalformedURLException {
@@ -69,7 +68,7 @@ class TokenRequestExecutor {
     }
 
     private AuthenticationResult createAuthenticationResultFromOauthHttpResponse(
-            HTTPResponse oauthHttpResponse, boolean isRefreshTokenGrantRequest) throws ParseException{
+            HTTPResponse oauthHttpResponse) throws ParseException{
         AuthenticationResult result;
 
         if (oauthHttpResponse.getStatusCode() == HTTPResponse.SC_OK) {
@@ -128,7 +127,7 @@ class TokenRequestExecutor {
                         serviceBundle.getServerSideTelemetry().previousRequestInProgress);
             }
 
-            throw MsalServiceExceptionFactory.fromHttpResponse(oauthHttpResponse, isRefreshTokenGrantRequest);
+            throw MsalServiceExceptionFactory.fromHttpResponse(oauthHttpResponse);
         }
         return result;
     }

--- a/src/main/java/com/microsoft/aad/msal4j/UiRequiredCache.java
+++ b/src/main/java/com/microsoft/aad/msal4j/UiRequiredCache.java
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Cache to hold MsalInteractionRequiredException responses for Silent and RefreshToken API requests
+ */
+class UiRequiredCache {
+
+    static int DEFAULT_CACHING_TIME_SEC = 120;
+    static final int CACHE_SIZE_LIMIT_TO_TRIGGER_EXPIRED_ENTITIES_REMOVAL = 10;
+
+    static Map<String, CachedEntity> requestsToCache = new ConcurrentHashMap<>();
+
+    static void set(String requestHash, MsalInteractionRequiredException ex) {
+        removeInvalidCacheEntities();
+
+        long currentTimestamp = System.currentTimeMillis();
+
+        requestsToCache.put(requestHash,
+                new CachedEntity(ex,
+                        currentTimestamp + DEFAULT_CACHING_TIME_SEC * 1000));
+    }
+
+    static MsalInteractionRequiredException getCachedInteractionRequiredException(String requestHash) {
+        removeInvalidCacheEntities();
+
+        if (requestsToCache.containsKey(requestHash)) {
+            CachedEntity cachedEntity = requestsToCache.get(requestHash);
+
+            if (isCacheEntityValid(cachedEntity)) {
+                return cachedEntity.exception;
+            } else {
+                requestsToCache.remove(requestHash);
+            }
+        }
+        return null;
+    }
+
+    private static boolean isCacheEntityValid(CachedEntity cachedEntity) {
+        long expirationTimestamp = cachedEntity.expirationTimestamp;
+        long currentTimestamp = System.currentTimeMillis();
+
+        if (currentTimestamp < expirationTimestamp &&
+                currentTimestamp >= expirationTimestamp - DEFAULT_CACHING_TIME_SEC * 1000) {
+            return true;
+        }
+        return false;
+    }
+
+    private static class CachedEntity {
+        MsalInteractionRequiredException exception;
+
+        long expirationTimestamp;
+
+        public CachedEntity(MsalInteractionRequiredException exception, long expirationTimestamp) {
+            this.exception = exception;
+            this.expirationTimestamp = expirationTimestamp;
+        }
+    }
+
+    private static void removeInvalidCacheEntities(){
+        if(requestsToCache.size() > CACHE_SIZE_LIMIT_TO_TRIGGER_EXPIRED_ENTITIES_REMOVAL){
+            requestsToCache.values().removeIf(value -> !isCacheEntityValid(value));
+        }
+    }
+
+    static void clear(){
+        requestsToCache.clear();
+    }
+}

--- a/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordParameters.java
@@ -21,7 +21,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class UserNamePasswordParameters {
+public class UserNamePasswordParameters implements IApiParameters {
 
     /**
      * Scopes application is requesting access to

--- a/src/test/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryTest.java
@@ -34,7 +34,7 @@ public class AadInstanceDiscoveryTest extends PowerMockTestCase {
         MsalRequest msalRequest = new AuthorizationCodeRequest(
                 parameters,
                 app,
-                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE));
+                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters));
 
         URL authority = new URL(app.authority());
 
@@ -91,7 +91,7 @@ public class AadInstanceDiscoveryTest extends PowerMockTestCase {
         MsalRequest msalRequest = new AuthorizationCodeRequest(
                 parameters,
                 app,
-                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE));
+                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters));
 
         URL authority = new URL(app.authority());
 

--- a/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
+++ b/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
@@ -30,6 +30,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 
+import static com.microsoft.aad.msal4j.Constants.POINT_DELIMITER;
+
 public class CacheFormatTests extends AbstractMsalTests {
     String TOKEN_RESPONSE = "/token_response.json";
     String TOKEN_RESPONSE_ID_TOKEN = "/token_response_id_token.json";
@@ -306,7 +308,9 @@ public class CacheFormatTests extends AbstractMsalTests {
 
         String encodedIdToken = new String(Base64.getEncoder().encode(tokenResponseIdToken.getBytes()), "UTF-8");
 
-        encodedIdToken = getJWTHeaderBase64EncodedJson() + "." + encodedIdToken + "." + getEmptyBase64EncodedJson();
+        encodedIdToken = getJWTHeaderBase64EncodedJson() + POINT_DELIMITER +
+                encodedIdToken + POINT_DELIMITER +
+                getEmptyBase64EncodedJson();
 
         return encodedIdToken;
     }

--- a/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
+++ b/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
@@ -140,7 +140,7 @@ public class CacheFormatTests extends AbstractMsalTests {
         MsalRequest msalRequest = new AuthorizationCodeRequest(
                 parameters,
                 app,
-                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE));
+                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters));
 
         ServiceBundle serviceBundle = new ServiceBundle(
                 null,

--- a/src/test/java/com/microsoft/aad/msal4j/DeviceCodeFlowTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/DeviceCodeFlowTest.java
@@ -207,7 +207,7 @@ public class DeviceCodeFlowTest extends PowerMockTestCase {
                 parameters,
                 futureReference,
                 app,
-                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_DEVICE_CODE_FLOW));
+                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_DEVICE_CODE_FLOW, parameters));
 
 
         TokenRequestExecutor request = PowerMock.createPartialMock(

--- a/src/test/java/com/microsoft/aad/msal4j/HttpHeaderTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/HttpHeaderTest.java
@@ -21,7 +21,8 @@ public class HttpHeaderTest {
                 .applicationVersion("app-version")
                 .build();
 
-        RequestContext requestContext = new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE);
+        RequestContext requestContext = new RequestContext(
+                app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, null);
 
         HttpHeaders httpHeaders = new HttpHeaders(requestContext);
 
@@ -43,7 +44,8 @@ public class HttpHeaderTest {
                 .builder("client-id")
                 .build();
 
-        RequestContext requestContext = new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE);
+        RequestContext requestContext = new RequestContext(
+                app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, null);
 
         HttpHeaders httpHeaders = new HttpHeaders(requestContext);
 

--- a/src/test/java/com/microsoft/aad/msal4j/RequestThrottlingTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/RequestThrottlingTest.java
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import org.easymock.EasyMock;
+import org.powermock.api.easymock.PowerMock;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.*;
+
+import static org.easymock.EasyMock.anyObject;
+
+public class RequestThrottlingTest extends AbstractMsalTests {
+
+    public final Integer THROTTLE_IN_SEC = 2;
+
+    @BeforeClass
+    void init(){
+        ThrottlingCache.DEFAULT_THROTTLING_TIME_SEC = THROTTLE_IN_SEC;
+    }
+
+    private AuthorizationCodeParameters getAcquireTokenApiParameters(String scope) throws URISyntaxException {
+        return AuthorizationCodeParameters
+                .builder("auth_code",
+                        new URI(TestConfiguration.AAD_DEFAULT_REDIRECT_URI))
+                .scopes(Collections.singleton(scope))
+                .build();
+    }
+
+    private AuthorizationCodeParameters getAcquireTokenApiParameters() throws URISyntaxException {
+        return getAcquireTokenApiParameters("default-scope");
+    }
+
+    private PublicClientApplication getPublicClientApp() throws Exception {
+        return getPublicClientApp(null);
+    }
+
+    private PublicClientApplication getPublicClientApp(IHttpClient httpClient) throws Exception {
+        String instanceDiscoveryResponse = TestHelper.readResource(
+                this.getClass(),
+                "/instance_discovery_data/aad_instance_discovery_response_valid.json");
+
+        PublicClientApplication.Builder appBuilder = PublicClientApplication
+                .builder(TestConfiguration.AAD_CLIENT_ID)
+                .aadInstanceDiscoveryResponse(instanceDiscoveryResponse);
+
+        if (httpClient != null) {
+            appBuilder.httpClient(httpClient);
+        }
+
+        return appBuilder.build();
+    }
+
+    private enum TokenEndpointResponseType {
+        RETRY_AFTER_HEADER,
+        STATUS_CODE_429,
+        STATUS_CODE_500
+    }
+
+    private PublicClientApplication getClientApplicationMockedWithOneTokenEndpointResponse(
+            TokenEndpointResponseType responseType)
+            throws Exception {
+        IHttpClient httpClientMock = EasyMock.createMock(IHttpClient.class);
+
+        HttpResponse httpResponse = new HttpResponse();
+        Map<String, List<String>> headers = new HashMap<>();
+
+        switch (responseType) {
+            case RETRY_AFTER_HEADER:
+                httpResponse.statusCode(HTTPResponse.SC_OK);
+                httpResponse.body(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE);
+
+                headers.put("Retry-After", Arrays.asList(THROTTLE_IN_SEC.toString()));
+                break;
+            case STATUS_CODE_429:
+                httpResponse.statusCode(429);
+                httpResponse.body(TestConfiguration.TOKEN_ENDPOINT_INVALID_GRANT_ERROR_RESPONSE);
+                break;
+            case STATUS_CODE_500:
+                httpResponse.statusCode(500);
+                httpResponse.body(TestConfiguration.TOKEN_ENDPOINT_INVALID_GRANT_ERROR_RESPONSE);
+                break;
+        }
+        headers.put("Content-Type", Arrays.asList("application/json"));
+        httpResponse.addHeaders(headers);
+
+        EasyMock.expect(httpClientMock.send(anyObject())).andReturn(httpResponse).times(1);
+
+        PublicClientApplication app = getPublicClientApp(httpClientMock);
+
+        PowerMock.replayAll(httpClientMock);
+        return app;
+    }
+
+    private void throttlingTest(TokenEndpointResponseType tokenEndpointResponseType) throws Exception {
+        ThrottlingCache.clear();
+        // request #1 to token endpoint
+        // response contains Retry-After header
+        PublicClientApplication
+                app = getClientApplicationMockedWithOneTokenEndpointResponse(tokenEndpointResponseType);
+        try {
+            app.acquireToken(getAcquireTokenApiParameters("scope1")).join();
+        } catch (Exception ex) {
+            if (!(ex.getCause() instanceof MsalServiceException)) {
+                Assert.fail("Unexpected exception");
+            }
+        }
+        PowerMock.verifyAll();
+        PowerMock.resetAll();
+
+        // repeat same request #1, should be throttled
+        try {
+            app = getPublicClientApp();
+            app.acquireToken(getAcquireTokenApiParameters("scope1")).join();
+        } catch (Exception ex) {
+            if (!(ex.getCause() instanceof MsalThrottlingException)) {
+                Assert.fail("Unexpected exception");
+            }
+        }
+
+        // request #2 (different scope) should not be throttled
+        app = getClientApplicationMockedWithOneTokenEndpointResponse(tokenEndpointResponseType);
+        try {
+            app.acquireToken(getAcquireTokenApiParameters("scope2")).join();
+        } catch (Exception ex) {
+            if (!(ex.getCause() instanceof MsalServiceException)) {
+                Assert.fail("Unexpected exception");
+            }
+        }
+        PowerMock.verifyAll();
+        PowerMock.resetAll();
+
+        // repeat request #1, should not be throttled after
+        // throttling for this request got expired
+        Thread.sleep(THROTTLE_IN_SEC * 1000);
+        app = getClientApplicationMockedWithOneTokenEndpointResponse(tokenEndpointResponseType);
+        try {
+            app.acquireToken(getAcquireTokenApiParameters("scope1")).join();
+        } catch (Exception ex) {
+            if (!(ex.getCause() instanceof MsalServiceException)) {
+                Assert.fail("Unexpected exception");
+            }
+        }
+        PowerMock.verifyAll();
+        PowerMock.resetAll();
+    }
+
+    @Test
+    public void STSResponseContainsRetryAfterHeader_repeatedRequestsThrottled() throws Exception {
+        throttlingTest(TokenEndpointResponseType.RETRY_AFTER_HEADER);
+    }
+
+    @Test
+    public void STSResponseContainsStatusCode429_repeatedRequestsThrottled() throws Exception {
+        throttlingTest(TokenEndpointResponseType.STATUS_CODE_429);
+    }
+
+    @Test
+    public void STSResponseContainsStatusCode500_repeatedRequestsThrottled() throws Exception  {
+        throttlingTest(TokenEndpointResponseType.STATUS_CODE_429);
+    }
+}

--- a/src/test/java/com/microsoft/aad/msal4j/ServerTelemetryTests.java
+++ b/src/test/java/com/microsoft/aad/msal4j/ServerTelemetryTests.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package com.microsoft.aad.msal4j;
 
 import org.testng.Assert;

--- a/src/test/java/com/microsoft/aad/msal4j/TestConfiguration.java
+++ b/src/test/java/com/microsoft/aad/msal4j/TestConfiguration.java
@@ -50,7 +50,7 @@ public final class TestConfiguration {
     public final static String AAD_PREFERRED_NETWORK_ENV_ALIAS = "login.microsoftonline.com";
     public final static String AAD_PREFERRED_CACHE__ENV_ALIAS = "login.windows.net";
 
-    public final static String HTTP_RESPONSE_FROM_AUTH_CODE = "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6I"
+    public final static String TOKEN_ENDPOINT_OK_RESPONSE = "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6I"
             + "k5HVEZ2ZEstZnl0aEV1THdqcHdBSk9NOW4tQSJ9.eyJhdWQiOiJiN2E2NzFkOC1hNDA4LTQyZmYtODZlMC1hYWY0NDdmZDE3YzQiLCJpc3MiOiJod"
             + "HRwczovL3N0cy53aW5kb3dzLm5ldC8zMGJhYTY2Ni04ZGY4LTQ4ZTctOTdlNi03N2NmZDA5OTU5NjMvIiwiaWF0IjoxMzkzODQ0NTA0LCJuYmYiOj"
             + "EzOTM4NDQ1MDQsImV4cCI6MTM5Mzg0ODQwNCwidmVyIjoiMS4wIiwidGlkIjoiMzBiYWE2NjYtOGRmOC00OGU3LTk3ZTYtNzdjZmQwOTk1OTYzIiwi"
@@ -81,4 +81,12 @@ public final class TestConfiguration {
             + "is ambiguous, multiple application identifiers found. Application identifiers: 'd09bb6da-4d46-4a16-880c-7885d8291fb9"
             + ", 216ef81d-f3b2-47d4-ad21-a4df49b56dee'.\r\nTrace ID: 428a1f68-767d-4a1c-ae8e-f710eeaf4e9b\r\nCorrelation ID: 1e0955"
             + "88-68e4-4bb4-a54e-71ad81e7f013\r\nTimestamp: 2014-03-11 20:19:02Z\"}";
+
+    public final static String TOKEN_ENDPOINT_INVALID_GRANT_ERROR_RESPONSE = "{\"error\":\"invalid_grant\"," +
+            "\"error_description\":\"AADSTS65001: description\\r\\nCorrelation ID: 3a...5a\\r\\nTimestamp:2017-07-15 02:35:05Z\"," +
+            "\"error_codes\":[50076]," +
+            "\"timestamp\":\"2017-07-15 02:35:05Z\"," +
+            "\"trace_id\":\"0788...000\"," +
+            "\"correlation_id\":\"3a...95a\"," +
+            "\"suberror\":\"basic_action\"}";
 }

--- a/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
@@ -106,17 +106,16 @@ public class TokenRequestExecutorTest extends AbstractMsalTests {
     }
 
     private TokenRequestExecutor createMockedTokenRequest() throws URISyntaxException, MalformedURLException {
-        PublicClientApplication app = PublicClientApplication.builder("id").correlationId("corr_id").build();
+        PublicClientApplication app = PublicClientApplication.builder("id")
+                .correlationId("corr_id").build();
 
-        AuthorizationCodeParameters parameters = AuthorizationCodeParameters
-                .builder("code", new URI("http://my.redirect.com"))
-                .scopes(Collections.singleton("default-scope"))
-                .build();
+        RefreshTokenParameters refreshTokenParameters = RefreshTokenParameters.
+                builder(Collections.singleton("default-scope"), "rt").build();
 
-        final AuthorizationCodeRequest acr =  new AuthorizationCodeRequest(
-                parameters,
+        RefreshTokenRequest refreshTokenRequest = new RefreshTokenRequest(
+                refreshTokenParameters,
                 app,
-                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE));
+                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, refreshTokenParameters));
 
         ServiceBundle serviceBundle = new ServiceBundle(
                 null,
@@ -126,7 +125,7 @@ public class TokenRequestExecutorTest extends AbstractMsalTests {
         return PowerMock.createPartialMock(
                 TokenRequestExecutor.class, new String[]{"createOauthHttpRequest"},
                 new AADAuthority(new URL(TestConstants.ORGANIZATIONS_AUTHORITY)),
-                acr,
+                refreshTokenRequest,
                 serviceBundle);
     }
 
@@ -144,7 +143,7 @@ public class TokenRequestExecutorTest extends AbstractMsalTests {
         final AuthorizationCodeRequest acr =  new AuthorizationCodeRequest(
                 parameters,
                 app,
-                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE));
+                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters));
 
         final TokenRequestExecutor request = new TokenRequestExecutor(
                 new AADAuthority(new URL(TestConstants.ORGANIZATIONS_AUTHORITY)),
@@ -167,7 +166,7 @@ public class TokenRequestExecutorTest extends AbstractMsalTests {
         AuthorizationCodeRequest acr =  new AuthorizationCodeRequest(
                 parameters,
                 app,
-                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE));
+                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters));
 
         TokenRequestExecutor request = new TokenRequestExecutor(
                 new AADAuthority(new URL(TestConstants.ORGANIZATIONS_AUTHORITY)),
@@ -196,7 +195,7 @@ public class TokenRequestExecutorTest extends AbstractMsalTests {
         final AuthorizationCodeRequest acr =  new AuthorizationCodeRequest(
                 parameters,
                 app,
-                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE));
+                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters));
 
         final TokenRequestExecutor request = new TokenRequestExecutor(
                 new AADAuthority(new URL(TestConstants.ORGANIZATIONS_AUTHORITY)),
@@ -221,7 +220,7 @@ public class TokenRequestExecutorTest extends AbstractMsalTests {
         final AuthorizationCodeRequest acr =  new AuthorizationCodeRequest(
                 parameters,
                 app,
-                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE));
+                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters));
 
         ServiceBundle serviceBundle = new ServiceBundle(
                 null,
@@ -245,7 +244,7 @@ public class TokenRequestExecutorTest extends AbstractMsalTests {
         EasyMock.expect(httpResponse.getContentAsJSONObject())
                 .andReturn(
                         JSONObjectUtils
-                                .parse(TestConfiguration.HTTP_RESPONSE_FROM_AUTH_CODE))
+                                .parse(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE))
                 .times(1);
         httpResponse.ensureStatusCode(200);
         EasyMock.expectLastCall();
@@ -279,7 +278,7 @@ public class TokenRequestExecutorTest extends AbstractMsalTests {
         final AuthorizationCodeRequest acr =  new AuthorizationCodeRequest(
                 parameters,
                 app,
-                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE));
+                new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters));
 
         ServiceBundle serviceBundle = new ServiceBundle(
                 null,

--- a/src/test/java/com/microsoft/aad/msal4j/TokenResponseTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/TokenResponseTest.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
@@ -50,7 +49,7 @@ public class TokenResponseTest extends AbstractMsalTests {
             throws com.nimbusds.oauth2.sdk.ParseException {
         final TokenResponse response = TokenResponse
                 .parseJsonObject(JSONObjectUtils
-                        .parse(TestConfiguration.HTTP_RESPONSE_FROM_AUTH_CODE));
+                        .parse(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE));
         Assert.assertNotNull(response);
         OIDCTokens tokens = response.getOIDCTokens();
         Assert.assertNotNull(tokens);

--- a/src/test/java/com/microsoft/aad/msal4j/UIRequiredCacheTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/UIRequiredCacheTest.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.easymock.EasyMock;
 import org.powermock.api.easymock.PowerMock;
 import org.testng.Assert;
@@ -13,13 +14,13 @@ import java.util.*;
 
 import static org.easymock.EasyMock.anyObject;
 
-public class UIRequiredCacheTest extends AbstractMsalTests  {
+public class UIRequiredCacheTest extends AbstractMsalTests {
 
     public final Integer CACHING_TIME_SEC = 2;
 
     @BeforeClass
-    void init(){
-        UiRequiredCache.DEFAULT_CACHING_TIME_SEC = CACHING_TIME_SEC;
+    void init() {
+        InteractionRequiredCache.DEFAULT_CACHING_TIME_SEC = CACHING_TIME_SEC;
     }
 
     private RefreshTokenParameters getAcquireTokenApiParameters(String scope) {
@@ -52,18 +53,25 @@ public class UIRequiredCacheTest extends AbstractMsalTests  {
         return appBuilder.build();
     }
 
-    private PublicClientApplication getClientApplicationMockedWithOneTokenEndpointResponse()
-            throws Exception {
-        IHttpClient httpClientMock = EasyMock.createMock(IHttpClient.class);
-
+    private HttpResponse getHttpResponse(int statusCode, String body) {
         HttpResponse httpResponse = new HttpResponse();
         Map<String, List<String>> headers = new HashMap<>();
 
-        httpResponse.statusCode(400);
-        httpResponse.body(TestConfiguration.TOKEN_ENDPOINT_INVALID_GRANT_ERROR_RESPONSE);
+        httpResponse.statusCode(statusCode);
+        httpResponse.body(body);
 
         headers.put("Content-Type", Arrays.asList("application/json"));
         httpResponse.addHeaders(headers);
+
+        return httpResponse;
+    }
+
+    private PublicClientApplication getApp_MockedWith_InvalidGrantTokenEndpointResponse()
+            throws Exception {
+        IHttpClient httpClientMock = EasyMock.createMock(IHttpClient.class);
+
+        HttpResponse httpResponse = getHttpResponse(400,
+                TestConfiguration.TOKEN_ENDPOINT_INVALID_GRANT_ERROR_RESPONSE);
 
         EasyMock.expect(httpClientMock.send(anyObject())).andReturn(httpResponse).times(1);
         PowerMock.replayAll(httpClientMock);
@@ -71,12 +79,32 @@ public class UIRequiredCacheTest extends AbstractMsalTests  {
         return getPublicClientApp(httpClientMock);
     }
 
+    private PublicClientApplication getApp_MockedWith_OKTokenEndpointResponse_InvalidGrantTokenEndpointResponse()
+            throws Exception {
+        IHttpClient httpClientMock = EasyMock.createMock(IHttpClient.class);
+
+        HttpResponse httpResponse =
+                getHttpResponse(HTTPResponse.SC_OK, TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE);
+        EasyMock.expect(httpClientMock.send(anyObject())).andReturn(httpResponse).times(1);
+
+        httpResponse = getHttpResponse(HTTPResponse.SC_UNAUTHORIZED,
+                TestConfiguration.TOKEN_ENDPOINT_INVALID_GRANT_ERROR_RESPONSE);
+        EasyMock.expect(httpClientMock.send(anyObject())).andReturn(httpResponse).times(1);
+
+        PublicClientApplication app = getPublicClientApp(httpClientMock);
+
+        PowerMock.replayAll(httpClientMock);
+        return app;
+    }
+
     @Test
-    public void SilentRequest_STSResponseInvalidGrantError_repeatedRequestsServedFromCache() throws Exception {
+    public void RefreshTokenRequest_STSResponseInvalidGrantError_repeatedRequestsServedFromCache() throws Exception {
+        InteractionRequiredCache.clear();
+
         // refresh token request #1 to token endpoint
         // response contains invalid grant error
         PublicClientApplication
-                app = getClientApplicationMockedWithOneTokenEndpointResponse();
+                app = getApp_MockedWith_InvalidGrantTokenEndpointResponse();
         try {
             app.acquireToken(getAcquireTokenApiParameters("scope1")).join();
         } catch (Exception ex) {
@@ -99,7 +127,7 @@ public class UIRequiredCacheTest extends AbstractMsalTests  {
 
         // request #2 (different scope) should not be served from cache
         // request to token endpoint should be sent
-        app = getClientApplicationMockedWithOneTokenEndpointResponse();
+        app = getApp_MockedWith_InvalidGrantTokenEndpointResponse();
         try {
             app.acquireToken(getAcquireTokenApiParameters("scope2")).join();
         } catch (Exception ex) {
@@ -113,9 +141,83 @@ public class UIRequiredCacheTest extends AbstractMsalTests  {
         // repeat request #1, should not be served from cache (cache entry should be expired)
         // request to token endpoint should be sent
         Thread.sleep(CACHING_TIME_SEC * 1000);
-        app = getClientApplicationMockedWithOneTokenEndpointResponse();
+        app = getApp_MockedWith_InvalidGrantTokenEndpointResponse();
         try {
             app.acquireToken(getAcquireTokenApiParameters("scope1")).join();
+        } catch (Exception ex) {
+            if (!(ex.getCause() instanceof MsalServiceException)) {
+                Assert.fail("Unexpected exception");
+            }
+        }
+        PowerMock.verifyAll();
+        PowerMock.resetAll();
+    }
+
+    @Test
+    public void SilentRequest_STSResponseInvalidGrantError_repeatedRequestsServedFromCache() throws Exception {
+        InteractionRequiredCache.clear();
+
+        PublicClientApplication
+                app = getApp_MockedWith_OKTokenEndpointResponse_InvalidGrantTokenEndpointResponse();
+
+        // silent request #1 fails with InteractionRequiredException, response cached
+        try {
+            app.acquireToken(getAcquireTokenApiParameters("scope1")).join();
+            SilentParameters silentParameters = SilentParameters.builder(
+                    Collections.singleton("scope1"),
+                    app.getAccounts().join().iterator().next())
+                    .build();
+            app.acquireTokenSilently(silentParameters).join();
+        } catch (Exception ex) {
+            if (!(ex.getCause() instanceof MsalInteractionRequiredException)) {
+                Assert.fail("Unexpected exception");
+            }
+        }
+        PowerMock.verifyAll();
+        PowerMock.resetAll();
+
+        // repeat same silent #1, cached response should be returned
+        try {
+            SilentParameters silentParameters = SilentParameters.builder(
+                    Collections.singleton("scope1"),
+                    app.getAccounts().join().iterator().next())
+                    .build();
+            app.acquireTokenSilently(silentParameters).join();
+        } catch (Exception ex) {
+            if (!(ex.getCause() instanceof MsalInteractionRequiredException)) {
+                Assert.fail("Unexpected exception");
+            }
+        }
+
+        // silent request #2 (different scope) should not be served from cache
+        // request to token endpoint should be sent
+        app = getApp_MockedWith_OKTokenEndpointResponse_InvalidGrantTokenEndpointResponse();
+        try {
+            app.acquireToken(getAcquireTokenApiParameters("scope1")).join();
+            SilentParameters silentParameters = SilentParameters.builder(
+                    Collections.singleton("scope2"),
+                    app.getAccounts().join().iterator().next())
+                    .build();
+            app.acquireTokenSilently(silentParameters).join();
+        } catch (Exception ex) {
+            if (!(ex.getCause() instanceof MsalInteractionRequiredException)) {
+                Assert.fail("Unexpected exception");
+            }
+        }
+        PowerMock.verifyAll();
+        PowerMock.resetAll();
+
+        // repeat request #1, should not be served from cache (cache entry should be expired)
+        // request to token endpoint should be sent
+        Thread.sleep(CACHING_TIME_SEC * 1000);
+        app = getApp_MockedWith_OKTokenEndpointResponse_InvalidGrantTokenEndpointResponse();
+        try {
+            app.acquireToken(getAcquireTokenApiParameters("scope1")).join();
+            SilentParameters silentParameters = SilentParameters.builder(
+                    Collections.singleton("scope1"),
+                    app.getAccounts().join().iterator().next())
+                    .build();
+            app.acquireTokenSilently(silentParameters).join();
         } catch (Exception ex) {
             if (!(ex.getCause() instanceof MsalServiceException)) {
                 Assert.fail("Unexpected exception");

--- a/src/test/java/com/microsoft/aad/msal4j/UIRequiredCacheTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/UIRequiredCacheTest.java
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import org.easymock.EasyMock;
+import org.powermock.api.easymock.PowerMock;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+import static org.easymock.EasyMock.anyObject;
+
+public class UIRequiredCacheTest extends AbstractMsalTests  {
+
+    public final Integer CACHING_TIME_SEC = 2;
+
+    @BeforeClass
+    void init(){
+        UiRequiredCache.DEFAULT_CACHING_TIME_SEC = CACHING_TIME_SEC;
+    }
+
+    private RefreshTokenParameters getAcquireTokenApiParameters(String scope) {
+        return RefreshTokenParameters
+                .builder(Collections.singleton(scope), "refreshToken")
+                .build();
+    }
+
+    private RefreshTokenParameters getAcquireTokenApiParameters() {
+        return getAcquireTokenApiParameters("default-scope");
+    }
+
+    private PublicClientApplication getPublicClientApp() throws Exception {
+        return getPublicClientApp(null);
+    }
+
+    private PublicClientApplication getPublicClientApp(IHttpClient httpClient) throws Exception {
+        String instanceDiscoveryResponse = TestHelper.readResource(
+                this.getClass(),
+                "/instance_discovery_data/aad_instance_discovery_response_valid.json");
+
+        PublicClientApplication.Builder appBuilder = PublicClientApplication
+                .builder(TestConfiguration.AAD_CLIENT_ID + "1")
+                .aadInstanceDiscoveryResponse(instanceDiscoveryResponse);
+
+        if (httpClient != null) {
+            appBuilder.httpClient(httpClient);
+        }
+
+        return appBuilder.build();
+    }
+
+    private PublicClientApplication getClientApplicationMockedWithOneTokenEndpointResponse()
+            throws Exception {
+        IHttpClient httpClientMock = EasyMock.createMock(IHttpClient.class);
+
+        HttpResponse httpResponse = new HttpResponse();
+        Map<String, List<String>> headers = new HashMap<>();
+
+        httpResponse.statusCode(400);
+        httpResponse.body(TestConfiguration.TOKEN_ENDPOINT_INVALID_GRANT_ERROR_RESPONSE);
+
+        headers.put("Content-Type", Arrays.asList("application/json"));
+        httpResponse.addHeaders(headers);
+
+        EasyMock.expect(httpClientMock.send(anyObject())).andReturn(httpResponse).times(1);
+        PowerMock.replayAll(httpClientMock);
+
+        return getPublicClientApp(httpClientMock);
+    }
+
+    @Test
+    public void SilentRequest_STSResponseInvalidGrantError_repeatedRequestsServedFromCache() throws Exception {
+        // refresh token request #1 to token endpoint
+        // response contains invalid grant error
+        PublicClientApplication
+                app = getClientApplicationMockedWithOneTokenEndpointResponse();
+        try {
+            app.acquireToken(getAcquireTokenApiParameters("scope1")).join();
+        } catch (Exception ex) {
+            if (!(ex.getCause() instanceof MsalInteractionRequiredException)) {
+                Assert.fail("Unexpected exception");
+            }
+        }
+        PowerMock.verifyAll();
+        PowerMock.resetAll();
+
+        // repeat same request #1, cached response should be returned
+        try {
+            app = getPublicClientApp();
+            app.acquireToken(getAcquireTokenApiParameters("scope1")).join();
+        } catch (Exception ex) {
+            if (!(ex.getCause() instanceof MsalInteractionRequiredException)) {
+                Assert.fail("Unexpected exception");
+            }
+        }
+
+        // request #2 (different scope) should not be served from cache
+        // request to token endpoint should be sent
+        app = getClientApplicationMockedWithOneTokenEndpointResponse();
+        try {
+            app.acquireToken(getAcquireTokenApiParameters("scope2")).join();
+        } catch (Exception ex) {
+            if (!(ex.getCause() instanceof MsalInteractionRequiredException)) {
+                Assert.fail("Unexpected exception");
+            }
+        }
+        PowerMock.verifyAll();
+        PowerMock.resetAll();
+
+        // repeat request #1, should not be served from cache (cache entry should be expired)
+        // request to token endpoint should be sent
+        Thread.sleep(CACHING_TIME_SEC * 1000);
+        app = getClientApplicationMockedWithOneTokenEndpointResponse();
+        try {
+            app.acquireToken(getAcquireTokenApiParameters("scope1")).join();
+        } catch (Exception ex) {
+            if (!(ex.getCause() instanceof MsalServiceException)) {
+                Assert.fail("Unexpected exception");
+            }
+        }
+        PowerMock.verifyAll();
+        PowerMock.resetAll();
+    }
+}


### PR DESCRIPTION
- support of STS throttling instructions - 429 Retry-After header + 429, 5xx response status codes
- caching of InteractionRequiredException responses for refresh token grant requests
- refactoring


issue https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/176