### PR TITLE
Region discovery support

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
@@ -205,6 +205,7 @@ class AadInstanceDiscoveryProvider {
             return StringHelper.EMPTY_STRING;
         } catch (Exception e) {
             //IMDS call failed, cannot find region
+            log.warn(String.format("Exception during call to local IMDS endpoint: %s", e.getMessage()));
             return StringHelper.EMPTY_STRING;
         }
     }

--- a/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
@@ -96,6 +96,10 @@ abstract class AbstractClientApplicationBase implements IClientApplicationBase {
     @Getter
     private String clientCapabilities;
 
+    @Accessors(fluent = true)
+    @Getter
+    private boolean autoDetectRegion;
+
     @Override
     public CompletableFuture<IAuthenticationResult> acquireToken(AuthorizationCodeParameters parameters) {
 
@@ -292,6 +296,7 @@ abstract class AbstractClientApplicationBase implements IClientApplicationBase {
         private ITokenCacheAccessAspect tokenCacheAccessAspect;
         private AadInstanceDiscoveryResponse aadInstanceDiscoveryResponse;
         private String clientCapabilities;
+        private boolean autoDetectRegion;
         private Integer connectTimeoutForDefaultHttpClient;
         private Integer readTimeoutForDefaultHttpClient;
 
@@ -573,6 +578,22 @@ abstract class AbstractClientApplicationBase implements IClientApplicationBase {
             return self();
         }
 
+        /**
+         * Indicates that the library should attempt to discover the Azure region the application is running in when
+         *  fetching the instance discovery metadata.
+         *
+         * If the region is found, token requests will be sent to the regional ESTS endpoint rather than the global endpoint.
+         * If region information could not be found, the library will fall back to using the global endpoint, which is also
+         *  the default behavior if this value is not set.
+         *
+         * @param val boolean (default is false)
+         * @return instance of the Builder on which method was called
+         */
+        public T autoDetectRegion(boolean val) {
+            autoDetectRegion = val;
+            return self();
+        }
+
         abstract AbstractClientApplicationBase build();
     }
 
@@ -599,6 +620,7 @@ abstract class AbstractClientApplicationBase implements IClientApplicationBase {
         tokenCache = new TokenCache(builder.tokenCacheAccessAspect);
         aadAadInstanceDiscoveryResponse = builder.aadInstanceDiscoveryResponse;
         clientCapabilities = builder.clientCapabilities;
+        autoDetectRegion = builder.autoDetectRegion;
 
         if(aadAadInstanceDiscoveryResponse != null){
             AadInstanceDiscoveryProvider.cacheInstanceDiscoveryMetadata(


### PR DESCRIPTION
Implements support for discovering Azure regions and fetching regional instance discovery metadata, as per https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/306 and [this spec](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview/pullrequest/2363?_a=files&path=%2FPinAuthToRegion%2FAAD%20SDK%20Proposal%20to%20Pin%20Auth%20to%20region.md)

