### PR TITLE
Upgrade oauth2-oidc-sdk version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>7.4</version>
+            <version>8.23.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Upgrades the version of `com.nimbusds.oauth2-oidc-sdk` dependency from 7.4 to 8.23.1, resolving issues described in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/316, https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/335, and https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/342 related to the version of `oauth2-oidc-sdk` used in newer version of Spring Boot.

Confirmed using our web-app samples that this version of `oauth2-oidc-sdk` works with Spring Boot versions 2.1.0 to the latest 2.4.2 with no apparent issues (2.1.0 is the oldest version of Spring Boot that our existing samples seem to work with).
