### PR TITLE
Remove use of Nimbus Oauth2 SDK's CommonContentTypes

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/ClientAuthenticationPost.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientAuthenticationPost.java
@@ -13,7 +13,6 @@ import javax.mail.internet.ContentType;
 import com.nimbusds.oauth2.sdk.SerializeException;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
-import com.nimbusds.oauth2.sdk.http.CommonContentTypes;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
@@ -45,10 +44,10 @@ class ClientAuthenticationPost extends ClientAuthentication {
         if (ct == null)
             throw new SerializeException("Missing HTTP Content-Type header");
 
-        if (!ct.match(CommonContentTypes.APPLICATION_URLENCODED))
+        if (!ct.match(HTTPContentType.ApplicationURLEncoded.contentType))
             throw new SerializeException(
                     "The HTTP Content-Type header must be "
-                            + CommonContentTypes.APPLICATION_URLENCODED);
+                    + HTTPContentType.ApplicationURLEncoded.contentType);
 
         Map<String, List<String>> params = httpRequest.getQueryParameters();
 

--- a/src/main/java/com/microsoft/aad/msal4j/ClientAuthenticationPost.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientAuthenticationPost.java
@@ -8,8 +8,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.mail.internet.ContentType;
-
 import com.nimbusds.oauth2.sdk.SerializeException;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
@@ -39,12 +37,12 @@ class ClientAuthenticationPost extends ClientAuthentication {
         if (httpRequest.getMethod() != HTTPRequest.Method.POST)
             throw new SerializeException("The HTTP request method must be POST");
 
-        ContentType ct = httpRequest.getContentType();
+        String ct = String.valueOf(httpRequest.getEntityContentType());
 
         if (ct == null)
             throw new SerializeException("Missing HTTP Content-Type header");
 
-        if (!ct.match(HTTPContentType.ApplicationURLEncoded.contentType))
+        if (!ct.equals(HTTPContentType.ApplicationURLEncoded.contentType))
             throw new SerializeException(
                     "The HTTP Content-Type header must be "
                     + HTTPContentType.ApplicationURLEncoded.contentType);

--- a/src/main/java/com/microsoft/aad/msal4j/HTTPContentType.java
+++ b/src/main/java/com/microsoft/aad/msal4j/HTTPContentType.java
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+/**
+ * Enum containing HTTP Content-Type header values
+ */
+enum HTTPContentType {
+
+    ApplicationURLEncoded("application/x-www-form-urlencoded; charset=UTF-8"),
+    ApplicationJSON("application/json; charset=UTF-8");
+
+    public final String contentType;
+
+    HTTPContentType(String contentType) {
+        this.contentType = contentType;
+    }
+}

--- a/src/main/java/com/microsoft/aad/msal4j/OAuthHttpRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/OAuthHttpRequest.java
@@ -4,7 +4,6 @@
 package com.microsoft.aad.msal4j;
 
 import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.http.CommonContentTypes;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import lombok.AccessLevel;
@@ -57,7 +56,7 @@ class OAuthHttpRequest extends HTTPRequest {
     private Map<String, String> configureHttpHeaders(){
 
         Map<String, String> httpHeaders = new HashMap<>(extraHeaderParams);
-        httpHeaders.put("Content-Type", CommonContentTypes.APPLICATION_URLENCODED.toString());
+        httpHeaders.put("Content-Type", HTTPContentType.ApplicationURLEncoded.contentType);
 
         if (this.getAuthorization() != null) {
             httpHeaders.put("Authorization", this.getAuthorization());

--- a/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -5,7 +5,6 @@ package com.microsoft.aad.msal4j;
 
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.SerializeException;
-import com.nimbusds.oauth2.sdk.http.CommonContentTypes;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
@@ -45,7 +44,7 @@ class TokenRequestExecutor {
         return createAuthenticationResultFromOauthHttpResponse(oauthHttpResponse);
     }
 
-    OAuthHttpRequest createOauthHttpRequest() throws SerializeException, MalformedURLException {
+    OAuthHttpRequest createOauthHttpRequest() throws SerializeException, MalformedURLException, ParseException {
 
         if (requestAuthority.tokenEndpointUrl() == null) {
             throw new SerializeException("The endpoint URI is not specified");
@@ -57,7 +56,7 @@ class TokenRequestExecutor {
                 msalRequest.headers().getReadonlyHeaderMap(),
                 msalRequest.requestContext(),
                 this.serviceBundle);
-        oauthHttpRequest.setContentType(CommonContentTypes.APPLICATION_URLENCODED);
+        oauthHttpRequest.setContentType(HTTPContentType.ApplicationURLEncoded.contentType);
 
         final Map<String, List<String>> params = new HashMap<>(msalRequest.msalAuthorizationGrant().toParameters());
         if (msalRequest.application().clientCapabilities() != null) {

--- a/src/test/java/com/microsoft/aad/msal4j/DeviceCodeFlowTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/DeviceCodeFlowTest.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.nimbusds.oauth2.sdk.http.CommonContentTypes;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
@@ -211,7 +210,7 @@ public class DeviceCodeFlowTest extends PowerMockTestCase {
                 "\"correlation_id\":\"ff60101b-cb23-4a52-82cb-9966f466327a\"}";
 
         httpResponse.setContent(content);
-        httpResponse.setContentType(CommonContentTypes.APPLICATION_JSON);
+        httpResponse.setContentType(HTTPContentType.ApplicationJSON.contentType);
 
         EasyMock.expect(request.createOauthHttpRequest()).andReturn(msalOAuthHttpRequest).times(1);
         EasyMock.expect(msalOAuthHttpRequest.send()).andReturn(httpResponse).times(1);

--- a/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
@@ -6,7 +6,6 @@ package com.microsoft.aad.msal4j;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.SerializeException;
 import com.nimbusds.oauth2.sdk.TokenErrorResponse;
-import com.nimbusds.oauth2.sdk.http.CommonContentTypes;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.util.JSONObjectUtils;
 import org.easymock.EasyMock;
@@ -49,7 +48,7 @@ public class TokenRequestExecutorTest extends AbstractMsalTests {
                 "\"suberror\":\"basic_action\"," +
                 "\"claims\":\"" + claims + "\"}";
         httpResponse.setContent(content);
-        httpResponse.setContentType(CommonContentTypes.APPLICATION_JSON);
+        httpResponse.setContentType(HTTPContentType.ApplicationJSON.contentType);
 
         EasyMock.expect(request.createOauthHttpRequest()).andReturn(msalOAuthHttpRequest).times(1);
         EasyMock.expect(msalOAuthHttpRequest.send()).andReturn(httpResponse).times(1);
@@ -88,7 +87,7 @@ public class TokenRequestExecutorTest extends AbstractMsalTests {
                 "\"suberror\":\"client_mismatch\"," +
                 "\"claims\":\"" + claims + "\"}";
         httpResponse.setContent(content);
-        httpResponse.setContentType(CommonContentTypes.APPLICATION_JSON);
+        httpResponse.setContentType(HTTPContentType.ApplicationJSON.contentType);
 
         EasyMock.expect(request.createOauthHttpRequest()).andReturn(msalOAuthHttpRequest).times(1);
         EasyMock.expect(msalOAuthHttpRequest.send()).andReturn(httpResponse).times(1);
@@ -154,7 +153,7 @@ public class TokenRequestExecutorTest extends AbstractMsalTests {
 
     @Test
     public void testToOAuthRequestNonEmptyCorrelationId()
-            throws MalformedURLException, SerializeException, URISyntaxException {
+            throws MalformedURLException, SerializeException, URISyntaxException, ParseException {
 
         PublicClientApplication app = PublicClientApplication.builder("id").correlationId("corr-id").build();
 
@@ -183,7 +182,7 @@ public class TokenRequestExecutorTest extends AbstractMsalTests {
     @Test
     public void testToOAuthRequestNullCorrelationId_NullClientAuth()
             throws MalformedURLException, SerializeException,
-            URISyntaxException {
+            URISyntaxException, ParseException {
 
         PublicClientApplication app = PublicClientApplication.builder("id").correlationId("corr-id").build();
 


### PR DESCRIPTION
Removes the use of a file in Nimbus's oauth2-oidc-sdk, which was deprecated and causing issues in environments which used newer versions of that dependency. However, to avoid causing issues in environments which use older versions of this dependency (i.e., ones that don't have the new version of the deprecated file), this PR just removes the file's references and replaces it with our own implementation, rather than upgrade to the latest version.

Should solve the issue in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/316, and can replace this PR https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/311.