### PR TITLE
Add default cache lookup to client credential flow

### DIFF
--- a/src/integrationtest/java/com.microsoft.aad.msal4j/ClientCredentialsIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/ClientCredentialsIT.java
@@ -60,6 +60,45 @@ public class ClientCredentialsIT {
         assertAcquireTokenCommon(clientId, credential);
     }
 
+    @Test
+    public void acquireTokenClientCredentials_DefaultCacheLookup() throws Exception{
+        AppCredentialProvider appProvider = new AppCredentialProvider(AzureEnvironment.AZURE);
+        final String clientId = appProvider.getLabVaultAppId();
+        final String password = appProvider.getLabVaultPassword();
+        IClientCredential credential = ClientCredentialFactory.createFromSecret(password);
+
+        ConfidentialClientApplication cca = ConfidentialClientApplication.builder(
+                clientId, credential).
+                authority(TestConstants.MICROSOFT_AUTHORITY).
+                build();
+
+        IAuthenticationResult result1 = cca.acquireToken(ClientCredentialParameters
+                .builder(Collections.singleton(KEYVAULT_DEFAULT_SCOPE))
+                .build())
+                .get();
+
+        Assert.assertNotNull(result1);
+        Assert.assertNotNull(result1.accessToken());
+
+        IAuthenticationResult result2 = cca.acquireToken(ClientCredentialParameters
+                .builder(Collections.singleton(KEYVAULT_DEFAULT_SCOPE))
+                .build())
+                .get();
+
+        Assert.assertEquals(result1.accessToken(), result2.accessToken());
+
+        IAuthenticationResult result3 = cca.acquireToken(ClientCredentialParameters
+                .builder(Collections.singleton(KEYVAULT_DEFAULT_SCOPE))
+                .skipCache(true)
+                .build())
+                .get();
+
+        Assert.assertNotNull(result3);
+        Assert.assertNotNull(result3.accessToken());
+        Assert.assertNotEquals(result2.accessToken(), result3.accessToken());
+    }
+
+
     private void assertAcquireTokenCommon(String clientId, IClientCredential credential) throws Exception{
         ConfidentialClientApplication cca = ConfidentialClientApplication.builder(
                 clientId, credential).

--- a/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
@@ -246,10 +246,14 @@ abstract class AbstractClientApplicationBase implements IClientApplicationBase {
                     (DeviceCodeFlowRequest) msalRequest);
         } else if (msalRequest instanceof SilentRequest) {
             supplier = new AcquireTokenSilentSupplier(this, (SilentRequest) msalRequest);
-        } else if(msalRequest instanceof  InteractiveRequest){
+        } else if(msalRequest instanceof InteractiveRequest){
             supplier = new AcquireTokenByInteractiveFlowSupplier(
                     (PublicClientApplication) this,
                     (InteractiveRequest) msalRequest);
+        } else if(msalRequest instanceof ClientCredentialRequest){
+            supplier = new AcquireTokenByClientCredentialSupplier(
+                    (ConfidentialClientApplication) this,
+                    (ClientCredentialRequest) msalRequest);
         } else {
             supplier = new AcquireTokenByAuthorizationGrantSupplier(
                     this,

--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByClientCredentialSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByClientCredentialSupplier.java
@@ -44,7 +44,7 @@ public class AcquireTokenByClientCredentialSupplier extends AuthenticationResult
             }
         }
 
-        LOG.info("SkipCache set to to true. Skipping cache lookup and attempting client credentials request");
+        LOG.info("SkipCache set to true. Skipping cache lookup and attempting client credentials request");
         return acquireTokenByClientCredential();
     }
 

--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByClientCredentialSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByClientCredentialSupplier.java
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AcquireTokenByClientCredentialSupplier extends AuthenticationResultSupplier {
+
+    private final static Logger LOG = LoggerFactory.getLogger(AcquireTokenByClientCredentialSupplier.class);
+    private ClientCredentialRequest clientCredentialRequest;
+
+    AcquireTokenByClientCredentialSupplier(ConfidentialClientApplication clientApplication,
+                                           ClientCredentialRequest clientCredentialRequest) {
+        super(clientApplication, clientCredentialRequest);
+        this.clientCredentialRequest = clientCredentialRequest;
+    }
+
+    @Override
+    AuthenticationResult execute() throws Exception {
+        if (clientCredentialRequest.parameters.skipCache() != null &&
+                !clientCredentialRequest.parameters.skipCache()) {
+            LOG.info("SkipCache set to false. Attempting cache lookup");
+            try {
+                SilentParameters parameters = SilentParameters
+                        .builder(this.clientCredentialRequest.parameters.scopes())
+                        .claims(this.clientCredentialRequest.parameters.claims())
+                        .build();
+
+                SilentRequest silentRequest = new SilentRequest(
+                        parameters,
+                        this.clientApplication,
+                        this.clientApplication.createRequestContext(PublicApi.ACQUIRE_TOKEN_SILENTLY, parameters));
+
+                AcquireTokenSilentSupplier supplier = new AcquireTokenSilentSupplier(
+                        this.clientApplication,
+                        silentRequest);
+
+                return supplier.execute();
+            } catch (MsalClientException ex) {
+                LOG.debug(String.format("Cache lookup failed: %s", ex.getMessage()));
+                return acquireTokenByClientCredential();
+            }
+        }
+
+        LOG.info("SkipCache set to to true. Skipping cache lookup and attempting client credentials request");
+        return acquireTokenByClientCredential();
+    }
+
+    private AuthenticationResult acquireTokenByClientCredential() throws Exception {
+        AcquireTokenByAuthorizationGrantSupplier supplier = new AcquireTokenByAuthorizationGrantSupplier(
+                this.clientApplication,
+                clientCredentialRequest,
+                null);
+
+        return supplier.execute();
+    }
+}

--- a/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
@@ -27,6 +27,13 @@ public class ClientCredentialParameters implements IApiParameters {
     private Set<String> scopes;
 
     /**
+     * Indicates whether the request should skip looking into the token cache. Be default it is
+     * set to false.
+     */
+    @Builder.Default
+    private Boolean skipCache = false;
+
+    /**
      * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
      */
     private ClaimsRequest claims;

--- a/src/main/java/com/microsoft/aad/msal4j/ClientCredentialRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientCredentialRequest.java
@@ -7,14 +7,16 @@ import com.nimbusds.oauth2.sdk.ClientCredentialsGrant;
 
 class ClientCredentialRequest extends MsalRequest{
 
+    ClientCredentialParameters parameters;
+
     ClientCredentialRequest(ClientCredentialParameters parameters,
                             ConfidentialClientApplication application,
                             RequestContext requestContext){
-        super(application, createMsalGrant(parameters), requestContext );
+        super(application, createMsalGrant(parameters), requestContext);
+        this.parameters = parameters;
     }
 
     private static OAuthAuthorizationGrant createMsalGrant(ClientCredentialParameters parameters){
-
         return new OAuthAuthorizationGrant(new ClientCredentialsGrant(), parameters.scopes(), parameters.claims());
     }
 }

--- a/src/main/java/com/microsoft/aad/msal4j/IConfidentialClientApplication.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IConfidentialClientApplication.java
@@ -21,7 +21,7 @@ public interface IConfidentialClientApplication extends IClientApplicationBase {
     /**
      * Acquires tokens from the authority configured in the application, for the confidential client
      * itself. It will by default attempt to get tokens from the token cache. If no tokens are found,
-     * it falls back to acquiring them via client credentials from teh STS
+     * it falls back to acquiring them via client credentials from the STS
      * @param parameters instance of {@link ClientCredentialParameters}
      * @return {@link CompletableFuture} containing an {@link IAuthenticationResult}
      */

--- a/src/main/java/com/microsoft/aad/msal4j/IConfidentialClientApplication.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IConfidentialClientApplication.java
@@ -20,7 +20,8 @@ public interface IConfidentialClientApplication extends IClientApplicationBase {
 
     /**
      * Acquires tokens from the authority configured in the application, for the confidential client
-     * itself
+     * itself. It will by default attempt to get tokens from the token cache. If no tokens are found,
+     * it falls back to acquiring them via client credentials from teh STS
      * @param parameters instance of {@link ClientCredentialParameters}
      * @return {@link CompletableFuture} containing an {@link IAuthenticationResult}
      */

--- a/src/samples/confidential-client/ClientCredentialGrant.java
+++ b/src/samples/confidential-client/ClientCredentialGrant.java
@@ -32,11 +32,11 @@ class ClientCredentialGrant {
                         .authority(AUTHORITY)
                         .build();
 
-        // Client credential requests will be default try to look for a valid token in the
-        // in-memory token cache. If found, it will return this token. If not token is found, or the
+        // Client credential requests will by default try to look for a valid token in the
+        // in-memory token cache. If found, it will return this token. If a token is not found, or the
         // token is not valid, it will fall back to acquiring a token from the AAD service. Although
-        // not recommended you can skip the cache lookup by using .skipCache(true) in
-        // ClientCredentialParameters.
+        // not recommended unless there is a reason for doing so, you can skip the cache lookup
+        // by using .skipCache(true) in ClientCredentialParameters.
         ClientCredentialParameters parameters =
                 ClientCredentialParameters
                         .builder(SCOPE)


### PR DESCRIPTION
We have noticed that the acquireTokenSilently step in client credential flow is causing confusion, as it differs from some of the other platforms, and is therefore not being used consistently. Adding this step by default, with the option to be skipped, both reduces the amount of code users have to write and the amount of request the STS service has to process. 

More details at https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview/pullrequest/1948