### PR TITLE
Support for refresh_in

### DIFF
--- a/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenSilentIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenSilentIT.java
@@ -231,7 +231,6 @@ public class AcquireTokenSilentIT {
                 build();
 
         IAuthenticationResult resultOriginal = acquireTokenUsernamePassword(user, pca, cfg.graphDefaultScope());
-
         assertResultNotNull(resultOriginal);
 
         IAuthenticationResult resultSilent = acquireTokenSilently(pca, resultOriginal.account(), cfg.graphDefaultScope(), false);
@@ -253,6 +252,7 @@ public class AcquireTokenSilentIT {
         IAuthenticationResult resultSilentWithRefreshOn = acquireTokenSilently(pca, resultOriginal.account(), cfg.graphDefaultScope(), false);
         //Current time is before refreshOn, so token should not have been refreshed
         Assert.assertNotNull(resultSilentWithRefreshOn);
+        Assert.assertEquals(pca.tokenCache.accessTokens.get(key).refreshOn(), Long.toString(currTimestampSec + 60));
         assertTokensAreEqual(resultSilent, resultSilentWithRefreshOn);
 
         token = pca.tokenCache.accessTokens.get(key);

--- a/src/main/java/com/microsoft/aad/msal4j/AccessTokenCacheEntity.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AccessTokenCacheEntity.java
@@ -34,6 +34,9 @@ class AccessTokenCacheEntity extends Credential {
     @JsonProperty("extended_expires_on")
     private String extExpiresOn;
 
+    @JsonProperty("refresh_on")
+    private String refreshOn;
+
     String getKey() {
         List<String> keyParts = new ArrayList<>();
 

--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
@@ -37,6 +37,10 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
                     silentRequest.parameters().scopes(),
                     clientApplication.clientId());
 
+            if (res == null) {
+                throw new MsalClientException(AuthenticationErrorMessage.NO_TOKEN_IN_CACHE, AuthenticationErrorCode.CACHE_MISS);
+            }
+
             if (!StringHelper.isBlank(res.accessToken())) {
                 clientApplication.getServiceBundle().getServerSideTelemetry().incrementSilentSuccessfulCount();
             }

--- a/src/main/java/com/microsoft/aad/msal4j/AuthenticationResult.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthenticationResult.java
@@ -31,6 +31,8 @@ final class AuthenticationResult implements IAuthenticationResult {
 
     private final String refreshToken;
 
+    private final Long refreshOn;
+
     @Getter(value = AccessLevel.PACKAGE)
     private final String familyId;
 

--- a/src/main/java/com/microsoft/aad/msal4j/TokenCache.java
+++ b/src/main/java/com/microsoft/aad/msal4j/TokenCache.java
@@ -258,6 +258,7 @@ public class TokenCache implements ITokenCache {
         long currTimestampSec = System.currentTimeMillis() / 1000;
         at.cachedAt(Long.toString(currTimestampSec));
         at.expiresOn(Long.toString(authenticationResult.expiresOn()));
+        at.refreshOn(authenticationResult.refreshOn() > 0 ? Long.toString(authenticationResult.refreshOn()) : "0");
         if (authenticationResult.extExpiresOn() > 0) {
             at.extExpiresOn(Long.toString(authenticationResult.extExpiresOn()));
         }
@@ -555,7 +556,8 @@ public class TokenCache implements ITokenCache {
                 if (atCacheEntity.isPresent()) {
                     builder.
                             accessToken(atCacheEntity.get().secret).
-                            expiresOn(Long.parseLong(atCacheEntity.get().expiresOn()));
+                            expiresOn(Long.parseLong(atCacheEntity.get().expiresOn())).
+                            refreshOn(Long.parseLong(atCacheEntity.get().refreshOn()));
                 }
                 if (idTokenCacheEntity.isPresent()) {
                     builder.
@@ -600,7 +602,8 @@ public class TokenCache implements ITokenCache {
                 if (atCacheEntity.isPresent()) {
                     builder.
                             accessToken(atCacheEntity.get().secret).
-                            expiresOn(Long.parseLong(atCacheEntity.get().expiresOn()));
+                            expiresOn(Long.parseLong(atCacheEntity.get().expiresOn())).
+                            refreshOn(Long.parseLong(atCacheEntity.get().refreshOn()));
                 }
             } finally {
                 lock.readLock().unlock();

--- a/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -121,6 +121,7 @@ class TokenRequestExecutor {
                     environment(requestAuthority.host()).
                     expiresOn(currTimestampSec + response.getExpiresIn()).
                     extExpiresOn(response.getExtExpiresIn() > 0 ? currTimestampSec + response.getExtExpiresIn() : 0).
+                    refreshOn(response.getRefreshIn() > 0 ? currTimestampSec + response.getRefreshIn() : 0).
                     accountCacheEntity(accountCacheEntity).
                     scopes(response.getScope()).
                     build();

--- a/src/main/java/com/microsoft/aad/msal4j/TokenResponse.java
+++ b/src/main/java/com/microsoft/aad/msal4j/TokenResponse.java
@@ -22,14 +22,17 @@ class TokenResponse extends OIDCTokenResponse {
     private long expiresIn;
     private long extExpiresIn;
     private String foci;
+    private long refreshIn;
 
     TokenResponse(final AccessToken accessToken, final RefreshToken refreshToken, final String idToken,
-                  final String scope, String clientInfo, long expiresIn, long extExpiresIn, String foci) {
+                  final String scope, String clientInfo, long expiresIn, long extExpiresIn, String foci,
+                  long refreshIn) {
         super(new OIDCTokens(idToken, accessToken, refreshToken));
         this.scope = scope;
         this.clientInfo = clientInfo;
         this.expiresIn = expiresIn;
         this.extExpiresIn = extExpiresIn;
+        this.refreshIn = refreshIn;
         this.foci = foci;
     }
 
@@ -90,11 +93,16 @@ class TokenResponse extends OIDCTokenResponse {
             foci = JSONObjectUtils.getString(jsonObject, "foci");
         }
 
+        long refreshIn = 0;
+        if (jsonObject.containsKey("refresh_in")) {
+            refreshIn = getLongValue(jsonObject, "refresh_in");
+        }
+
         try {
             final AccessToken accessToken = AccessToken.parse(jsonObject);
             final RefreshToken refreshToken = RefreshToken.parse(jsonObject);
             return new TokenResponse(accessToken, refreshToken, idTokenValue, scopeValue, clientInfo,
-                    expiresIn, ext_expires_in, foci);
+                    expiresIn, ext_expires_in, foci, refreshIn);
         } catch (ParseException e) {
             throw new MsalClientException("Invalid or missing token, could not parse. If using B2C, information on a potential B2C issue and workaround can be found here: https://aka.ms/msal4j-b2c-known-issues",
                     AuthenticationErrorCode.INVALID_JSON);

--- a/src/test/java/com/microsoft/aad/msal4j/TokenResponseTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/TokenResponseTest.java
@@ -30,13 +30,14 @@ public class TokenResponseTest extends AbstractMsalTests {
             + "gWpKmnue_2Mgl3jBozTSJJ34r-R6lnWWeN6lqZ2Svw7saI5pmPtC8OZbw";
 
     private final long expiresIn = 12345678910L;
-    private final long  extExpiresIn = 12345678910L;
+    private final long extExpiresIn = 12345678910L;
+    private final long refreshIn = 0;
 
     @Test
     public void testConstructor() throws ParseException {
         final TokenResponse response = new TokenResponse(
                 new BearerAccessToken("access_token"), new RefreshToken(
-                        "refresh_token"), idToken, null, null, expiresIn, extExpiresIn, null, 0);
+                        "refresh_token"), idToken, null, null, expiresIn, extExpiresIn, null, refreshIn);
         Assert.assertNotNull(response);
         OIDCTokens tokens = response.getOIDCTokens();
         Assert.assertNotNull(tokens);
@@ -63,7 +64,7 @@ public class TokenResponseTest extends AbstractMsalTests {
         final TokenResponse response = new TokenResponse(
                 new BearerAccessToken(idToken),
                 new RefreshToken("refresh_token"),
-                "", null, null, expiresIn, extExpiresIn, null, 0);
+                "", null, null, expiresIn, extExpiresIn, null, refreshIn);
 
         Assert.assertNotNull(response);
         OIDCTokens tokens = response.getOIDCTokens();

--- a/src/test/java/com/microsoft/aad/msal4j/TokenResponseTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/TokenResponseTest.java
@@ -36,7 +36,7 @@ public class TokenResponseTest extends AbstractMsalTests {
     public void testConstructor() throws ParseException {
         final TokenResponse response = new TokenResponse(
                 new BearerAccessToken("access_token"), new RefreshToken(
-                        "refresh_token"), idToken, null, null, expiresIn, extExpiresIn, null);
+                        "refresh_token"), idToken, null, null, expiresIn, extExpiresIn, null, 0);
         Assert.assertNotNull(response);
         OIDCTokens tokens = response.getOIDCTokens();
         Assert.assertNotNull(tokens);
@@ -63,7 +63,7 @@ public class TokenResponseTest extends AbstractMsalTests {
         final TokenResponse response = new TokenResponse(
                 new BearerAccessToken(idToken),
                 new RefreshToken("refresh_token"),
-                "", null, null, expiresIn, extExpiresIn, null);
+                "", null, null, expiresIn, extExpiresIn, null, 0);
 
         Assert.assertNotNull(response);
         OIDCTokens tokens = response.getOIDCTokens();


### PR DESCRIPTION
Adds support for the optional refresh_in field of a token response, as per https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/198