### PR TITLE
Update lab API urls

### DIFF
--- a/src/integrationtest/java/labapi/LabConstants.java
+++ b/src/integrationtest/java/labapi/LabConstants.java
@@ -9,11 +9,11 @@ public class LabConstants {
     public final static String LAB_APP_ENDPOINT = "https://msidlab.com/api/App";
     public final static String LAB_LAB_ENDPOINT = "https://msidlab.com/api/Lab";
 
-    public final static String APP_ID_KEY_VAULT_SECRET = "https://msidlabs.vault.azure.net/secrets/LabVaultAppID/4032a45f48dc424d8edd445a42d25960";
-    public final static String APP_PASSWORD_KEY_VAULT_SECRET = "https://msidlabs.vault.azure.net/secrets/LabVaultAppSecret/c2be68b1f01d4861819d6afde2ec71e3";
-    public final static String USER_MSA_USERNAME_URL = "https://msidlabs.vault.azure.net/secrets/MSA-MSIDLAB4-UserName/a6df85b08cf54347a64db17fe34d9a5f";
-    public final static String USER_MSA_PASSWORD_URL= "https://msidlabs.vault.azure.net/secrets/MSA-MSIDLAB4-Password/69850200618d43cf86c5b51e4cf8a7e5";
-    public final static String OBO_APP_PASSWORD_URL = "https://msidlabs.vault.azure.net/secrets/TodoListServiceV2-OBO/c58ba97c34ca4464886943a847d1db56";
+    public final static String APP_ID_KEY_VAULT_SECRET = "https://msidlabs.vault.azure.net/secrets/LabVaultAppID";
+    public final static String APP_PASSWORD_KEY_VAULT_SECRET = "https://msidlabs.vault.azure.net/secrets/LabVaultAppSecret";
+    public final static String USER_MSA_USERNAME_URL = "https://msidlabs.vault.azure.net/secrets/MSA-MSIDLAB4-UserName";
+    public final static String USER_MSA_PASSWORD_URL= "https://msidlabs.vault.azure.net/secrets/MSA-MSIDLAB4-Password";
+    public final static String OBO_APP_PASSWORD_URL = "https://msidlabs.vault.azure.net/secrets/TodoListServiceV2-OBO";
 
     public final static String ARLINGTON_APP_ID = "cb7faed4-b8c0-49ee-b421-f5ed16894c83";
     public final static String ARLINGTON_OBO_APP_ID = "c0555d2d-02f2-4838-802e-3463422e571d";


### PR DESCRIPTION
Integration tests were failing due to a rolled over lab secret. Lab team recommended updating URLs. 