### PR TITLE
Fixed parsing ClientInfo: added support for Base64URL encoding characters

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/ClientInfo.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientInfo.java
@@ -19,18 +19,19 @@ class ClientInfo {
     private String uniqueIdentifier;
 
     @JsonProperty("utid")
-    private String unqiueTenantIdentifier;
+    private String uniqueTenantIdentifier;
 
     public static ClientInfo createFromJson(String clientInfoJsonBase64Encoded){
         if(StringHelper.isBlank(clientInfoJsonBase64Encoded)){
-           return null;
+            return null;
         }
-        byte[] decodedInput =  Base64.getDecoder().decode(clientInfoJsonBase64Encoded.getBytes(StandardCharset.UTF_8));
+
+        byte[] decodedInput = Base64.getUrlDecoder().decode(clientInfoJsonBase64Encoded.getBytes(StandardCharset.UTF_8));
 
         return JsonHelper.convertJsonToObject(new String(decodedInput, StandardCharset.UTF_8), ClientInfo.class);
     }
 
     String toAccountIdentifier(){
-        return uniqueIdentifier + POINT_DELIMITER + unqiueTenantIdentifier;
+        return uniqueIdentifier + POINT_DELIMITER + uniqueTenantIdentifier;
     }
 }


### PR DESCRIPTION
Fixed parsing ClientInfo: on some accounts, the server response contained characters that are incorrect for Base64 encoding 
('_', '-'), but acceptable for Base64URL

This case was tested in our project Getapy and after the patch everything worked correctly as expected.
Otherwise our clients were getting errors like this: `java.lang.IllegalArgumentException: Illegal base64 character 2d`

Link to issue: #281 