### PR TITLE
Enable device code flow for ADFS 2019

### DIFF
--- a/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
@@ -35,7 +35,7 @@ public class DeviceCodeIT {
     }
 
     @Test(dataProvider = "environments", dataProviderClass = EnvironmentsProvider.class)
-    public void DeviceCodeFlowTest(String environment) throws Exception {
+    public void DeviceCodeFlowADTest(String environment) throws Exception {
         cfg = new Config(environment);
 
         User user = labUserProvider.getDefaultUser(cfg.azureEnvironment);
@@ -59,22 +59,57 @@ public class DeviceCodeIT {
         Assert.assertTrue(!Strings.isNullOrEmpty(result.accessToken()));
     }
 
+    @Test(dataProvider = "environments", dataProviderClass = EnvironmentsProvider.class)
+    public void DeviceCodeFlowADFSv2019Test(String environment) throws Exception {
+        cfg = new Config(environment);
+
+        User user = labUserProvider.getOnPremAdfsUser(FederationProvider.ADFS_2019);
+
+        PublicClientApplication pca = PublicClientApplication.builder(
+                TestConstants.ADFS_APP_ID).
+                authority(TestConstants.ADFS_AUTHORITY).validateAuthority(false).
+                build();
+
+        Consumer<DeviceCode> deviceCodeConsumer = (DeviceCode deviceCode) -> {
+            runAutomatedDeviceCodeFlow(deviceCode, user);
+        };
+
+        IAuthenticationResult result = pca.acquireToken(DeviceCodeFlowParameters
+                .builder(Collections.singleton(TestConstants.ADFS_SCOPE),
+                        deviceCodeConsumer)
+                .build())
+                .get();
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(Strings.isNullOrEmpty(result.accessToken()));
+    }
+
     private void runAutomatedDeviceCodeFlow(DeviceCode deviceCode, User user){
         boolean isRunningLocally = true;//!Strings.isNullOrEmpty(
                 //System.getenv(TestConstants.LOCAL_FLAG_ENV_VAR));
+
+        boolean isADFS2019 = user.getFederationProvider().equals("adfsv2019");
 
         LOG.info("Device code running locally: " + isRunningLocally);
         try{
             String deviceCodeFormId;
             String continueButtonId;
             if(isRunningLocally){
-                deviceCodeFormId = "otc";
-                continueButtonId = "idSIButton9";
+                if (isADFS2019) {
+                    deviceCodeFormId = "userCodeInput";
+                    continueButtonId = "confirmationButton";
+                } else {
+                    deviceCodeFormId = "otc";
+                    continueButtonId = "idSIButton9";
+                }
             } else {
                 deviceCodeFormId = "code";
                 continueButtonId = "continueBtn";
             }
             LOG.info("Loggin in ... Entering device code");
+            if (isADFS2019) {
+                seleniumDriver.manage().deleteAllCookies();
+            }
             seleniumDriver.navigate().to(deviceCode.verificationUri());
             seleniumDriver.findElement(new By.ById(deviceCodeFormId)).sendKeys(deviceCode.userCode());
 
@@ -84,7 +119,11 @@ public class DeviceCodeIT {
                    new By.ById(continueButtonId));
             continueBtn.click();
 
-            SeleniumExtensions.performADLogin(seleniumDriver, user);
+            if (isADFS2019) {
+                SeleniumExtensions.performADFS2019Login(seleniumDriver, user);
+            } else {
+                SeleniumExtensions.performADLogin(seleniumDriver, user);
+            }
         } catch(Exception e){
             if(!isRunningLocally){
                 SeleniumExtensions.takeScreenShot(seleniumDriver);

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
@@ -61,7 +61,6 @@ public class DeviceCodeIT {
 
     @Test(dataProvider = "environments", dataProviderClass = EnvironmentsProvider.class)
     public void DeviceCodeFlowADFSv2019Test(String environment) throws Exception {
-        cfg = new Config(environment);
 
         User user = labUserProvider.getOnPremAdfsUser(FederationProvider.ADFS_2019);
 

--- a/src/main/java/com/microsoft/aad/msal4j/AADAuthority.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AADAuthority.java
@@ -23,8 +23,6 @@ class AADAuthority extends Authority {
     private final static String AAD_TOKEN_ENDPOINT_FORMAT = AAD_AUTHORITY_FORMAT + TOKEN_ENDPOINT;
     private final static String DEVICE_CODE_ENDPOINT_FORMAT = AAD_AUTHORITY_FORMAT + DEVICE_CODE_ENDPOINT;
 
-    String deviceCodeEndpoint;
-
     AADAuthority(final URL authorityUrl) {
         super(authorityUrl, AuthorityType.AAD);
         setAuthorityProperties();

--- a/src/main/java/com/microsoft/aad/msal4j/ADFSAuthority.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ADFSAuthority.java
@@ -9,8 +9,12 @@ class ADFSAuthority extends Authority{
 
     final static String AUTHORIZATION_ENDPOINT = "oauth2/authorize";
     final static String TOKEN_ENDPOINT = "oauth2/token";
+    final static String DEVICE_CODE_ENDPOINT = "oauth2/devicecode";
 
     private final static String ADFS_AUTHORITY_FORMAT = "https://%s/%s/";
+    private final static String DEVICE_CODE_ENDPOINT_FORMAT = ADFS_AUTHORITY_FORMAT + DEVICE_CODE_ENDPOINT;
+
+    String deviceCodeEndpoint;
 
     ADFSAuthority(final URL authorityUrl) {
         super(authorityUrl, AuthorityType.ADFS);
@@ -18,5 +22,10 @@ class ADFSAuthority extends Authority{
         this.authorizationEndpoint = authority + AUTHORIZATION_ENDPOINT;
         this.tokenEndpoint = authority + TOKEN_ENDPOINT;
         this.selfSignedJwtAudience = this.tokenEndpoint;
+        this.deviceCodeEndpoint = String.format(DEVICE_CODE_ENDPOINT_FORMAT, host, tenant);
+    }
+
+    String deviceCodeEndpoint() {
+        return deviceCodeEndpoint;
     }
 }

--- a/src/main/java/com/microsoft/aad/msal4j/ADFSAuthority.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ADFSAuthority.java
@@ -14,8 +14,6 @@ class ADFSAuthority extends Authority{
     private final static String ADFS_AUTHORITY_FORMAT = "https://%s/%s/";
     private final static String DEVICE_CODE_ENDPOINT_FORMAT = ADFS_AUTHORITY_FORMAT + DEVICE_CODE_ENDPOINT;
 
-    String deviceCodeEndpoint;
-
     ADFSAuthority(final URL authorityUrl) {
         super(authorityUrl, AuthorityType.ADFS);
         this.authority = String.format(ADFS_AUTHORITY_FORMAT, host, tenant);
@@ -25,7 +23,5 @@ class ADFSAuthority extends Authority{
         this.deviceCodeEndpoint = String.format(DEVICE_CODE_ENDPOINT_FORMAT, host, tenant);
     }
 
-    String deviceCodeEndpoint() {
-        return deviceCodeEndpoint;
-    }
+
 }

--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByDeviceCodeFlowSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByDeviceCodeFlowSupplier.java
@@ -22,12 +22,12 @@ class AcquireTokenByDeviceCodeFlowSupplier extends AuthenticationResultSupplier 
         Authority requestAuthority = clientApplication.authenticationAuthority;
         requestAuthority = getAuthorityWithPrefNetworkHost(requestAuthority.authority());
 
-        DeviceCode deviceCode = getDeviceCode((AADAuthority) requestAuthority);
+        DeviceCode deviceCode = getDeviceCode(requestAuthority);
 
         return acquireTokenWithDeviceCode(deviceCode, requestAuthority);
     }
 
-    private DeviceCode getDeviceCode(AADAuthority requestAuthority) throws Exception{
+    private DeviceCode getDeviceCode(Authority requestAuthority) throws Exception{
 
         DeviceCode deviceCode = deviceCodeFlowRequest.acquireDeviceCode(
                 requestAuthority.deviceCodeEndpoint(),

--- a/src/main/java/com/microsoft/aad/msal4j/Authority.java
+++ b/src/main/java/com/microsoft/aad/msal4j/Authority.java
@@ -36,6 +36,17 @@ abstract class Authority {
     String authorizationEndpoint;
     String tokenEndpoint;
 
+    final static String DEVICE_CODE_ENDPOINT = "oauth2/devicecode";
+
+    private final static String ADFS_AUTHORITY_FORMAT = "https://%s/%s/";
+    private final static String DEVICE_CODE_ENDPOINT_FORMAT = ADFS_AUTHORITY_FORMAT + DEVICE_CODE_ENDPOINT;
+
+    String deviceCodeEndpoint;
+
+    String deviceCodeEndpoint() {
+        return deviceCodeEndpoint;
+    }
+
     URL tokenEndpointUrl() throws MalformedURLException {
         return new URL(tokenEndpoint);
     }
@@ -49,6 +60,7 @@ abstract class Authority {
     private void setCommonAuthorityProperties() {
         this.tenant = getTenant(canonicalAuthorityUrl, authorityType);
         this.host = canonicalAuthorityUrl.getAuthority().toLowerCase();
+        this.deviceCodeEndpoint = String.format(DEVICE_CODE_ENDPOINT_FORMAT, host, tenant);
     }
 
     static Authority createAuthority(URL authorityUrl) {

--- a/src/main/java/com/microsoft/aad/msal4j/Authority.java
+++ b/src/main/java/com/microsoft/aad/msal4j/Authority.java
@@ -147,4 +147,8 @@ abstract class Authority {
     private static boolean isB2CAuthority(final String firstPath) {
         return firstPath.compareToIgnoreCase(B2C_PATH_SEGMENT) == 0;
     }
+
+    String deviceCodeEndpoint() {
+        return deviceCodeEndpoint;
+    }
 }

--- a/src/main/java/com/microsoft/aad/msal4j/Authority.java
+++ b/src/main/java/com/microsoft/aad/msal4j/Authority.java
@@ -35,9 +35,7 @@ abstract class Authority {
 
     String authorizationEndpoint;
     String tokenEndpoint;
-
-    private final static String ADFS_AUTHORITY_FORMAT = "https://%s/%s/";
-
+    
     String deviceCodeEndpoint;
 
     URL tokenEndpointUrl() throws MalformedURLException {

--- a/src/main/java/com/microsoft/aad/msal4j/Authority.java
+++ b/src/main/java/com/microsoft/aad/msal4j/Authority.java
@@ -36,16 +36,9 @@ abstract class Authority {
     String authorizationEndpoint;
     String tokenEndpoint;
 
-    final static String DEVICE_CODE_ENDPOINT = "oauth2/devicecode";
-
     private final static String ADFS_AUTHORITY_FORMAT = "https://%s/%s/";
-    private final static String DEVICE_CODE_ENDPOINT_FORMAT = ADFS_AUTHORITY_FORMAT + DEVICE_CODE_ENDPOINT;
 
     String deviceCodeEndpoint;
-
-    String deviceCodeEndpoint() {
-        return deviceCodeEndpoint;
-    }
 
     URL tokenEndpointUrl() throws MalformedURLException {
         return new URL(tokenEndpoint);
@@ -60,7 +53,6 @@ abstract class Authority {
     private void setCommonAuthorityProperties() {
         this.tenant = getTenant(canonicalAuthorityUrl, authorityType);
         this.host = canonicalAuthorityUrl.getAuthority().toLowerCase();
-        this.deviceCodeEndpoint = String.format(DEVICE_CODE_ENDPOINT_FORMAT, host, tenant);
     }
 
     static Authority createAuthority(URL authorityUrl) {

--- a/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowRequest.java
@@ -39,18 +39,12 @@ class DeviceCodeFlowRequest extends MsalRequest {
     DeviceCode acquireDeviceCode(String url,
                                  String clientId,
                                  Map<String, String> clientDataHeaders,
-                                 ServiceBundle serviceBundle) throws Exception {
+                                 ServiceBundle serviceBundle) {
 
         Map<String, String> headers = appendToHeaders(clientDataHeaders);
+        String bodyParams = createQueryParams(clientId);
 
-        String scopesParam = AbstractMsalAuthorizationGrant.COMMON_SCOPES_PARAM +
-                AbstractMsalAuthorizationGrant.SCOPES_DELIMITER + scopesStr;
-
-        Map<String, List<String>> queryParameters = new HashMap<>();
-        queryParameters.put("client_id", Collections.singletonList(clientId));
-        queryParameters.put("scope", Collections.singletonList(scopesParam));
-
-        HttpRequest httpRequest = new HttpRequest(HttpMethod.POST, url, headers, URLUtils.serializeParameters(queryParameters));
+        HttpRequest httpRequest = new HttpRequest(HttpMethod.POST, url, headers, bodyParams);
 
         final IHttpResponse response = HttpHelper.executeHttpRequest(
                 httpRequest,
@@ -64,7 +58,7 @@ class DeviceCodeFlowRequest extends MsalRequest {
         msalAuthorizationGrant = new DeviceCodeAuthorizationGrant(deviceCode, deviceCode.scopes());
     }
 
-    private String createQueryParamsAndAppendToURL(String url, String clientId) {
+    private String createQueryParams(String clientId) {
         Map<String, List<String>> queryParameters = new HashMap<>();
         queryParameters.put("client_id", Collections.singletonList(clientId));
 
@@ -73,8 +67,7 @@ class DeviceCodeFlowRequest extends MsalRequest {
 
         queryParameters.put("scope", Collections.singletonList(scopesParam));
 
-        url = url + "?" + URLUtils.serializeParameters(queryParameters);
-        return url;
+        return URLUtils.serializeParameters(queryParameters);
     }
 
     private Map<String, String> appendToHeaders(Map<String, String> clientDataHeaders) {

--- a/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowRequest.java
@@ -41,10 +41,17 @@ class DeviceCodeFlowRequest extends MsalRequest {
                                  Map<String, String> clientDataHeaders,
                                  ServiceBundle serviceBundle) throws Exception {
 
-        String urlWithQueryParams = createQueryParamsAndAppendToURL(url, clientId);
         Map<String, String> headers = appendToHeaders(clientDataHeaders);
 
-        HttpRequest httpRequest = new HttpRequest(HttpMethod.GET, urlWithQueryParams, headers);
+        String scopesParam = AbstractMsalAuthorizationGrant.COMMON_SCOPES_PARAM +
+                AbstractMsalAuthorizationGrant.SCOPES_DELIMITER + scopesStr;
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("client_id", Collections.singletonList(clientId));
+        queryParameters.put("scope", Collections.singletonList(scopesParam));
+
+        HttpRequest httpRequest = new HttpRequest(HttpMethod.POST, url, headers, URLUtils.serializeParameters(queryParameters));
+
         final IHttpResponse response = HttpHelper.executeHttpRequest(
                 httpRequest,
                 this.requestContext(),

--- a/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
+++ b/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
@@ -55,6 +55,12 @@ public class PublicClientApplication extends AbstractClientApplicationBase imple
     @Override
     public CompletableFuture<IAuthenticationResult> acquireToken(DeviceCodeFlowParameters parameters) {
 
+        if (!(AuthorityType.AAD.equals(authenticationAuthority.authorityType()) ||
+                AuthorityType.ADFS.equals(authenticationAuthority.authorityType()))) {
+            throw new IllegalArgumentException(
+                    "Invalid authority type. Device Flow is only supported by AAD and ADFS authority");
+        }
+
         validateNotNull("parameters", parameters);
 
         AtomicReference<CompletableFuture<IAuthenticationResult>> futureReference =

--- a/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
+++ b/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
@@ -58,7 +58,7 @@ public class PublicClientApplication extends AbstractClientApplicationBase imple
         if (!(AuthorityType.AAD.equals(authenticationAuthority.authorityType()) ||
                 AuthorityType.ADFS.equals(authenticationAuthority.authorityType()))) {
             throw new IllegalArgumentException(
-                    "Invalid authority type. Device Flow is only supported by AAD and ADFS authority");
+                    "Invalid authority type. Device Flow is only supported by AAD and ADFS authorities");
         }
 
         validateNotNull("parameters", parameters);

--- a/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
+++ b/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
@@ -55,11 +55,6 @@ public class PublicClientApplication extends AbstractClientApplicationBase imple
     @Override
     public CompletableFuture<IAuthenticationResult> acquireToken(DeviceCodeFlowParameters parameters) {
 
-        if (!AuthorityType.AAD.equals(authenticationAuthority.authorityType())) {
-            throw new IllegalArgumentException(
-                    "Invalid authority type. Device Flow is only supported by AAD authority");
-        }
-
         validateNotNull("parameters", parameters);
 
         AtomicReference<CompletableFuture<IAuthenticationResult>> futureReference =

--- a/src/test/java/com/microsoft/aad/msal4j/DeviceCodeFlowTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/DeviceCodeFlowTest.java
@@ -149,6 +149,21 @@ public class DeviceCodeFlowTest extends PowerMockTestCase {
         PowerMock.verify();
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "Invalid authority type. Device Flow is only supported by AAD and ADFS authority")
+    public void executeAcquireDeviceCode_B2CAuthorityUsed_IllegalArgumentExceptionThrown()
+            throws Exception {
+
+        app = PublicClientApplication.builder("client_id")
+                .b2cAuthority(TestConfiguration.B2C_AUTHORITY)
+                .validateAuthority(false).build();
+
+        app.acquireToken
+                (DeviceCodeFlowParameters
+                        .builder(Collections.singleton(AAD_RESOURCE_ID), (DeviceCode deviceCode) -> {})
+                        .build());
+    }
+
     @Test
     public void executeAcquireDeviceCode_AuthenticaionPendingErrorReturned_AuthenticationExceptionThrown()
             throws Exception {

--- a/src/test/java/com/microsoft/aad/msal4j/DeviceCodeFlowTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/DeviceCodeFlowTest.java
@@ -150,7 +150,7 @@ public class DeviceCodeFlowTest extends PowerMockTestCase {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class,
-            expectedExceptionsMessageRegExp = "Invalid authority type. Device Flow is only supported by AAD and ADFS authority")
+            expectedExceptionsMessageRegExp = "Invalid authority type. Device Flow is only supported by AAD and ADFS authorities")
     public void executeAcquireDeviceCode_B2CAuthorityUsed_IllegalArgumentExceptionThrown()
             throws Exception {
 


### PR DESCRIPTION
Allows device code flow to for ADFS users, per https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/237

- Adds device code endpoint parameter to Authority objects
- Changes device code's HTTP request from GET to POST, moves query parameters to body
- Adds integration test for device code with ADFS user, removes unit tests looking for exception in that situation