### PR TITLE
Fix spelling mistake in Prompt.java

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/Prompt.java
+++ b/src/main/java/com/microsoft/aad/msal4j/Prompt.java
@@ -27,8 +27,16 @@ public enum Prompt {
 
     /**
      * An administrator should be prompted to consent on behalf of all users in their organization.
+     *
+     * Deprecated, instead use Prompt.ADMIN_CONSENT
      */
-    ADMING_CONSENT ("admin_consent");
+    @Deprecated
+    ADMING_CONSENT ("admin_consent"),
+
+    /**
+     * An administrator should be prompted to consent on behalf of all users in their organization.
+     */
+    ADMIN_CONSENT ("admin_consent");
 
     private String prompt;
 


### PR DESCRIPTION
ADMING_CONSENT should instead be ADMIN_CONSENT. Deprecating the old value so it can be removed next time major version is bumped. 