### PR TITLE
Allow support for a chained certificate / pkcs12 file off the bat

### DIFF
--- a/src/integrationtest/java/com.microsoft.aad.msal4j/ConfidentialClientApplicationUnitT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/ConfidentialClientApplicationUnitT.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.security.*;
 import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.*;
 import java.util.concurrent.Future;
 
@@ -186,7 +187,9 @@ public class ConfidentialClientApplicationUnitT extends PowerMockTestCase {
         SignedJWT jwt;
         try {
             List<Base64> certs = new ArrayList<>();
-            certs.add(new Base64(credential.publicCertificate()));
+            for (String cert: credential.publicCertificates()) {
+                certs.add(new Base64(cert));
+            }
             JWSHeader.Builder builder = new JWSHeader.Builder(JWSAlgorithm.RS256);
             builder.x509CertChain(certs);
             builder.x509CertThumbprint(new Base64URL(credential.publicCertificateHash()));

--- a/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
@@ -104,6 +104,7 @@ final class ClientCertificate implements IClientCertificate {
             String alias = aliases.nextElement();
             if (keystore.isKeyEntry(alias)) {
                 key = (PrivateKey) keystore.getKey(alias, password.toCharArray());
+                //dig down the certificate chain and put the public keys in the keystore
                 Certificate[] chain = keystore.getCertificateChain(alias);
                 for (Certificate c: chain) {
                     publicCertificates.add((X509Certificate)c);

--- a/src/main/java/com/microsoft/aad/msal4j/IClientCertificate.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IClientCertificate.java
@@ -6,6 +6,7 @@ package com.microsoft.aad.msal4j;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.CertificateEncodingException;
+import java.util.List;
 
 /**
  * Credential type containing X509 public certificate and RSA private key.
@@ -36,5 +37,5 @@ public interface IClientCertificate extends IClientCredential{
      * @return base64 encoded string
      * @throws CertificateEncodingException if an encoding error occurs
      */
-    String publicCertificate() throws CertificateEncodingException;
+    List<String> publicCertificates() throws CertificateEncodingException;
 }

--- a/src/main/java/com/microsoft/aad/msal4j/JwtHelper.java
+++ b/src/main/java/com/microsoft/aad/msal4j/JwtHelper.java
@@ -46,7 +46,9 @@ final class JwtHelper {
         SignedJWT jwt;
         try {
             List<Base64> certs = new ArrayList<>();
-            certs.add(new Base64(credential.publicCertificate()));
+            for(String publicCertificate: credential.publicCertificates()) {
+                certs.add(new Base64(publicCertificate));
+            }
 
             JWSHeader.Builder builder = new Builder(JWSAlgorithm.RS256);
             builder.x509CertChain(certs);


### PR DESCRIPTION
Trying to tackle #219 

It seems via the code that SNI is "supported by default"

https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/dev/src/main/java/com/microsoft/aad/msal4j/JwtHelper.java#L52

This goes ahead and sets multiple certificates to the x5c header and it's also already using x5t

The issue seems that when supporting a chained certificate, it's currently hardcoded to only accept one certificate and not a chain.

I'm not a Java guy and this is not pretty code and a decent amount of stackoverflow/googling

Please help critique the code so it's up to standards, but the goal of the PR is to support a list of x509 certificates instead of a single cert