### PR TITLE
HTTPClient default timeouts

### DIFF
--- a/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
@@ -46,7 +46,7 @@ public class DeviceCodeIT {
         build();
 
         Consumer<DeviceCode> deviceCodeConsumer = (DeviceCode deviceCode) -> {
-            runAutomatedDeviceCodeFlow(deviceCode, user);
+            runAutomatedDeviceCodeFlow(deviceCode, user, environment);
         };
 
         IAuthenticationResult result = pca.acquireToken(DeviceCodeFlowParameters
@@ -70,7 +70,7 @@ public class DeviceCodeIT {
                 build();
 
         Consumer<DeviceCode> deviceCodeConsumer = (DeviceCode deviceCode) -> {
-            runAutomatedDeviceCodeFlow(deviceCode, user);
+            runAutomatedDeviceCodeFlow(deviceCode, user, environment);
         };
 
         IAuthenticationResult result = pca.acquireToken(DeviceCodeFlowParameters
@@ -83,7 +83,7 @@ public class DeviceCodeIT {
         Assert.assertFalse(Strings.isNullOrEmpty(result.accessToken()));
     }
 
-    private void runAutomatedDeviceCodeFlow(DeviceCode deviceCode, User user){
+    private void runAutomatedDeviceCodeFlow(DeviceCode deviceCode, User user, String environment){
         boolean isRunningLocally = true;//!Strings.isNullOrEmpty(
                 //System.getenv(TestConstants.LOCAL_FLAG_ENV_VAR));
 
@@ -123,6 +123,15 @@ public class DeviceCodeIT {
             } else {
                 SeleniumExtensions.performADLogin(seleniumDriver, user);
             }
+
+            if (environment.equals("azurecloud") && !isADFS2019) {
+                //Login flow for azurecloud environment has an extra "Stay signed in?" page after authentication
+                continueBtn = SeleniumExtensions.waitForElementToBeVisibleAndEnable(
+                        seleniumDriver,
+                        new By.ById(continueButtonId));
+                continueBtn.click();
+            }
+
         } catch(Exception e){
             if(!isRunningLocally){
                 SeleniumExtensions.takeScreenShot(seleniumDriver);

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
@@ -124,7 +124,7 @@ public class DeviceCodeIT {
                 SeleniumExtensions.performADLogin(seleniumDriver, user);
             }
 
-            if (environment.equals("azurecloud") && !isADFS2019) {
+            if (environment.equals(AzureEnvironment.AZURE) && !isADFS2019) {
                 //Login flow for azurecloud environment has an extra "Stay signed in?" page after authentication
                 continueBtn = SeleniumExtensions.waitForElementToBeVisibleAndEnable(
                         seleniumDriver,

--- a/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClient.java
+++ b/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClient.java
@@ -15,8 +15,8 @@ class DefaultHttpClient implements IHttpClient {
 
     private final Proxy proxy;
     private final SSLSocketFactory sslSocketFactory;
-    public int defaultConnectTimeout = 3000;
-    public int defaultReadTimeout = 5000;
+    public int DEFAULTCONNECTIONTIMEOUT = 3000;
+    public int DEFAULTREADTIMEOUT = 5000;
 
     DefaultHttpClient(Proxy proxy, SSLSocketFactory sslSocketFactory){
         this.proxy = proxy;
@@ -37,8 +37,6 @@ class DefaultHttpClient implements IHttpClient {
     private HttpResponse executeHttpGet(HttpRequest httpRequest) throws Exception {
 
         final HttpsURLConnection conn = openConnection(httpRequest.url());
-        conn.setConnectTimeout(defaultConnectTimeout);
-        conn.setReadTimeout(defaultReadTimeout);
         configureAdditionalHeaders(conn, httpRequest);
 
         return readResponseFromConnection(conn);
@@ -50,8 +48,6 @@ class DefaultHttpClient implements IHttpClient {
         configureAdditionalHeaders(conn, httpRequest);
         conn.setRequestMethod("POST");
         conn.setDoOutput(true);
-        conn.setConnectTimeout(defaultConnectTimeout);
-        conn.setReadTimeout(defaultReadTimeout);
 
         DataOutputStream wr = null;
         try {
@@ -81,6 +77,9 @@ class DefaultHttpClient implements IHttpClient {
         if (sslSocketFactory != null) {
             connection.setSSLSocketFactory(sslSocketFactory);
         }
+
+        connection.setConnectTimeout(DEFAULTCONNECTIONTIMEOUT);
+        connection.setReadTimeout(DEFAULTREADTIMEOUT);
 
         return connection;
     }

--- a/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClient.java
+++ b/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClient.java
@@ -15,6 +15,8 @@ class DefaultHttpClient implements IHttpClient {
 
     private final Proxy proxy;
     private final SSLSocketFactory sslSocketFactory;
+    public int defaultConnectTimeout = 3000;
+    public int defaultReadTimeout = 5000;
 
     DefaultHttpClient(Proxy proxy, SSLSocketFactory sslSocketFactory){
         this.proxy = proxy;
@@ -35,6 +37,8 @@ class DefaultHttpClient implements IHttpClient {
     private HttpResponse executeHttpGet(HttpRequest httpRequest) throws Exception {
 
         final HttpsURLConnection conn = openConnection(httpRequest.url());
+        conn.setConnectTimeout(defaultConnectTimeout);
+        conn.setReadTimeout(defaultReadTimeout);
         configureAdditionalHeaders(conn, httpRequest);
 
         return readResponseFromConnection(conn);
@@ -46,6 +50,8 @@ class DefaultHttpClient implements IHttpClient {
         configureAdditionalHeaders(conn, httpRequest);
         conn.setRequestMethod("POST");
         conn.setDoOutput(true);
+        conn.setConnectTimeout(defaultConnectTimeout);
+        conn.setReadTimeout(defaultReadTimeout);
 
         DataOutputStream wr = null;
         try {

--- a/src/test/java/com/microsoft/aad/msal4j/DefaultHttpClientTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/DefaultHttpClientTest.java
@@ -44,6 +44,9 @@ public class DefaultHttpClientTest extends PowerMockTestCase {
 
         EasyMock.expect(mockCon.getHeaderFields()).andReturn(expectedHeaders).times(1);
 
+        mockCon.setReadTimeout(0);
+        mockCon.setConnectTimeout(0);
+
         DefaultHttpClient httpClient =
                 PowerMock.createPartialMock(DefaultHttpClient.class, "openConnection");
 


### PR DESCRIPTION
Adds some default timeouts for the library's default HTTPClient, per https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/257

Also fixes an issue discovered in a DeviceCodeIT test: there is now a 'Stay signed in?' confirmation page in the device code flow, which caused the test to hang until the device code became invalid. An extra Selenium step was added to handle this confirmation page.