### PR TITLE
Add tenant profile/id claims to auth result

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/AuthenticationResult.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthenticationResult.java
@@ -66,6 +66,21 @@ final class AuthenticationResult implements IAuthenticationResult {
         return accountCacheEntity.toAccount();
     }
 
+    @Getter(lazy = true)
+    private final ITenantProfile tenantProfile = getTenantProfile();
+
+    private ITenantProfile getTenantProfile() {
+        if (idToken == null) {
+            return null;
+        }
+
+        try {
+            return new TenantProfile(JWTParser.parse(idToken).getJWTClaimsSet().getClaims());
+        } catch (ParseException e) {
+            throw new MsalClientException("Cached JWT could not be parsed: " + e.getMessage(), AuthenticationErrorCode.INVALID_JWT);
+        }
+    }
+
     private String environment;
 
     @Getter(lazy = true)

--- a/src/main/java/com/microsoft/aad/msal4j/IAuthenticationResult.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IAuthenticationResult.java
@@ -24,6 +24,11 @@ public interface IAuthenticationResult {
     IAccount account();
 
     /**
+     * @return claims from id token
+     */
+    ITenantProfile tenantProfile();
+
+    /**
      * @return environment
      */
     String environment();

--- a/src/main/java/com/microsoft/aad/msal4j/IAuthenticationResult.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IAuthenticationResult.java
@@ -24,7 +24,7 @@ public interface IAuthenticationResult {
     IAccount account();
 
     /**
-     * @return claims from id token
+     * @return tenant profile
      */
     ITenantProfile tenantProfile();
 


### PR DESCRIPTION
Adds the parsed claims from an ID token directly to the authentication result via the TenantProfile class, as per https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/294 and https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/296