### PR TITLE
Add String-to-ClaimsRequest helper method

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/ClaimsRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClaimsRequest.java
@@ -3,10 +3,16 @@
 
 package com.microsoft.aad.msal4j;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.Iterator;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +38,16 @@ public class ClaimsRequest {
      */
     public void requestClaimInIdToken(String claim, RequestedClaimAdditionalInfo requestedClaimAdditionalInfo) {
         idTokenRequestedClaims.add(new RequestedClaim(claim, requestedClaimAdditionalInfo));
+    }
+
+    /**
+     * Inserts a claim into the list of claims to be added to the "userinfo" section of an OIDC claims request
+     *
+     * @param claim the name of the claim to be requested
+     * @param requestedClaimAdditionalInfo additional information about the claim being requested
+     */
+    protected void requestClaimInUserInfo(String claim, RequestedClaimAdditionalInfo requestedClaimAdditionalInfo) {
+        userInfoRequestedClaims.add(new RequestedClaim(claim, requestedClaimAdditionalInfo));
     }
 
     /**
@@ -70,9 +86,62 @@ public class ClaimsRequest {
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode claimsNode = mapper.createObjectNode();
 
-        for (RequestedClaim claim: claims) {
+        for (RequestedClaim claim : claims) {
             claimsNode.setAll((ObjectNode) mapper.valueToTree(claim));
         }
         return claimsNode;
+    }
+
+    /**
+     * Creates an instance of ClaimsRequest from a JSON-formatted String which follows the specification for the OIDC claims request parameter
+     *
+     * @param claims a String following JSON formatting
+     * @return a ClaimsRequest instance
+     */
+    public static ClaimsRequest formatAsClaimsRequest(String claims) {
+        try {
+            ClaimsRequest cr = new ClaimsRequest();
+
+            ObjectMapper mapper = new ObjectMapper();
+            ObjectReader reader = mapper.readerFor(new TypeReference<List<String>>() {});
+
+            JsonNode jsonClaims = mapper.readTree(claims);
+
+            addClaimsFromJsonNode(jsonClaims.get("id_token"), "id_token", cr, reader);
+            addClaimsFromJsonNode(jsonClaims.get("userinfo"), "userinfo", cr, reader);
+            addClaimsFromJsonNode(jsonClaims.get("access_token"), "access_token", cr, reader);
+
+            return cr;
+        } catch (IOException e) {
+            throw new MsalClientException("Could not convert string to ClaimsRequest: " + e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
+        }
+    }
+
+    private static void addClaimsFromJsonNode(JsonNode claims, String group, ClaimsRequest cr, ObjectReader reader) throws IOException {
+        Iterator<String> claimsIterator;
+
+        if (claims != null) {
+            claimsIterator = claims.fieldNames();
+            while (claimsIterator.hasNext()) {
+                String claim = claimsIterator.next();
+                Boolean essential = null;
+                String value = null;
+                List<String> values = null;
+                RequestedClaimAdditionalInfo claimInfo = null;
+
+                if (claims.get(claim).has("essential")) essential = claims.get(claim).get("essential").asBoolean();
+                if (claims.get(claim).has("value")) value = claims.get(claim).get("value").textValue();
+                if (claims.get(claim).has("values")) values = reader.readValue(claims.get(claim).get("values"));
+
+                //'null' is a valid value for RequestedClaimAdditionalInfo, so only initialize it if one of the parameters is not null
+                if (essential != null || value != null || values != null) {
+                    claimInfo = new RequestedClaimAdditionalInfo(essential == null ? false : essential, value, values);
+                }
+
+                if (group.equals("id_token")) cr.requestClaimInIdToken(claim, claimInfo);
+                if (group.equals("userinfo")) cr.requestClaimInUserInfo(claim, claimInfo);
+                if (group.equals("access_token")) cr.requestClaimInAccessToken(claim, claimInfo);
+            }
+        }
     }
 }

--- a/src/test/java/com/microsoft/aad/msal4j/ClaimsTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/ClaimsTest.java
@@ -71,4 +71,11 @@ public class ClaimsTest {
         Assert.assertEquals(mergedClaimsAndChallenge, TestConfiguration.MERGED_CLAIMS_AND_CHALLENGE);
         Assert.assertEquals(mergedAll, TestConfiguration.MERGED_CLAIMS_CAPABILITIES_AND_CHALLENGE);
     }
+
+    @Test
+    public void testClaimsRequest_StringToClaimsRequest() {
+        ClaimsRequest cr = ClaimsRequest.formatAsClaimsRequest(TestConfiguration.CLAIMS_CHALLENGE);
+
+        Assert.assertEquals(cr.formatAsJSONString(), TestConfiguration.CLAIMS_CHALLENGE);
+    }
 }


### PR DESCRIPTION
Adds a `formatAsClaimsRequest` method to the ClaimsRequest class to help create ClaimsRequest objects from JSON-formatted Strings of [OIDC claims](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter), such as those found in a claims challenge.