### PR TITLE
Make IAccount serializable

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/AuthenticationResult.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthenticationResult.java
@@ -18,7 +18,7 @@ import java.util.Date;
 @Getter
 @EqualsAndHashCode
 @Builder
-final class AuthenticationResult implements Serializable, IAuthenticationResult {
+final class AuthenticationResult implements IAuthenticationResult {
     private static final long serialVersionUID = 1L;
 
     private final String accessToken;

--- a/src/main/java/com/microsoft/aad/msal4j/IAccount.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IAccount.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
+import java.io.Serializable;
 import java.util.Map;
 
 /**
@@ -10,7 +11,7 @@ import java.util.Map;
  * property, and is used as parameter in {@link SilentParameters#builder(Set, IAccount)} )}
  *
  */
-public interface IAccount {
+public interface IAccount extends Serializable {
 
     /**
      * @return account id

--- a/src/main/java/com/microsoft/aad/msal4j/ITenantProfile.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ITenantProfile.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
+import java.io.Serializable;
 import java.util.Map;
 
 /**
@@ -10,7 +11,7 @@ import java.util.Map;
  * {@link IAccount#getTenantProfiles()} method of an Account
  *
  */
-public interface ITenantProfile {
+public interface ITenantProfile extends Serializable {
 
     /**
      * A map of claims taken from an ID token. Keys and values will follow the structure of a JSON Web Token


### PR DESCRIPTION
As per discussions regarding https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/292, this change makes IAccount serializable, and removes the potential implicit serialization of IAuthenticationResult by making AuthenticationResult not serializable.