### PR TITLE
Update Nimbus SDK version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>6.5</version>
+            <version>7.4</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/test/java/com/microsoft/aad/msal4j/OauthHttpRequestTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/OauthHttpRequestTest.java
@@ -37,7 +37,7 @@ public class OauthHttpRequestTest extends AbstractMsalTests {
         assertNotNull(request);
     }
 
-    @Test(expectedExceptions = IOException.class, expectedExceptionsMessageRegExp = "Couldn't parse Content-Type header: Invalid Content-Type value: In Content-Type string <invalid-content>, expected '/', got null")
+    @Test(expectedExceptions = IOException.class, expectedExceptionsMessageRegExp = "Couldn't parse Content-Type header: Invalid Content-Type value: Invalid content type string")
     public void testCreateResponseContentTypeParsingFailure() throws Exception {
 
         final OAuthHttpRequest request = new OAuthHttpRequest(


### PR DESCRIPTION
Updated Nimbus to newer version, as per https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/223, and related to https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/214

Changed the .pom file use version 7.4 of com.nimbusds.oauth2-oidc-sdk, and adjusted one test due to a change in an exception message