### PR TITLE
Add missing check when creating tenant profile

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/AuthenticationResult.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthenticationResult.java
@@ -72,7 +72,7 @@ final class AuthenticationResult implements IAuthenticationResult {
     private final ITenantProfile tenantProfile = getTenantProfile();
 
     private ITenantProfile getTenantProfile() {
-        if (idToken == null) {
+        if (StringHelper.isBlank(idToken)) {
             return null;
         }
 


### PR DESCRIPTION
Fixes a small issue discovered when investigating https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/328, now it checks if the ID token is an empty string as well as null.