### PR TITLE
Update Nimbus SDK version 8.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>7.4</version>
+            <version>8.22</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/com/microsoft/aad/msal4j/ClientAuthenticationPost.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientAuthenticationPost.java
@@ -8,12 +8,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.mail.internet.ContentType;
-
+import com.nimbusds.common.contenttype.ContentType;
 import com.nimbusds.oauth2.sdk.SerializeException;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
-import com.nimbusds.oauth2.sdk.http.CommonContentTypes;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
@@ -40,15 +38,15 @@ class ClientAuthenticationPost extends ClientAuthentication {
         if (httpRequest.getMethod() != HTTPRequest.Method.POST)
             throw new SerializeException("The HTTP request method must be POST");
 
-        ContentType ct = httpRequest.getContentType();
+        ContentType ct = httpRequest.getEntityContentType();
 
         if (ct == null)
             throw new SerializeException("Missing HTTP Content-Type header");
 
-        if (!ct.match(CommonContentTypes.APPLICATION_URLENCODED))
+        if (!ct.matches(ContentType.APPLICATION_URLENCODED))
             throw new SerializeException(
                     "The HTTP Content-Type header must be "
-                            + CommonContentTypes.APPLICATION_URLENCODED);
+                            + ContentType.APPLICATION_URLENCODED);
 
         Map<String, List<String>> params = httpRequest.getQueryParameters();
 

--- a/src/main/java/com/microsoft/aad/msal4j/OAuthHttpRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/OAuthHttpRequest.java
@@ -3,8 +3,8 @@
 
 package com.microsoft.aad.msal4j;
 
+import com.nimbusds.common.contenttype.ContentType;
 import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.http.CommonContentTypes;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import lombok.AccessLevel;
@@ -57,7 +57,7 @@ class OAuthHttpRequest extends HTTPRequest {
     private Map<String, String> configureHttpHeaders(){
 
         Map<String, String> httpHeaders = new HashMap<>(extraHeaderParams);
-        httpHeaders.put("Content-Type", CommonContentTypes.APPLICATION_URLENCODED.toString());
+        httpHeaders.put("Content-Type", ContentType.APPLICATION_URLENCODED.toString());
 
         if (this.getAuthorization() != null) {
             httpHeaders.put("Authorization", this.getAuthorization());

--- a/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -3,9 +3,9 @@
 
 package com.microsoft.aad.msal4j;
 
+import com.nimbusds.common.contenttype.ContentType;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.SerializeException;
-import com.nimbusds.oauth2.sdk.http.CommonContentTypes;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
@@ -57,7 +57,7 @@ class TokenRequestExecutor {
                 msalRequest.headers().getReadonlyHeaderMap(),
                 msalRequest.requestContext(),
                 this.serviceBundle);
-        oauthHttpRequest.setContentType(CommonContentTypes.APPLICATION_URLENCODED);
+        oauthHttpRequest.setEntityContentType(ContentType.APPLICATION_URLENCODED);
 
         final Map<String, List<String>> params = new HashMap<>(msalRequest.msalAuthorizationGrant().toParameters());
         if (msalRequest.application().clientCapabilities() != null) {

--- a/src/test/java/com/microsoft/aad/msal4j/DeviceCodeFlowTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/DeviceCodeFlowTest.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.nimbusds.oauth2.sdk.http.CommonContentTypes;
+import com.nimbusds.common.contenttype.ContentType;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
@@ -211,7 +211,7 @@ public class DeviceCodeFlowTest extends PowerMockTestCase {
                 "\"correlation_id\":\"ff60101b-cb23-4a52-82cb-9966f466327a\"}";
 
         httpResponse.setContent(content);
-        httpResponse.setContentType(CommonContentTypes.APPLICATION_JSON);
+        httpResponse.setEntityContentType(ContentType.APPLICATION_JSON);
 
         EasyMock.expect(request.createOauthHttpRequest()).andReturn(msalOAuthHttpRequest).times(1);
         EasyMock.expect(msalOAuthHttpRequest.send()).andReturn(httpResponse).times(1);

--- a/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
@@ -3,10 +3,10 @@
 
 package com.microsoft.aad.msal4j;
 
+import com.nimbusds.common.contenttype.ContentType;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.SerializeException;
 import com.nimbusds.oauth2.sdk.TokenErrorResponse;
-import com.nimbusds.oauth2.sdk.http.CommonContentTypes;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.util.JSONObjectUtils;
 import org.easymock.EasyMock;
@@ -49,7 +49,7 @@ public class TokenRequestExecutorTest extends AbstractMsalTests {
                 "\"suberror\":\"basic_action\"," +
                 "\"claims\":\"" + claims + "\"}";
         httpResponse.setContent(content);
-        httpResponse.setContentType(CommonContentTypes.APPLICATION_JSON);
+        httpResponse.setEntityContentType(ContentType.APPLICATION_JSON);
 
         EasyMock.expect(request.createOauthHttpRequest()).andReturn(msalOAuthHttpRequest).times(1);
         EasyMock.expect(msalOAuthHttpRequest.send()).andReturn(httpResponse).times(1);
@@ -88,7 +88,7 @@ public class TokenRequestExecutorTest extends AbstractMsalTests {
                 "\"suberror\":\"client_mismatch\"," +
                 "\"claims\":\"" + claims + "\"}";
         httpResponse.setContent(content);
-        httpResponse.setContentType(CommonContentTypes.APPLICATION_JSON);
+        httpResponse.setEntityContentType(ContentType.APPLICATION_JSON);
 
         EasyMock.expect(request.createOauthHttpRequest()).andReturn(msalOAuthHttpRequest).times(1);
         EasyMock.expect(msalOAuthHttpRequest.send()).andReturn(httpResponse).times(1);


### PR DESCRIPTION
Updating com.nimbusds.oauth2-oidc-sdk to version 8.22

Deprecated javax.mail package was removed in version 8. Making changes to use `com.nimbusds.common.contenttype.ContentType` instead of `com.nimbusds.oauth2.sdk.http.CommonContentTypes`

Issue for reference: https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/issues/195/deprecate-usage-of-javaxmail-package