### PR TITLE
Exception Improvements

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByDeviceCodeFlowSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByDeviceCodeFlowSupplier.java
@@ -58,7 +58,7 @@ class AcquireTokenByDeviceCodeFlowSupplier extends AuthenticationResultSupplier 
             try {
                 return acquireTokenByAuthorisationGrantSupplier.execute();
             } catch (MsalServiceException ex) {
-                if (ex.errorCode().equals(AUTHORIZATION_PENDING)) {
+                if (ex.errorCode() != null && ex.errorCode().equals(AUTHORIZATION_PENDING)) {
                     TimeUnit.SECONDS.sleep(deviceCode.interval());
                 } else {
                     throw ex;

--- a/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultSupplier.java
@@ -71,11 +71,11 @@ abstract class AuthenticationResultSupplier implements Supplier<IAuthenticationR
                 String error = StringHelper.EMPTY_STRING;
                 if (ex instanceof MsalException) {
                     MsalException exception = ((MsalException) ex);
-                    if(exception.errorCode() != null){
+                    if (exception.errorCode() != null){
                         apiEvent.setApiErrorCode(exception.errorCode());
                     }
                 } else {
-                    if(ex.getCause() != null){
+                    if (ex.getCause() != null){
                         error = ex.getCause().toString();
                     }
                 }
@@ -136,7 +136,7 @@ abstract class AuthenticationResultSupplier implements Supplier<IAuthenticationR
 
          if (ex instanceof MsalClientException) {
              MsalClientException exception = (MsalClientException) ex;
-             if (exception.errorCode().equalsIgnoreCase(AuthenticationErrorCode.CACHE_MISS)) {
+             if (exception.errorCode() != null && exception.errorCode().equalsIgnoreCase(AuthenticationErrorCode.CACHE_MISS)) {
                  clientApplication.log.debug(logMessage, ex);
                  return;
              }

--- a/src/main/java/com/microsoft/aad/msal4j/TokenResponse.java
+++ b/src/main/java/com/microsoft/aad/msal4j/TokenResponse.java
@@ -96,7 +96,7 @@ class TokenResponse extends OIDCTokenResponse {
             return new TokenResponse(accessToken, refreshToken, idTokenValue, scopeValue, clientInfo,
                     expiresIn, ext_expires_in, foci);
         } catch (ParseException e) {
-            throw new MsalClientException("Invalid or null token. If using B2C, information on a potential B2C issue and workaround can be found here: https://aka.ms/msal4j-b2c-known-issues",
+            throw new MsalClientException("Invalid or missing token, could not parse. If using B2C, information on a potential B2C issue and workaround can be found here: https://aka.ms/msal4j-b2c-known-issues",
                     AuthenticationErrorCode.INVALID_JSON);
         } catch (Exception e) {
             throw new MsalClientException(e);

--- a/src/main/java/com/microsoft/aad/msal4j/TokenResponse.java
+++ b/src/main/java/com/microsoft/aad/msal4j/TokenResponse.java
@@ -57,9 +57,6 @@ class TokenResponse extends OIDCTokenResponse {
     static TokenResponse parseJsonObject(final JSONObject jsonObject)
             throws ParseException {
 
-        final AccessToken accessToken = AccessToken.parse(jsonObject);
-        final RefreshToken refreshToken = RefreshToken.parse(jsonObject);
-
         // In same cases such as client credentials there isn't an id token. Instead of a null value
         // use an empty string in order to avoid an IllegalArgumentException from OIDCTokens.
         String idTokenValue = "";
@@ -93,7 +90,16 @@ class TokenResponse extends OIDCTokenResponse {
             foci = JSONObjectUtils.getString(jsonObject, "foci");
         }
 
-        return new TokenResponse(accessToken, refreshToken,idTokenValue, scopeValue, clientInfo,
-                expiresIn, ext_expires_in, foci);
+        try {
+            final AccessToken accessToken = AccessToken.parse(jsonObject);
+            final RefreshToken refreshToken = RefreshToken.parse(jsonObject);
+            return new TokenResponse(accessToken, refreshToken, idTokenValue, scopeValue, clientInfo,
+                    expiresIn, ext_expires_in, foci);
+        } catch (ParseException e) {
+            throw new MsalClientException("Invalid or null token. If using B2C, information on a potential B2C issue and workaround can be found here: https://aka.ms/msal4j-b2c-known-issues",
+                    AuthenticationErrorCode.INVALID_JSON);
+        } catch (Exception e) {
+            throw new MsalClientException(e);
+        }
     }
 }


### PR DESCRIPTION
Fixes for two exception-related issues:
- https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/250 The errorCode field of MsalException could be null, so some references to the field needed null checks or the actual error would be overriden by a null pointer exception. 
- https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/140 There is a known issue in B2C where an access token is not always returned on a valid request, so some extra exception handling was added with a message referring to [this page](https://github.com/AzureAD/microsoft-authentication-library-for-java/wiki/Known-Issues-and-Workarounds) for the workaround