### PR TITLE
Client Capabilities Support

### DIFF
--- a/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
@@ -44,10 +44,10 @@ public class AuthorizationCodeIT extends SeleniumTest {
         Map<String, Set<String>> claimsAndCapabilities = new HashMap<>();
 
         //Two separate claims used to test merging claim JSONs
-        claims.add("{\"userinfo\":{\"given_name\":{\"essential\":true},\"nickname\":null,\"email\":{\"essential\":true},\"email_verified\":{\"essential\":true},\"picture\":null,\"http://example.info/claims/groups\":null}}");
-        claims.add("{\"id_token\":{\"auth_time\":{\"essential\":true}}}");
+        claims.add(TestConstants.CLAIMS_USERINFO);
+        claims.add(TestConstants.CLAIMS_IDTOKEN);
         //Client Capabilities with no values, as client capabilities were not yet supported when this test was written
-        clientCapabilities.add("{\"access_token\":{\"xms_cc\":{\"values\":[]}}}");
+        clientCapabilities.add(TestConstants.CLIENT_CAPABILITIES);
 
         claimsAndCapabilities.put("claims", claims);
         claimsAndCapabilities.put("clientCapabilities", clientCapabilities);

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
@@ -33,7 +33,8 @@ public class AuthorizationCodeIT extends SeleniumTest {
         assertAcquireTokenAAD(user, null);
     }
 
-    @Test(dataProvider = "environments", dataProviderClass = EnvironmentsProvider.class)
+    //TODO: Re-enable test once list of claims/capabilities and their expected behavior is known
+    //@Test(dataProvider = "environments", dataProviderClass = EnvironmentsProvider.class)
     public void acquireTokenWithAuthorizationCode_ManagedUserWithClaimsAndCapabilities(String environment){
         cfg = new Config(environment);
 

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
@@ -39,18 +39,10 @@ public class AuthorizationCodeIT extends SeleniumTest {
 
         User user = labUserProvider.getDefaultUser(cfg.azureEnvironment);
 
-        Set<String> claims = new HashSet<>();
-        Set<String> clientCapabilities = new HashSet<>();
         Map<String, Set<String>> claimsAndCapabilities = new HashMap<>();
 
-        //Two separate claims used to test merging claim JSONs
-        claims.add(TestConstants.CLAIMS_USERINFO);
-        claims.add(TestConstants.CLAIMS_IDTOKEN);
-        //Client Capabilities with no values, as client capabilities were not yet supported when this test was written
-        clientCapabilities.add(TestConstants.CLIENT_CAPABILITIES);
-
-        claimsAndCapabilities.put("claims", claims);
-        claimsAndCapabilities.put("clientCapabilities", clientCapabilities);
+        claimsAndCapabilities.put("claims", Collections.singleton(TestConstants.CLAIMS));
+        claimsAndCapabilities.put("clientCapabilities", TestConstants.CLIENT_CAPABILITIES_LLT);
 
         assertAcquireTokenAAD(user, claimsAndCapabilities);
     }
@@ -333,7 +325,7 @@ public class AuthorizationCodeIT extends SeleniumTest {
                 AuthorizationRequestUrlParameters
                         .builder(TestConstants.LOCALHOST + httpListener.port(),
                                 Collections.singleton(scope))
-                        .claims(parameters.getOrDefault("claims", null))
+                        .claims(String.valueOf(parameters.getOrDefault("claims", null).toArray()[0]))
                         .clientCapabilities(parameters.getOrDefault("clientCapabilities", null))
                         .build();
 

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
@@ -152,10 +152,18 @@ public class AuthorizationCodeIT extends SeleniumTest {
 
         PublicClientApplication pca;
         try {
-            pca = PublicClientApplication.builder(
-                    user.getAppId()).
-                    authority(cfg.organizationsAuthority()).
-                    build();
+            if (parameters != null) {
+                pca = PublicClientApplication.builder(
+                        user.getAppId()).
+                        authority(cfg.organizationsAuthority()).
+                        clientCapabilities(parameters.getOrDefault("clientCapabilities", null)).
+                        build();
+            } else {
+                pca = PublicClientApplication.builder(
+                        user.getAppId()).
+                        authority(cfg.organizationsAuthority()).
+                        build();
+            }
         } catch(MalformedURLException ex){
             throw new RuntimeException(ex.getMessage());
         }
@@ -325,8 +333,7 @@ public class AuthorizationCodeIT extends SeleniumTest {
                 AuthorizationRequestUrlParameters
                         .builder(TestConstants.LOCALHOST + httpListener.port(),
                                 Collections.singleton(scope))
-                        .claims(String.valueOf(parameters.getOrDefault("claims", null).toArray()[0]))
-                        .clientCapabilities(parameters.getOrDefault("clientCapabilities", null))
+                        .claims(String.valueOf(parameters.getOrDefault("claims", Collections.singleton("")).toArray()[0]))
                         .build();
 
         return app.getAuthorizationRequestUrl(requestUrlParameters).toString();

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
@@ -315,7 +315,6 @@ public class AuthorizationCodeIT extends SeleniumTest {
 
     private String buildAuthenticationCodeURLWithParameters(ClientApplicationBase app, Map<String, Set<String>> parameters) {
         String scope;
-        Set<String> claims = new HashSet<>();
 
         AuthorityType authorityType= app.authenticationAuthority.authorityType;
         if(authorityType == AuthorityType.AAD){

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
@@ -314,7 +314,7 @@ public class AuthorizationCodeIT extends SeleniumTest {
         return app.getAuthorizationRequestUrl(parameters).toString();
     }
 
-    private String buildAuthenticationCodeURLWithParameters(ClientApplicationBase app, Map<String, Set<String>> parameters) {
+    private String buildAuthenticationCodeURLWithParameters(AbstractClientApplicationBase app, Map<String, Set<String>> parameters) {
         String scope;
 
         AuthorityType authorityType= app.authenticationAuthority.authorityType;

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
@@ -42,7 +42,7 @@ public class AuthorizationCodeIT extends SeleniumTest {
         Map<String, Set<String>> claimsAndCapabilities = new HashMap<>();
 
         claimsAndCapabilities.put("claims", Collections.singleton(TestConstants.CLAIMS));
-        claimsAndCapabilities.put("clientCapabilities", TestConstants.CLIENT_CAPABILITIES_LLT);
+        claimsAndCapabilities.put("clientCapabilities", TestConstants.CLIENT_CAPABILITIES_EMPTY);
 
         assertAcquireTokenAAD(user, claimsAndCapabilities);
     }

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
@@ -47,7 +47,7 @@ public class TestConstants {
     public final static String ADFS_SCOPE = USER_READ_SCOPE;
     public final static String ADFS_APP_ID = "PublicClientId";
 
-    public final static String CLAIMS = "{\"userinfo\":{\"given_name\":{\"essential\":true},\"nickname\":null,\"email\":{\"essential\":true},\"email_verified\":{\"essential\":true},\"picture\":null,\"http://example.info/claims/groups\":null},\"id_token\":{\"auth_time\":{\"essential\":true},\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\"]}}}";
+    public final static String CLAIMS = "{\"id_token\":{\"auth_time\":{\"essential\":true}}}";
     public final static Set<String> CLIENT_CAPABILITIES_EMPTY = new HashSet<String>(Collections.emptySet());
     public final static Set<String> CLIENT_CAPABILITIES_LLT = new HashSet<String>(Collections.singletonList("llt"));
 }

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
@@ -3,8 +3,9 @@
 
 package com.microsoft.aad.msal4j;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
 
 public class TestConstants {
     public final static String KEYVAULT_DEFAULT_SCOPE = "https://vault.azure.net/.default";
@@ -46,7 +47,7 @@ public class TestConstants {
     public final static String ADFS_SCOPE = USER_READ_SCOPE;
     public final static String ADFS_APP_ID = "PublicClientId";
 
-    public final static String CLAIMS_USERINFO = "{\"userinfo\":{\"given_name\":{\"essential\":true},\"nickname\":null,\"email\":{\"essential\":true},\"email_verified\":{\"essential\":true},\"picture\":null,\"http://example.info/claims/groups\":null}}";
-    public final static String CLAIMS_IDTOKEN = "{\"id_token\":{\"auth_time\":{\"essential\":true}}}";
-    public final static String CLIENT_CAPABILITIES = "{\"access_token\":{\"xms_cc\":{\"values\":[]}}}";
+    public final static String CLAIMS = "{\"userinfo\":{\"given_name\":{\"essential\":true},\"nickname\":null,\"email\":{\"essential\":true},\"email_verified\":{\"essential\":true},\"picture\":null,\"http://example.info/claims/groups\":null},\"id_token\":{\"auth_time\":{\"essential\":true},\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\"]}}}";
+    public final static Set<String> CLIENT_CAPABILITIES_EMPTY = new HashSet<String>(Collections.emptySet());
+    public final static Set<String> CLIENT_CAPABILITIES_LLT = new HashSet<String>(Collections.singletonList("llt"));
 }

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
@@ -3,6 +3,9 @@
 
 package com.microsoft.aad.msal4j;
 
+import java.util.Arrays;
+import java.util.HashSet;
+
 public class TestConstants {
     public final static String KEYVAULT_DEFAULT_SCOPE = "https://vault.azure.net/.default";
     public final static String MSIDLAB_DEFAULT_SCOPE = "https://msidlab.com/.default";
@@ -42,4 +45,8 @@ public class TestConstants {
     public final static String ADFS_AUTHORITY = "https://fs.msidlab8.com/adfs/";
     public final static String ADFS_SCOPE = USER_READ_SCOPE;
     public final static String ADFS_APP_ID = "PublicClientId";
+
+    public final static String CLAIMS_USERINFO = "{\"userinfo\":{\"given_name\":{\"essential\":true},\"nickname\":null,\"email\":{\"essential\":true},\"email_verified\":{\"essential\":true},\"picture\":null,\"http://example.info/claims/groups\":null}}";
+    public final static String CLAIMS_IDTOKEN = "{\"id_token\":{\"auth_time\":{\"essential\":true}}}";
+    public final static String CLIENT_CAPABILITIES = "{\"access_token\":{\"xms_cc\":{\"values\":[]}}}";
 }

--- a/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
@@ -175,9 +175,12 @@ abstract class AbstractClientApplicationBase implements IClientApplicationBase {
 
         parameters.requestParameters.put("client_id", Collections.singletonList(this.clientId));
 
+        //If the client application has any client capabilities set, they must be merged into the claims parameter
         if (this.clientCapabilities != null) {
             if (parameters.requestParameters.containsKey("claims")) {
-                parameters.requestParameters.put("claims", Collections.singletonList(JsonHelper.mergeJSONString(String.valueOf(parameters.requestParameters.get("claims").get(0)), this.clientCapabilities)));
+                String claims = String.valueOf(parameters.requestParameters.get("claims").get(0));
+                String mergedClaimsCapabilities = JsonHelper.mergeJSONString(claims, this.clientCapabilities);
+                parameters.requestParameters.put("claims", Collections.singletonList(mergedClaimsCapabilities));
             } else {
                 parameters.requestParameters.put("claims", Collections.singletonList(this.clientCapabilities));
             }

--- a/src/main/java/com/microsoft/aad/msal4j/AuthenticationErrorCode.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthenticationErrorCode.java
@@ -90,4 +90,9 @@ public class AuthenticationErrorCode {
      * https://aka.ms/msal4j-interactive-request
      */
     public final static String DESKTOP_BROWSER_NOT_SUPPORTED = "desktop_browser_not_supported";
+
+    /**
+     * A JsonProcessingException was thrown, indicating the JSON provided to MSAL is of invalid format.
+     */
+    public final static String INVALID_JSON = "invalid_json";
 }

--- a/src/main/java/com/microsoft/aad/msal4j/AuthenticationErrorMessage.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthenticationErrorMessage.java
@@ -6,7 +6,7 @@ package com.microsoft.aad.msal4j;
 public class AuthenticationErrorMessage {
 
     /**
-     * Token not found it the cache
+     * Token not found in the cache
      */
-    public final static String NO_TOKEN_IN_CACHE = "Token not found it the cache";
+    public final static String NO_TOKEN_IN_CACHE = "Token not found in the cache";
 }

--- a/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
@@ -71,9 +71,14 @@ public class AuthorizationRequestUrlParameters {
         requestParameters.put("response_type",Collections.singletonList("code"));
 
         // Optional parameters
-        if(builder.claims != null && builder.claims.trim().length() > 0){
-            JsonHelper.validateJsonFormat(builder.claims);
-            requestParameters.put("claims", Collections.singletonList(builder.claims));
+        if(builder.claims != null) {
+            String claimsParam = String.join(" ", builder.claims);
+            requestParameters.put("claims", Collections.singletonList(claimsParam));
+        }
+
+        if(builder.claimsChallenge != null && builder.claimsChallenge.trim().length() > 0){
+            JsonHelper.validateJsonFormat(builder.claimsChallenge);
+            requestParameters.put("claims", Collections.singletonList(builder.claimsChallenge));
         }
 
         if(builder.codeChallenge != null){
@@ -146,7 +151,8 @@ public class AuthorizationRequestUrlParameters {
 
         private String redirectUri;
         private Set<String> scopes;
-        private String claims;
+        private Set<String> claims;
+        private String claimsChallenge;
         private String codeChallenge;
         private String codeChallengeMethod;
         private String state;
@@ -186,9 +192,22 @@ public class AuthorizationRequestUrlParameters {
          * In cases where Azure AD tenant admin has enabled conditional access policies, and the
          * policy has not been met,{@link MsalServiceException} will contain claims that need be
          * consented to.
+         *
+         * Deprecated in favor of {@link #claimsChallenge(String)}
          */
-        public Builder claims(String val){
+        @Deprecated
+        public Builder claims(Set<String> val){
             this.claims = val;
+            return self();
+        }
+
+        /**
+         * In cases where Azure AD tenant admin has enabled conditional access policies, and the
+         * policy has not been met,{@link MsalServiceException} will contain claims that need be
+         * consented to.
+         */
+        public Builder claimsChallenge(String val){
+            this.claimsChallenge = val;
             return self();
         }
 

--- a/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
@@ -76,7 +76,7 @@ public class AuthorizationRequestUrlParameters {
             requestParameters.put("claims", Collections.singletonList(builder.claims));
         }
 
-        if(!builder.clientCapabilities.isEmpty()){
+        if(builder.clientCapabilities != null && !builder.clientCapabilities.isEmpty()){
             String capabilitiesParam = JsonHelper.formCapabilitiesJson(builder.clientCapabilities);
             JsonHelper.validateJsonFormat(capabilitiesParam);
             if (requestParameters.containsKey("claims")) {

--- a/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
@@ -71,20 +71,9 @@ public class AuthorizationRequestUrlParameters {
         requestParameters.put("response_type",Collections.singletonList("code"));
 
         // Optional parameters
-        if(builder.claims != null){
+        if(builder.claims != null && builder.claims.trim().length() > 0){
             JsonHelper.validateJsonFormat(builder.claims);
             requestParameters.put("claims", Collections.singletonList(builder.claims));
-        }
-
-        if(builder.clientCapabilities != null && !builder.clientCapabilities.isEmpty()){
-            String capabilitiesParam = JsonHelper.formCapabilitiesJson(builder.clientCapabilities);
-            JsonHelper.validateJsonFormat(capabilitiesParam);
-            if (requestParameters.containsKey("claims")) {
-                String mergedClaimsAndCapabilities = JsonHelper.mergeJSONString(String.valueOf(requestParameters.get("claims").get(0)), capabilitiesParam);
-                requestParameters.replace("claims", Collections.singletonList(mergedClaimsAndCapabilities));
-            } else {
-                requestParameters.put("claims", Collections.singletonList(capabilitiesParam));
-            }
         }
 
         if(builder.codeChallenge != null){
@@ -158,7 +147,6 @@ public class AuthorizationRequestUrlParameters {
         private String redirectUri;
         private Set<String> scopes;
         private String claims;
-        private Set<String> clientCapabilities;
         private String codeChallenge;
         private String codeChallengeMethod;
         private String state;
@@ -201,15 +189,6 @@ public class AuthorizationRequestUrlParameters {
          */
         public Builder claims(String val){
             this.claims = val;
-            return self();
-        }
-
-        /**
-         * Allows the client to indicate to the token service what policies or features it is
-         * capable of handling
-         */
-        public Builder clientCapabilities(Set<String> val){
-            this.clientCapabilities = val;
             return self();
         }
 

--- a/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
@@ -72,12 +72,13 @@ public class AuthorizationRequestUrlParameters {
 
         // Optional parameters
         if(builder.claims != null){
-            String claimsParam = JsonHelper.mergeJSONString(builder.claims);
-            requestParameters.put("claims", Collections.singletonList(claimsParam));
+            JsonHelper.validateJsonFormat(builder.claims);
+            requestParameters.put("claims", Collections.singletonList(builder.claims));
         }
 
-        if(builder.clientCapabilities != null){
-            String capabilitiesParam = JsonHelper.mergeJSONString(builder.clientCapabilities);
+        if(!builder.clientCapabilities.isEmpty()){
+            String capabilitiesParam = JsonHelper.formCapabilitiesJson(builder.clientCapabilities);
+            JsonHelper.validateJsonFormat(capabilitiesParam);
             if (requestParameters.containsKey("claims")) {
                 String mergedClaimsAndCapabilities = JsonHelper.mergeJSONString(String.valueOf(requestParameters.get("claims").get(0)), capabilitiesParam);
                 requestParameters.replace("claims", Collections.singletonList(mergedClaimsAndCapabilities));
@@ -156,7 +157,7 @@ public class AuthorizationRequestUrlParameters {
 
         private String redirectUri;
         private Set<String> scopes;
-        private Set<String> claims;
+        private String claims;
         private Set<String> clientCapabilities;
         private String codeChallenge;
         private String codeChallengeMethod;
@@ -198,7 +199,7 @@ public class AuthorizationRequestUrlParameters {
          * policy has not been met,{@link MsalServiceException} will contain claims that need be
          * consented to.
          */
-        public Builder claims(Set<String> val){
+        public Builder claims(String val){
             this.claims = val;
             return self();
         }

--- a/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
@@ -72,8 +72,18 @@ public class AuthorizationRequestUrlParameters {
 
         // Optional parameters
         if(builder.claims != null){
-            String claimsParam = String.join(" ", builder.claims);
+            String claimsParam = JsonHelper.mergeJSONString(builder.claims);
             requestParameters.put("claims", Collections.singletonList(claimsParam));
+        }
+
+        if(builder.clientCapabilities != null){
+            String capabilitiesParam = JsonHelper.mergeJSONString(builder.clientCapabilities);
+            if (requestParameters.containsKey("claims")) {
+                String mergedClaimsAndCapabilities = JsonHelper.mergeJSONString(String.valueOf(requestParameters.get("claims").get(0)), capabilitiesParam);
+                requestParameters.replace("claims", Collections.singletonList(mergedClaimsAndCapabilities));
+            } else {
+                requestParameters.put("claims", Collections.singletonList(capabilitiesParam));
+            }
         }
 
         if(builder.codeChallenge != null){
@@ -147,6 +157,7 @@ public class AuthorizationRequestUrlParameters {
         private String redirectUri;
         private Set<String> scopes;
         private Set<String> claims;
+        private Set<String> clientCapabilities;
         private String codeChallenge;
         private String codeChallengeMethod;
         private String state;
@@ -189,6 +200,15 @@ public class AuthorizationRequestUrlParameters {
          */
         public Builder claims(Set<String> val){
             this.claims = val;
+            return self();
+        }
+
+        /**
+         * Allows the client to indicate to the token service what policies or features it is
+         * capable of handling
+         */
+        public Builder clientCapabilities(Set<String> val){
+            this.clientCapabilities = val;
             return self();
         }
 

--- a/src/main/java/com/microsoft/aad/msal4j/InteractiveRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/InteractiveRequest.java
@@ -83,7 +83,7 @@ class InteractiveRequest extends MsalRequest{
                         .builder(interactiveRequestParameters.redirectUri().toString(),
                                 interactiveRequestParameters.scopes())
                         .prompt(interactiveRequestParameters.prompt())
-                        .claims(interactiveRequestParameters.claims())
+                        .claimsChallenge(interactiveRequestParameters.claimsChallenge())
                         .loginHint(interactiveRequestParameters.loginHint())
                         .domainHint(interactiveRequestParameters.domainHint())
                         .correlationId(publicClientApplication.correlationId());

--- a/src/main/java/com/microsoft/aad/msal4j/InteractiveRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/InteractiveRequest.java
@@ -84,7 +84,6 @@ class InteractiveRequest extends MsalRequest{
                                 interactiveRequestParameters.scopes())
                         .prompt(interactiveRequestParameters.prompt())
                         .claims(interactiveRequestParameters.claims())
-                        .clientCapabilities(interactiveRequestParameters.clientCapabilities())
                         .loginHint(interactiveRequestParameters.loginHint())
                         .domainHint(interactiveRequestParameters.domainHint())
                         .correlationId(publicClientApplication.correlationId());

--- a/src/main/java/com/microsoft/aad/msal4j/InteractiveRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/InteractiveRequest.java
@@ -83,6 +83,8 @@ class InteractiveRequest extends MsalRequest{
                         .builder(interactiveRequestParameters.redirectUri().toString(),
                                 interactiveRequestParameters.scopes())
                         .prompt(interactiveRequestParameters.prompt())
+                        .claims(interactiveRequestParameters.claims())
+                        .clientCapabilities(interactiveRequestParameters.clientCapabilities())
                         .loginHint(interactiveRequestParameters.loginHint())
                         .domainHint(interactiveRequestParameters.domainHint())
                         .correlationId(publicClientApplication.correlationId());

--- a/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
@@ -67,7 +67,7 @@ public class InteractiveRequestParameters implements IApiParameters {
      */
     private SystemBrowserOptions systemBrowserOptions;
 
-    private String claims;
+    private String claimsChallenge;
 
     private static InteractiveRequestParametersBuilder builder() {
         return new InteractiveRequestParametersBuilder();

--- a/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
@@ -67,6 +67,10 @@ public class InteractiveRequestParameters {
      */
     private SystemBrowserOptions systemBrowserOptions;
 
+    private String claims;
+
+    private Set<String> clientCapabilities;
+
     private static InteractiveRequestParametersBuilder builder() {
         return new InteractiveRequestParametersBuilder();
     }

--- a/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
@@ -69,8 +69,6 @@ public class InteractiveRequestParameters {
 
     private String claims;
 
-    private Set<String> clientCapabilities;
-
     private static InteractiveRequestParametersBuilder builder() {
         return new InteractiveRequestParametersBuilder();
     }

--- a/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
+++ b/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
@@ -48,20 +48,22 @@ class JsonHelper {
 
         mergeJSONNode(mainJson, addJson);
 
-        return mainJson != null ? mainJson.toString() : null;
+        return mainJson.toString();
     }
 
     /**
      * Merges set of given JSON strings into one Jackson JsonNode object, which is returned as a String
      */
     static String mergeJSONString(Set<String> jsonStrings) {
-        JsonNode mainJson = null;
+        JsonNode mainJson;
         JsonNode addJson;
 
         Iterator<String> jsons = jsonStrings.iterator();
         try {
             if (jsons.hasNext()) {
                 mainJson = mapper.readTree(jsons.next());
+            } else {
+                return "";
             }
         } catch (JsonProcessingException e) {
             throw new MsalClientException(e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
@@ -76,7 +78,7 @@ class JsonHelper {
             mergeJSONNode(mainJson, addJson);
         }
 
-        return mainJson != null ? mainJson.toString() : null;
+        return mainJson.toString();
     }
 
     /**

--- a/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
+++ b/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
@@ -36,7 +36,9 @@ class JsonHelper {
      * Merges given JSON strings into one Jackson JSONNode object, which is returned as a String
      */
     static String mergeJSONString(String mainJsonString, String addJsonString) {
-        JsonNode mainJson, addJson;
+        JsonNode mainJson;
+        JsonNode addJson;
+
         try {
             mainJson = mapper.readTree(mainJsonString);
             addJson = mapper.readTree(addJsonString);
@@ -53,7 +55,8 @@ class JsonHelper {
      * Merges set of given JSON strings into one Jackson JsonNode object, which is returned as a String
      */
     static String mergeJSONString(Set<String> jsonStrings) {
-        JsonNode mainJson = null, addJson;
+        JsonNode mainJson = null;
+        JsonNode addJson;
 
         Iterator<String> jsons = jsonStrings.iterator();
         try {

--- a/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
+++ b/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
@@ -53,11 +53,13 @@ class JsonHelper {
      * Merges set of given JSON strings into one Jackson JsonNode object, which is returned as a String
      */
     static String mergeJSONString(Set<String> jsonStrings) {
-        JsonNode mainJson, addJson;
+        JsonNode mainJson = null, addJson;
 
         Iterator<String> jsons = jsonStrings.iterator();
         try {
-            mainJson = mapper.readTree(jsons.next());
+            if (jsons.hasNext()) {
+                mainJson = mapper.readTree(jsons.next());
+            }
         } catch (JsonProcessingException e) {
             throw new MsalClientException(e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
         }
@@ -83,8 +85,8 @@ class JsonHelper {
         }
 
         Iterator<String> fieldNames = addNode.fieldNames();
-
         while (fieldNames.hasNext()) {
+
             String fieldName = fieldNames.next();
             JsonNode jsonNode = mainNode.get(fieldName);
 

--- a/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
+++ b/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
@@ -6,11 +6,13 @@ package com.microsoft.aad.msal4j;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Iterator;
+import java.util.Set;
 
 class JsonHelper {
     static ObjectMapper mapper;
@@ -27,6 +29,73 @@ class JsonHelper {
             return mapper.readValue(json, clazz);
         } catch (JsonProcessingException e) {
             throw new MsalClientException(e);
+        }
+    }
+
+    /**
+     * Merges given JSON strings into one Jackson JSONNode object, which is returned as a String
+     */
+    static String mergeJSONString(String mainJsonString, String addJsonString) {
+        JsonNode mainJson, addJson;
+        try {
+            mainJson = mapper.readTree(mainJsonString);
+            addJson = mapper.readTree(addJsonString);
+        } catch (JsonProcessingException e) {
+            throw new MsalClientException(e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
+        }
+
+        mergeJSONNode(mainJson, addJson);
+
+        return mainJson != null ? mainJson.toString() : null;
+    }
+
+    /**
+     * Merges set of given JSON strings into one Jackson JsonNode object, which is returned as a String
+     */
+    static String mergeJSONString(Set<String> jsonStrings) {
+        JsonNode mainJson, addJson;
+
+        Iterator<String> jsons = jsonStrings.iterator();
+        try {
+            mainJson = mapper.readTree(jsons.next());
+        } catch (JsonProcessingException e) {
+            throw new MsalClientException(e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
+        }
+
+        while (jsons.hasNext()) {
+            try {
+                addJson = mapper.readTree(jsons.next());
+            } catch (JsonProcessingException e) {
+                throw new MsalClientException(e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
+            }
+            mergeJSONNode(mainJson, addJson);
+        }
+
+        return mainJson != null ? mainJson.toString() : null;
+    }
+
+    /**
+     * Merges given Jackson JsonNode object into another JsonNode
+     */
+    static void mergeJSONNode(JsonNode mainNode, JsonNode addNode) {
+        if (addNode == null) {
+            return;
+        }
+
+        Iterator<String> fieldNames = addNode.fieldNames();
+
+        while (fieldNames.hasNext()) {
+            String fieldName = fieldNames.next();
+            JsonNode jsonNode = mainNode.get(fieldName);
+
+            if (jsonNode != null && jsonNode.isObject()) {
+                mergeJSONNode(jsonNode, addNode.get(fieldName));
+            } else {
+                if (mainNode instanceof ObjectNode) {
+                    JsonNode value = addNode.get(fieldName);
+                    ((ObjectNode) mainNode).put(fieldName, value);
+                }
+            }
         }
     }
 }

--- a/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
+++ b/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
@@ -54,7 +54,12 @@ class JsonHelper {
      *  }
      */
     public static String formCapabilitiesJson(Set<String> clientCapabilities) {
-        return "{\"access_token\":{\"xms_cc\":{\"values\":[\"" + String.join("\",\"", clientCapabilities) + "\"]}}}\"";
+        if (clientCapabilities != null && !clientCapabilities.isEmpty()) {
+            return "{\"access_token\":{\"xms_cc\":{\"values\":[\"" + String.join("\",\"", clientCapabilities) + "\"]}}}";
+        }
+        else {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
+++ b/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
@@ -33,6 +33,31 @@ class JsonHelper {
     }
 
     /**
+     * Throws exception if given String does not follow JSON syntax
+     */
+    static void validateJsonFormat(String jsonString) {
+        try {
+            mapper.readTree(jsonString);
+        } catch (JsonProcessingException e) {
+            throw new MsalClientException(e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
+        }
+    }
+
+    /**
+     * Take a set of Strings and return a String representing a JSON object of the format:
+     *  {
+     *    "access_token": {
+     *      "xms_cc": {
+     *        "values": [ clientCapabilities ]
+     *      }
+     *    }
+     *  }
+     */
+    public static String formCapabilitiesJson(Set<String> clientCapabilities) {
+        return "{\"access_token\":{\"xms_cc\":{\"values\":[\"" + String.join("\",\"", clientCapabilities) + "\"]}}}\"";
+    }
+
+    /**
      * Merges given JSON strings into one Jackson JSONNode object, which is returned as a String
      */
     static String mergeJSONString(String mainJsonString, String addJsonString) {

--- a/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -17,7 +17,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -57,7 +59,11 @@ class TokenRequestExecutor {
                 this.serviceBundle);
         oauthHttpRequest.setContentType(CommonContentTypes.APPLICATION_URLENCODED);
 
-        final Map<String, List<String>> params = msalRequest.msalAuthorizationGrant().toParameters();
+        final Map<String, List<String>> params = new HashMap<>(msalRequest.msalAuthorizationGrant().toParameters());
+        if (msalRequest.application().clientCapabilities() != null) {
+            params.put("claims", Collections.singletonList(msalRequest.application().clientCapabilities()));
+        }
+
         oauthHttpRequest.setQuery(URLUtils.serializeParameters(params));
 
         if (msalRequest.application().clientAuthentication() != null) {

--- a/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
@@ -127,6 +127,6 @@ public class AuthorizationRequestUrlParametersTest {
         Assert.assertEquals(queryParameters.get("correlation_id"), "corr_id");
         Assert.assertEquals(queryParameters.get("login_hint"), "hint");
         Assert.assertEquals(queryParameters.get("domain_hint"), "domain_hint");
-        Assert.assertEquals(queryParameters.get("claims"), "{\"access_token\":{\"auth_time\":{\"essential\":true},\"xms_cc\":{\"values\":[\"llt\",\"ssm\"]}}}");
+        Assert.assertEquals(queryParameters.get("claims"), "{\"id_token\":{\"auth_time\":{\"essential\":true}},\"access_token\":{\"auth_time\":{\"essential\":true},\"xms_cc\":{\"values\":[\"llt\",\"ssm\"]}}}");
     }
 }

--- a/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
@@ -97,7 +97,7 @@ public class AuthorizationRequestUrlParametersTest {
                         .correlationId("corr_id")
                         .loginHint("hint")
                         .domainHint("domain_hint")
-                        .claims("{\"id_token\":{\"auth_time\":{\"essential\":true}},\"access_token\":{\"auth_time\":{\"essential\":true}}}")
+                        .claimsChallenge("{\"id_token\":{\"auth_time\":{\"essential\":true}},\"access_token\":{\"auth_time\":{\"essential\":true}}}")
                         .prompt(Prompt.SELECT_ACCOUNT)
                         .build();
 

--- a/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
@@ -92,6 +92,8 @@ public class AuthorizationRequestUrlParametersTest {
                         .correlationId("corr_id")
                         .loginHint("hint")
                         .domainHint("domain_hint")
+                        .claims(Collections.singleton("{\"userinfo\":{\"given_name\":{\"essential\":true},\"nickname\":null,\"email\":{\"essential\":true},\"email_verified\":{\"essential\":true},\"picture\":null,\"http://example.info/claims/groups\":null}}"))
+                        .clientCapabilities(Collections.singleton("{\"access_token\":{\"xms_cc\":{\"values\":[]}}}"))
                         .prompt(Prompt.SELECT_ACCOUNT)
                         .build();
 
@@ -121,5 +123,6 @@ public class AuthorizationRequestUrlParametersTest {
         Assert.assertEquals(queryParameters.get("correlation_id"), "corr_id");
         Assert.assertEquals(queryParameters.get("login_hint"), "hint");
         Assert.assertEquals(queryParameters.get("domain_hint"), "domain_hint");
+        Assert.assertEquals(queryParameters.get("claims"), "{\"userinfo\":{\"given_name\":{\"essential\":true},\"nickname\":null,\"email\":{\"essential\":true},\"email_verified\":{\"essential\":true},\"picture\":null,\"http://example.info/claims/groups\":null},\"access_token\":{\"xms_cc\":{\"values\":[]}}}");
     }
 }

--- a/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashSet;
 
 public class AuthorizationRequestUrlParametersTest {
 
@@ -76,7 +77,11 @@ public class AuthorizationRequestUrlParametersTest {
 
     @Test
     public void testBuilder_optionalParameters() throws UnsupportedEncodingException{
-        PublicClientApplication app = PublicClientApplication.builder("client_id").build();
+        Set<String> clientCapabilities = new HashSet<>();
+        clientCapabilities.add("llt");
+        clientCapabilities.add("ssm");
+
+        PublicClientApplication app = PublicClientApplication.builder("client_id").clientCapabilities(clientCapabilities).build();
 
         String redirectUri = "http://localhost:8080";
         Set<String> scope = Collections.singleton("scope");
@@ -92,8 +97,7 @@ public class AuthorizationRequestUrlParametersTest {
                         .correlationId("corr_id")
                         .loginHint("hint")
                         .domainHint("domain_hint")
-                        .claims("{\"userinfo\":{\"given_name\":{\"essential\":true},\"nickname\":null,\"email\":{\"essential\":true},\"email_verified\":{\"essential\":true},\"picture\":null,\"http://example.info/claims/groups\":null}}")
-                        .clientCapabilities(Collections.emptySet())
+                        .claims("{\"id_token\":{\"auth_time\":{\"essential\":true}}}")
                         .prompt(Prompt.SELECT_ACCOUNT)
                         .build();
 
@@ -123,6 +127,6 @@ public class AuthorizationRequestUrlParametersTest {
         Assert.assertEquals(queryParameters.get("correlation_id"), "corr_id");
         Assert.assertEquals(queryParameters.get("login_hint"), "hint");
         Assert.assertEquals(queryParameters.get("domain_hint"), "domain_hint");
-        Assert.assertEquals(queryParameters.get("claims"), "{\"userinfo\":{\"given_name\":{\"essential\":true},\"nickname\":null,\"email\":{\"essential\":true},\"email_verified\":{\"essential\":true},\"picture\":null,\"http://example.info/claims/groups\":null},\"access_token\":{\"xms_cc\":{\"values\":[]}}}");
+        Assert.assertEquals(queryParameters.get("claims"), "{\"id_token\":{\"auth_time\":{\"essential\":true}},\"access_token\":{\"xms_cc\":{\"values\":[\"llt\",\"ssm\"]}}}");
     }
 }

--- a/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
@@ -92,8 +92,8 @@ public class AuthorizationRequestUrlParametersTest {
                         .correlationId("corr_id")
                         .loginHint("hint")
                         .domainHint("domain_hint")
-                        .claims(Collections.singleton("{\"userinfo\":{\"given_name\":{\"essential\":true},\"nickname\":null,\"email\":{\"essential\":true},\"email_verified\":{\"essential\":true},\"picture\":null,\"http://example.info/claims/groups\":null}}"))
-                        .clientCapabilities(Collections.singleton("{\"access_token\":{\"xms_cc\":{\"values\":[]}}}"))
+                        .claims("{\"userinfo\":{\"given_name\":{\"essential\":true},\"nickname\":null,\"email\":{\"essential\":true},\"email_verified\":{\"essential\":true},\"picture\":null,\"http://example.info/claims/groups\":null}}")
+                        .clientCapabilities(Collections.emptySet())
                         .prompt(Prompt.SELECT_ACCOUNT)
                         .build();
 

--- a/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
@@ -97,7 +97,7 @@ public class AuthorizationRequestUrlParametersTest {
                         .correlationId("corr_id")
                         .loginHint("hint")
                         .domainHint("domain_hint")
-                        .claims("{\"id_token\":{\"auth_time\":{\"essential\":true}}}")
+                        .claims("{\"id_token\":{\"auth_time\":{\"essential\":true}},\"access_token\":{\"auth_time\":{\"essential\":true}}}")
                         .prompt(Prompt.SELECT_ACCOUNT)
                         .build();
 
@@ -127,6 +127,6 @@ public class AuthorizationRequestUrlParametersTest {
         Assert.assertEquals(queryParameters.get("correlation_id"), "corr_id");
         Assert.assertEquals(queryParameters.get("login_hint"), "hint");
         Assert.assertEquals(queryParameters.get("domain_hint"), "domain_hint");
-        Assert.assertEquals(queryParameters.get("claims"), "{\"id_token\":{\"auth_time\":{\"essential\":true}},\"access_token\":{\"xms_cc\":{\"values\":[\"llt\",\"ssm\"]}}}");
+        Assert.assertEquals(queryParameters.get("claims"), "{\"access_token\":{\"auth_time\":{\"essential\":true},\"xms_cc\":{\"values\":[\"llt\",\"ssm\"]}}}");
     }
 }


### PR DESCRIPTION
Added support for client capabilities, as per https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/197

Main functionality is to create a new parameter that can be set as part of an authorization request, and this new parameter is merged into the existing claims parameter. 

See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/1641 for a related implementation in the .NET library