### PR TITLE
Add CCS routing information to headers

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByClientCredentialSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByClientCredentialSupplier.java
@@ -28,10 +28,15 @@ class AcquireTokenByClientCredentialSupplier extends AuthenticationResultSupplie
                         .claims(this.clientCredentialRequest.parameters.claims())
                         .build();
 
+                RequestContext context = new RequestContext(
+                        this.clientApplication,
+                        PublicApi.ACQUIRE_TOKEN_SILENTLY,
+                        parameters);
+
                 SilentRequest silentRequest = new SilentRequest(
                         parameters,
                         this.clientApplication,
-                        this.clientApplication.createRequestContext(PublicApi.ACQUIRE_TOKEN_SILENTLY, parameters),
+                        context,
                         null);
 
                 AcquireTokenSilentSupplier supplier = new AcquireTokenSilentSupplier(

--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByOnBehalfOfSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByOnBehalfOfSupplier.java
@@ -28,10 +28,15 @@ class AcquireTokenByOnBehalfOfSupplier extends AuthenticationResultSupplier {
                         .claims(this.onBehalfOfRequest.parameters.claims())
                         .build();
 
+                RequestContext context = new RequestContext(
+                        this.clientApplication,
+                        PublicApi.ACQUIRE_TOKEN_SILENTLY,
+                        parameters);
+
                 SilentRequest silentRequest = new SilentRequest(
                         parameters,
                         this.clientApplication,
-                        this.clientApplication.createRequestContext(PublicApi.ACQUIRE_TOKEN_SILENTLY, parameters),
+                        context,
                         onBehalfOfRequest.parameters.userAssertion());
 
                 AcquireTokenSilentSupplier supplier = new AcquireTokenSilentSupplier(

--- a/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeParameters.java
@@ -7,6 +7,7 @@ import lombok.*;
 import lombok.experimental.Accessors;
 
 import java.net.URI;
+import java.util.Map;
 import java.util.Set;
 
 import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotBlank;
@@ -50,6 +51,11 @@ public class AuthorizationCodeParameters implements IApiParameters {
      * Code verifier used for PKCE. For more details, see https://tools.ietf.org/html/rfc7636
      */
     private String codeVerifier;
+
+    /**
+     * Adds additional headers to the token request
+     */
+    private Map<String, String> extraHttpHeaders;
 
     private static AuthorizationCodeParametersBuilder builder() {
 

--- a/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeParameters.java
@@ -21,7 +21,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotBlank
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class AuthorizationCodeParameters implements IApiParameters {
+public class AuthorizationCodeParameters implements IAcquireTokenParameters {
 
     /**
      * Authorization code acquired in the first step of OAuth2.0 authorization code flow. For more

--- a/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
@@ -124,6 +124,10 @@ public class AuthorizationRequestUrlParameters {
         if(builder.loginHint != null){
             this.loginHint = loginHint();
             requestParameters.put("login_hint", Collections.singletonList(builder.loginHint));
+
+            // For CCS routing
+            requestParameters.put(HttpHeaders.X_ANCHOR_MAILBOX, Collections.singletonList(
+                    String.format(HttpHeaders.X_ANCHOR_MAILBOX_UPN_FORMAT, builder.loginHint)));
         }
 
         if(builder.domainHint != null){

--- a/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
@@ -19,7 +19,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class ClientCredentialParameters implements IApiParameters {
+public class ClientCredentialParameters implements IAcquireTokenParameters {
 
     /**
      * Scopes for which the application is requesting access to.

--- a/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
@@ -6,6 +6,7 @@ package com.microsoft.aad.msal4j;
 import lombok.*;
 import lombok.experimental.Accessors;
 
+import java.util.Map;
 import java.util.Set;
 
 import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty;
@@ -37,6 +38,11 @@ public class ClientCredentialParameters implements IApiParameters {
      * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
      */
     private ClaimsRequest claims;
+
+    /**
+     * Adds additional headers to the token request
+     */
+    private Map<String, String> extraHttpHeaders;
 
     private static ClientCredentialParametersBuilder builder() {
 

--- a/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
@@ -41,27 +41,35 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
 
     @Override
     public CompletableFuture<IAuthenticationResult> acquireToken(ClientCredentialParameters parameters) {
-
         validateNotNull("parameters", parameters);
+
+        RequestContext context = new RequestContext(
+                this,
+                PublicApi.ACQUIRE_TOKEN_FOR_CLIENT,
+                parameters);
 
         ClientCredentialRequest clientCredentialRequest =
                 new ClientCredentialRequest(
                         parameters,
                         this,
-                        createRequestContext(PublicApi.ACQUIRE_TOKEN_FOR_CLIENT, parameters));
+                        context);
 
         return this.executeRequest(clientCredentialRequest);
     }
 
     @Override
     public CompletableFuture<IAuthenticationResult> acquireToken(OnBehalfOfParameters parameters) {
-
         validateNotNull("parameters", parameters);
+
+        RequestContext context = new RequestContext(
+                this,
+                PublicApi.ACQUIRE_TOKEN_ON_BEHALF_OF,
+                parameters);
 
         OnBehalfOfRequest oboRequest = new OnBehalfOfRequest(
                 parameters,
                 this,
-                createRequestContext(PublicApi.ACQUIRE_TOKEN_ON_BEHALF_OF, parameters));
+                context);
 
         return this.executeRequest(oboRequest);
     }

--- a/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowParameters.java
@@ -6,6 +6,7 @@ package com.microsoft.aad.msal4j;
 import lombok.*;
 import lombok.experimental.Accessors;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -29,11 +30,6 @@ public class DeviceCodeFlowParameters implements IApiParameters {
     private Set<String> scopes;
 
     /**
-     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
-     */
-    private ClaimsRequest claims;
-
-    /**
      * Receives the device code returned from the first step of Oauth2.0 device code flow. The
      * {@link DeviceCode#verificationUri} and the {@link DeviceCode#userCode} should be shown
      * to the end user.
@@ -42,6 +38,16 @@ public class DeviceCodeFlowParameters implements IApiParameters {
      */
     @NonNull
     private Consumer<DeviceCode> deviceCodeConsumer;
+
+    /**
+     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
+     */
+    private ClaimsRequest claims;
+
+    /**
+     * Adds additional headers to the token request
+     */
+    private Map<String, String> extraHttpHeaders;
 
     private static DeviceCodeFlowParametersBuilder builder() {
 

--- a/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowParameters.java
@@ -21,7 +21,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class DeviceCodeFlowParameters implements IApiParameters {
+public class DeviceCodeFlowParameters implements IAcquireTokenParameters {
 
     /**
      * Scopes to which the application is requesting access to.

--- a/src/main/java/com/microsoft/aad/msal4j/HttpHeaders.java
+++ b/src/main/java/com/microsoft/aad/msal4j/HttpHeaders.java
@@ -39,8 +39,8 @@ final class HttpHeaders {
 
     // Used for CCS routing
     static final String X_ANCHOR_MAILBOX = "X-AnchorMailbox";
-    private static final String X_ANCHOR_MAILBOX_OID_FORMAT = "oid:%s";
-    private static final String X_ANCHOR_MAILBOX_UPN_FORMAT = "upn:%s";
+    static final String X_ANCHOR_MAILBOX_OID_FORMAT = "oid:%s";
+    static final String X_ANCHOR_MAILBOX_UPN_FORMAT = "upn:%s";
     private String anchorMailboxHeaderValue = null;
 
     private String headerValues;

--- a/src/main/java/com/microsoft/aad/msal4j/HttpHeaders.java
+++ b/src/main/java/com/microsoft/aad/msal4j/HttpHeaders.java
@@ -10,45 +10,64 @@ import java.util.function.BiConsumer;
 
 final class HttpHeaders {
 
-    final static String PRODUCT_HEADER_NAME = "x-client-SKU";
-    final static String PRODUCT_HEADER_VALUE = "MSAL.Java";
+    static final String PRODUCT_HEADER_NAME = "x-client-SKU";
+    static final String PRODUCT_HEADER_VALUE = "MSAL.Java";
 
-    final static String PRODUCT_VERSION_HEADER_NAME = "x-client-VER";
-    final static String PRODUCT_VERSION_HEADER_VALUE = getProductVersion();
+    static final String PRODUCT_VERSION_HEADER_NAME = "x-client-VER";
+    static final String PRODUCT_VERSION_HEADER_VALUE = getProductVersion();
 
-    final static String CPU_HEADER_NAME = "x-client-CPU";
-    final static String CPU_HEADER_VALUE = System.getProperty("os.arch");
+    static final String CPU_HEADER_NAME = "x-client-CPU";
+    static final String CPU_HEADER_VALUE = System.getProperty("os.arch");
 
-    final static String OS_HEADER_NAME = "x-client-OS";
-    final static String OS_HEADER_VALUE = System.getProperty("os.name");
+    static final String OS_HEADER_NAME = "x-client-OS";
+    static final String OS_HEADER_VALUE = System.getProperty("os.name");
 
-    final static String APPLICATION_NAME_HEADER_NAME = "x-app-name";
+    static final String APPLICATION_NAME_HEADER_NAME = "x-app-name";
     private final String applicationNameHeaderValue;
 
-    final static String APPLICATION_VERSION_HEADER_NAME = "x-app-ver";
+    static final String APPLICATION_VERSION_HEADER_NAME = "x-app-ver";
     private final String applicationVersionHeaderValue;
 
-    final static String CORRELATION_ID_HEADER_NAME = "client-request-id";
+    static final String CORRELATION_ID_HEADER_NAME = "client-request-id";
     private final String correlationIdHeaderValue;
 
-    private  final static String REQUEST_CORRELATION_ID_IN_RESPONSE_HEADER_NAME = "return-client-request-id";
-    private final static String REQUEST_CORRELATION_ID_IN_RESPONSE_HEADER_VALUE = "true";
+    private static final String REQUEST_CORRELATION_ID_IN_RESPONSE_HEADER_NAME = "return-client-request-id";
+    private static final String REQUEST_CORRELATION_ID_IN_RESPONSE_HEADER_VALUE = "true";
 
-    private  final static String X_MS_LIB_CAPABILITY_NAME = "x-ms-lib-capability";
-    private final static String X_MS_LIB_CAPABILITY_VALUE = "retry-after, h429";
+    private static final String X_MS_LIB_CAPABILITY_NAME = "x-ms-lib-capability";
+    private static final String X_MS_LIB_CAPABILITY_VALUE = "retry-after, h429";
 
-    private final String headerValues;
-    private final Map<String, String> headerMap = new HashMap<>();
+    // Used for CCS routing
+    static final String X_ANCHOR_MAILBOX = "X-AnchorMailbox";
+    private static final String X_ANCHOR_MAILBOX_OID_FORMAT = "oid:%s";
+    private static final String X_ANCHOR_MAILBOX_UPN_FORMAT = "upn:%s";
+    private String anchorMailboxHeaderValue = null;
+
+    private String headerValues;
+    private Map<String, String> headerMap = new HashMap<>();
 
     HttpHeaders(final RequestContext requestContext) {
         correlationIdHeaderValue = requestContext.correlationId();
         applicationNameHeaderValue = requestContext.applicationName();
         applicationVersionHeaderValue = requestContext.applicationVersion();
 
-        this.headerValues = initHeaderMap();
+        if (requestContext.userIdentifier() != null) {
+            String upn = requestContext.userIdentifier().upn();
+            String oid = requestContext.userIdentifier().oid();
+            if (!StringHelper.isBlank(upn)) {
+                anchorMailboxHeaderValue = String.format(X_ANCHOR_MAILBOX_UPN_FORMAT, upn);
+            } else if (!StringHelper.isBlank(oid)) {
+                anchorMailboxHeaderValue = String.format(X_ANCHOR_MAILBOX_OID_FORMAT, oid);
+            }
+        }
+
+        Map<String, String> extraHttpHeaders = requestContext.apiParameters() == null ?
+                null :
+                requestContext.apiParameters().extraHttpHeaders();
+        this.initializeHeaders(extraHttpHeaders);
     }
 
-    private String initHeaderMap() {
+    private void initializeHeaders(Map<String, String> extraHttpHeaders) {
         StringBuilder sb = new StringBuilder();
 
         BiConsumer<String, String> init = (String key, String val) -> {
@@ -63,16 +82,23 @@ final class HttpHeaders {
         init.accept(REQUEST_CORRELATION_ID_IN_RESPONSE_HEADER_NAME, REQUEST_CORRELATION_ID_IN_RESPONSE_HEADER_VALUE);
         init.accept(CORRELATION_ID_HEADER_NAME, this.correlationIdHeaderValue);
 
-        if(!StringHelper.isBlank(this.applicationNameHeaderValue)){
+        if (!StringHelper.isBlank(this.applicationNameHeaderValue)) {
             init.accept(APPLICATION_NAME_HEADER_NAME, this.applicationNameHeaderValue);
         }
-        if(!StringHelper.isBlank(this.applicationVersionHeaderValue)){
+        if (!StringHelper.isBlank(this.applicationVersionHeaderValue)) {
             init.accept(APPLICATION_VERSION_HEADER_NAME, this.applicationVersionHeaderValue);
         }
+        if (!StringHelper.isBlank(this.anchorMailboxHeaderValue)) {
+            init.accept(X_ANCHOR_MAILBOX, this.anchorMailboxHeaderValue);
+        }
 
-        init.accept(X_MS_LIB_CAPABILITY_NAME, this.X_MS_LIB_CAPABILITY_VALUE);
+        init.accept(X_MS_LIB_CAPABILITY_NAME, X_MS_LIB_CAPABILITY_VALUE);
 
-        return sb.toString();
+        if (extraHttpHeaders != null) {
+            extraHttpHeaders.forEach(init);
+        }
+
+        this.headerValues = sb.toString();
     }
 
     Map<String, String> getReadonlyHeaderMap() {

--- a/src/main/java/com/microsoft/aad/msal4j/HttpHelper.java
+++ b/src/main/java/com/microsoft/aad/msal4j/HttpHelper.java
@@ -22,7 +22,7 @@ class HttpHelper {
         sb.append(requestContext.clientId() + POINT_DELIMITER);
         sb.append(requestContext.authority() + POINT_DELIMITER);
 
-        IApiParameters apiParameters = requestContext.apiParameters();
+        IAcquireTokenParameters apiParameters = requestContext.apiParameters();
 
         if (apiParameters instanceof SilentParameters) {
             IAccount account = ((SilentParameters) apiParameters).account();

--- a/src/main/java/com/microsoft/aad/msal4j/IAcquireTokenParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IAcquireTokenParameters.java
@@ -9,7 +9,7 @@ import java.util.Set;
 /**
  * Parameters shared by all acquireToken methods
  */
-interface IApiParameters {
+interface IAcquireTokenParameters {
     Set<String> scopes();
     ClaimsRequest claims();
     Map<String, String> extraHttpHeaders();

--- a/src/main/java/com/microsoft/aad/msal4j/IApiParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IApiParameters.java
@@ -3,10 +3,14 @@
 
 package com.microsoft.aad.msal4j;
 
+import java.util.Map;
 import java.util.Set;
 
+/**
+ * Parameters shared by all acquireToken methods
+ */
 interface IApiParameters {
     Set<String> scopes();
-
     ClaimsRequest claims();
+    Map<String, String> extraHttpHeaders();
 }

--- a/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthenticationParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthenticationParameters.java
@@ -6,6 +6,7 @@ package com.microsoft.aad.msal4j;
 import lombok.*;
 import lombok.experimental.Accessors;
 
+import java.util.Map;
 import java.util.Set;
 
 import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotBlank;
@@ -30,15 +31,21 @@ public class IntegratedWindowsAuthenticationParameters implements IApiParameters
     private Set<String> scopes;
 
     /**
+     * Identifier of user account for which to acquire tokens for
+     */
+    @NonNull
+    private String username;
+
+    /**
      * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
      */
     private ClaimsRequest claims;
 
     /**
-     * Identifier of user account for which to acquire tokens for
+     * Adds additional headers to the token request
      */
-    @NonNull
-    private String username;
+    private Map<String, String> extraHttpHeaders;
+
 
     private static IntegratedWindowsAuthenticationParametersBuilder builder() {
 

--- a/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthenticationParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthenticationParameters.java
@@ -22,7 +22,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class IntegratedWindowsAuthenticationParameters implements IApiParameters {
+public class IntegratedWindowsAuthenticationParameters implements IAcquireTokenParameters {
 
     /**
      * Scopes that the application is requesting access to

--- a/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 
 import java.net.URI;
+import java.util.Map;
 import java.util.Set;
 
 import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
@@ -73,6 +74,11 @@ public class InteractiveRequestParameters implements IApiParameters {
     private SystemBrowserOptions systemBrowserOptions;
 
     private String claimsChallenge;
+
+    /**
+     * Adds additional headers to the token request
+     */
+    private Map<String, String> extraHttpHeaders;
 
     /**
      * If set to true, the authorization result will contain the authority for the user's home cloud, and this authority

--- a/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
@@ -27,7 +27,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class InteractiveRequestParameters implements IApiParameters {
+public class InteractiveRequestParameters implements IAcquireTokenParameters {
 
     /**
      * Redirect URI where MSAL will listen to for the authorization code returned by Azure AD.

--- a/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfParameters.java
@@ -6,6 +6,7 @@ package com.microsoft.aad.msal4j;
 import lombok.*;
 import lombok.experimental.Accessors;
 
+import java.util.Map;
 import java.util.Set;
 
 import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty;
@@ -26,11 +27,6 @@ public class OnBehalfOfParameters implements IApiParameters {
     private Set<String> scopes;
 
     /**
-     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
-     */
-    private ClaimsRequest claims;
-
-    /**
      * Indicates whether the request should skip looking into the token cache. Be default it is
      * set to false.
      */
@@ -39,6 +35,16 @@ public class OnBehalfOfParameters implements IApiParameters {
 
     @NonNull
     private IUserAssertion userAssertion;
+
+    /**
+     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
+     */
+    private ClaimsRequest claims;
+
+    /**
+     * Adds additional headers to the token request
+     */
+    private Map<String, String> extraHttpHeaders;
 
     private static OnBehalfOfParametersBuilder builder() {
 

--- a/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfParameters.java
@@ -21,7 +21,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class OnBehalfOfParameters implements IApiParameters {
+public class OnBehalfOfParameters implements IAcquireTokenParameters {
 
     @NonNull
     private Set<String> scopes;

--- a/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
+++ b/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
@@ -17,7 +17,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
 /**
  * Class to be used to acquire tokens for public client applications (Desktop, Mobile).
  * For details see {@link IPublicClientApplication}
- * 
+ * <p>
  * Conditionally thread-safe
  */
 public class PublicClientApplication extends AbstractClientApplicationBase implements IPublicClientApplication {
@@ -29,10 +29,16 @@ public class PublicClientApplication extends AbstractClientApplicationBase imple
 
         validateNotNull("parameters", parameters);
 
+        RequestContext context = new RequestContext(
+                this,
+                PublicApi.ACQUIRE_TOKEN_BY_USERNAME_PASSWORD,
+                parameters,
+                UserIdentifier.fromUpn(parameters.username()));
+
         UserNamePasswordRequest userNamePasswordRequest =
                 new UserNamePasswordRequest(parameters,
                         this,
-                        createRequestContext(PublicApi.ACQUIRE_TOKEN_BY_USERNAME_PASSWORD, parameters));
+                        context);
 
         return this.executeRequest(userNamePasswordRequest);
     }
@@ -42,12 +48,17 @@ public class PublicClientApplication extends AbstractClientApplicationBase imple
 
         validateNotNull("parameters", parameters);
 
+        RequestContext context = new RequestContext(
+                this,
+                PublicApi.ACQUIRE_TOKEN_BY_INTEGRATED_WINDOWS_AUTH,
+                parameters,
+                UserIdentifier.fromUpn(parameters.username()));
+
         IntegratedWindowsAuthenticationRequest integratedWindowsAuthenticationRequest =
                 new IntegratedWindowsAuthenticationRequest(
                         parameters,
                         this,
-                        createRequestContext(
-                                PublicApi.ACQUIRE_TOKEN_BY_INTEGRATED_WINDOWS_AUTH, parameters));
+                        context);
 
         return this.executeRequest(integratedWindowsAuthenticationRequest);
     }
@@ -63,6 +74,11 @@ public class PublicClientApplication extends AbstractClientApplicationBase imple
 
         validateNotNull("parameters", parameters);
 
+        RequestContext context = new RequestContext(
+                this,
+                PublicApi.ACQUIRE_TOKEN_BY_DEVICE_CODE_FLOW,
+                parameters);
+
         AtomicReference<CompletableFuture<IAuthenticationResult>> futureReference =
                 new AtomicReference<>();
 
@@ -70,7 +86,7 @@ public class PublicClientApplication extends AbstractClientApplicationBase imple
                 parameters,
                 futureReference,
                 this,
-                createRequestContext(PublicApi.ACQUIRE_TOKEN_BY_DEVICE_CODE_FLOW, parameters));
+                context);
 
         CompletableFuture<IAuthenticationResult> future = executeRequest(deviceCodeRequest);
         futureReference.set(future);
@@ -78,17 +94,23 @@ public class PublicClientApplication extends AbstractClientApplicationBase imple
     }
 
     @Override
-    public CompletableFuture<IAuthenticationResult> acquireToken(InteractiveRequestParameters parameters){
+    public CompletableFuture<IAuthenticationResult> acquireToken(InteractiveRequestParameters parameters) {
 
         validateNotNull("parameters", parameters);
 
         AtomicReference<CompletableFuture<IAuthenticationResult>> futureReference = new AtomicReference<>();
 
+        RequestContext context = new RequestContext(
+                this,
+                PublicApi.ACQUIRE_TOKEN_INTERACTIVE,
+                parameters,
+                UserIdentifier.fromUpn(parameters.loginHint()));
+
         InteractiveRequest interactiveRequest = new InteractiveRequest(
                 parameters,
                 futureReference,
                 this,
-                createRequestContext(PublicApi.ACQUIRE_TOKEN_INTERACTIVE, parameters));
+                context);
 
         CompletableFuture<IAuthenticationResult> future = executeRequest(interactiveRequest);
         futureReference.set(future);

--- a/src/main/java/com/microsoft/aad/msal4j/RefreshTokenParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/RefreshTokenParameters.java
@@ -24,7 +24,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class RefreshTokenParameters implements IApiParameters {
+public class RefreshTokenParameters implements IAcquireTokenParameters {
 
     /**
      * Scopes the application is requesting access to

--- a/src/main/java/com/microsoft/aad/msal4j/RefreshTokenParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/RefreshTokenParameters.java
@@ -6,6 +6,7 @@ package com.microsoft.aad.msal4j;
 import lombok.*;
 import lombok.experimental.Accessors;
 
+import java.util.Map;
 import java.util.Set;
 
 import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotBlank;
@@ -32,15 +33,20 @@ public class RefreshTokenParameters implements IApiParameters {
     private Set<String> scopes;
 
     /**
+     * Refresh token received from the STS
+     */
+    @NonNull
+    private String refreshToken;
+
+    /**
      * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
      */
     private ClaimsRequest claims;
 
     /**
-     * Refresh token received from the STS
+     * Adds additional headers to the token request
      */
-    @NonNull
-    private String refreshToken;
+    private Map<String, String> extraHttpHeaders;
 
     private static RefreshTokenParametersBuilder builder() {
 

--- a/src/main/java/com/microsoft/aad/msal4j/RequestContext.java
+++ b/src/main/java/com/microsoft/aad/msal4j/RequestContext.java
@@ -24,6 +24,7 @@ class RequestContext {
     private String authority;
     private IApiParameters apiParameters;
     private IClientApplicationBase clientApplication;
+    private UserIdentifier userIdentifier;
 
     public RequestContext(AbstractClientApplicationBase clientApplication,
                           PublicApi publicApi,
@@ -42,6 +43,14 @@ class RequestContext {
         this.publicApi = publicApi;
         this.authority = clientApplication.authority();
         this.apiParameters = apiParameters;
+    }
+
+    public RequestContext(AbstractClientApplicationBase clientApplication,
+                          PublicApi publicApi,
+                          IApiParameters apiParameters,
+                          UserIdentifier userIdentifier) {
+        this(clientApplication, publicApi, apiParameters);
+        this.userIdentifier = userIdentifier;
     }
 
     private static String generateNewCorrelationId() {

--- a/src/main/java/com/microsoft/aad/msal4j/RequestContext.java
+++ b/src/main/java/com/microsoft/aad/msal4j/RequestContext.java
@@ -22,13 +22,13 @@ class RequestContext {
     private String applicationName;
     private String applicationVersion;
     private String authority;
-    private IApiParameters apiParameters;
+    private IAcquireTokenParameters apiParameters;
     private IClientApplicationBase clientApplication;
     private UserIdentifier userIdentifier;
 
     public RequestContext(AbstractClientApplicationBase clientApplication,
                           PublicApi publicApi,
-                          IApiParameters apiParameters) {
+                          IAcquireTokenParameters apiParameters) {
         this.clientApplication = clientApplication;
 
         this.clientId = StringHelper.isBlank(clientApplication.clientId()) ?
@@ -47,7 +47,7 @@ class RequestContext {
 
     public RequestContext(AbstractClientApplicationBase clientApplication,
                           PublicApi publicApi,
-                          IApiParameters apiParameters,
+                          IAcquireTokenParameters apiParameters,
                           UserIdentifier userIdentifier) {
         this(clientApplication, publicApi, apiParameters);
         this.userIdentifier = userIdentifier;

--- a/src/main/java/com/microsoft/aad/msal4j/SilentParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/SilentParameters.java
@@ -22,7 +22,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class SilentParameters implements IApiParameters {
+public class SilentParameters implements IAcquireTokenParameters {
 
     /**
      * Scopes application is requesting access to.

--- a/src/main/java/com/microsoft/aad/msal4j/SilentParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/SilentParameters.java
@@ -6,6 +6,7 @@ package com.microsoft.aad.msal4j;
 import lombok.*;
 import lombok.experimental.Accessors;
 
+import java.util.Map;
 import java.util.Set;
 
 import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty;
@@ -23,19 +24,36 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class SilentParameters implements IApiParameters {
 
+    /**
+     * Scopes application is requesting access to.
+     */
     @NonNull
     private Set<String> scopes;
 
+    /**
+     * Account for which you are requesting a token for.
+     */
     private IAccount account;
 
     /**
-     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
+     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims.
      */
     private ClaimsRequest claims;
 
+    /**
+     * Authority for which the application is requesting tokens from.
+     */
     private String authorityUrl;
 
+    /**
+     * Force MSAL to refresh the tokens in the cache, even if there is a valid access token.
+     */
     private boolean forceRefresh;
+
+    /**
+     * Adds additional headers to the token request
+     */
+    private Map<String, String> extraHttpHeaders;
 
     private static SilentParametersBuilder builder() {
 
@@ -60,9 +78,15 @@ public class SilentParameters implements IApiParameters {
 
     /**
      * Builder for SilentParameters
+     *
+     * @deprecated This method was used for using cached tokens in client credentials or On-behalf-of
+     * flow. Those flows will now by default attempt to use cached the cached tokens, so there is
+     * no need to call acquireTokenSilently. This overload will be removed in the next major version.
+     *
      * @param scopes scopes application is requesting access to
      * @return builder object that can be used to construct SilentParameters
      */
+    @Deprecated
     public static SilentParametersBuilder builder(Set<String> scopes) {
         validateNotEmpty("scopes", scopes);
 

--- a/src/main/java/com/microsoft/aad/msal4j/UserIdentifier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/UserIdentifier.java
@@ -38,7 +38,7 @@ public class UserIdentifier {
         if (homeAccountIdParts.length < 2
                 || StringHelper.isBlank(homeAccountIdParts[0])
                 || StringHelper.isBlank(homeAccountIdParts[1])) {
-            userIdentifier.oid = StringHelper.EMPTY_STRING;
+            userIdentifier.oid = null;
             return userIdentifier;
         }
 

--- a/src/main/java/com/microsoft/aad/msal4j/UserIdentifier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/UserIdentifier.java
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+/**
+ * Used for populating the X-AnchorMailbox header, which is used in the cached credential service
+ * (CCS) routing
+ */
+@Getter(AccessLevel.PACKAGE)
+@Accessors(fluent = true)
+public class UserIdentifier {
+
+    // Format is "userObjectId@userTenantId"
+    private static final String OID_HEADER_FORMAT = "%s@%s";
+
+    private String upn;
+    private String oid;
+
+    private UserIdentifier() {
+    }
+
+    public static UserIdentifier fromUpn(String upn) {
+        UserIdentifier userIdentifier = new UserIdentifier();
+        userIdentifier.upn = upn;
+        return userIdentifier;
+    }
+
+    public static UserIdentifier fromHomeAccountId(String homeAccountId) {
+        UserIdentifier userIdentifier = new UserIdentifier();
+
+        // HomeAccountId is userObjectId.userTenantId
+        String[] homeAccountIdParts = homeAccountId.split("\\.");
+        if (homeAccountIdParts.length < 2
+                || StringHelper.isBlank(homeAccountIdParts[0])
+                || StringHelper.isBlank(homeAccountIdParts[1])) {
+            userIdentifier.oid = StringHelper.EMPTY_STRING;
+            return userIdentifier;
+        }
+
+        userIdentifier.oid = String.format(OID_HEADER_FORMAT, homeAccountIdParts[0], homeAccountIdParts[1]);
+        return userIdentifier;
+    }
+}

--- a/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordParameters.java
@@ -6,6 +6,7 @@ package com.microsoft.aad.msal4j;
 import lombok.*;
 import lombok.experimental.Accessors;
 
+import java.util.Map;
 import java.util.Set;
 
 import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotBlank;
@@ -30,11 +31,6 @@ public class UserNamePasswordParameters implements IApiParameters {
     private Set<String> scopes;
 
     /**
-     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
-     */
-    private ClaimsRequest claims;
-
-    /**
      * Username of the account
      */
     @NonNull
@@ -45,6 +41,16 @@ public class UserNamePasswordParameters implements IApiParameters {
      */
     @NonNull
     private char[] password;
+
+    /**
+     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
+     */
+    private ClaimsRequest claims;
+
+    /**
+     * Adds additional headers to the token request
+     */
+    private Map<String, String> extraHttpHeaders;
 
     public char[] password(){
         return password.clone();

--- a/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordParameters.java
@@ -22,7 +22,7 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty
 @Accessors(fluent = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class UserNamePasswordParameters implements IApiParameters {
+public class UserNamePasswordParameters implements IAcquireTokenParameters {
 
     /**
      * Scopes application is requesting access to

--- a/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
@@ -126,5 +126,8 @@ public class AuthorizationRequestUrlParametersTest {
         Assert.assertEquals(queryParameters.get("login_hint"), "hint");
         Assert.assertEquals(queryParameters.get("domain_hint"), "domain_hint");
         Assert.assertEquals(queryParameters.get("claims"), "{\"id_token\":{\"auth_time\":{\"essential\":true}},\"access_token\":{\"auth_time\":{\"essential\":true},\"xms_cc\":{\"values\":[\"llt\",\"ssm\"]}}}");
+
+        // CCS routing
+        Assert.assertEquals(queryParameters.get(HttpHeaders.X_ANCHOR_MAILBOX), String.format(HttpHeaders.X_ANCHOR_MAILBOX_UPN_FORMAT, "hint"));
     }
 }

--- a/src/test/java/com/microsoft/aad/msal4j/HttpHeaderTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/HttpHeaderTest.java
@@ -6,13 +6,15 @@ package com.microsoft.aad.msal4j;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
-@Test(groups = { "checkin" })
+@Test(groups = {"checkin"})
 public class HttpHeaderTest {
 
     @Test
-    public void testHttpHeaderConstructor(){
+    public void testHttpHeaderConstructor() {
 
         PublicClientApplication app = PublicClientApplication
                 .builder("client-id")
@@ -21,8 +23,12 @@ public class HttpHeaderTest {
                 .applicationVersion("app-version")
                 .build();
 
+        IApiParameters parameters = UserNamePasswordParameters
+                .builder(Collections.singleton("scopes"), "username", "password".toCharArray())
+                .build();
+
         RequestContext requestContext = new RequestContext(
-                app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, null);
+                app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters);
 
         HttpHeaders httpHeaders = new HttpHeaders(requestContext);
 
@@ -38,14 +44,18 @@ public class HttpHeaderTest {
     }
 
     @Test
-    public void testHttpHeaderConstructor_valuesNotSet(){
+    public void testHttpHeaderConstructor_valuesNotSet() {
 
         PublicClientApplication app = PublicClientApplication
                 .builder("client-id")
                 .build();
 
+        IApiParameters parameters = UserNamePasswordParameters
+                .builder(Collections.singleton("scopes"), "username", "password".toCharArray())
+                .build();
+
         RequestContext requestContext = new RequestContext(
-                app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, null);
+                app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters);
 
         HttpHeaders httpHeaders = new HttpHeaders(requestContext);
 
@@ -58,5 +68,95 @@ public class HttpHeaderTest {
         Assert.assertNull(httpHeaderMap.get(HttpHeaders.APPLICATION_NAME_HEADER_NAME));
         Assert.assertNull(httpHeaderMap.get(HttpHeaders.APPLICATION_VERSION_HEADER_NAME));
         Assert.assertNotNull(httpHeaderMap.get(HttpHeaders.CORRELATION_ID_HEADER_NAME));
+    }
+
+    @Test
+    public void testHttpHeaderConstructor_userIdentifierUPN() {
+
+        PublicClientApplication app = PublicClientApplication
+                .builder("client-id")
+                .build();
+
+        IApiParameters parameters = UserNamePasswordParameters
+                .builder(Collections.singleton("scopes"), "username", "password".toCharArray())
+                .build();
+
+        String upn = "testuser@microsoft.com";
+        RequestContext requestContext = new RequestContext(
+                app,
+                PublicApi.ACQUIRE_TOKEN_BY_USERNAME_PASSWORD,
+                parameters,
+                UserIdentifier.fromUpn(upn));
+
+        HttpHeaders httpHeaders = new HttpHeaders(requestContext);
+
+        Map<String, String> httpHeaderMap = httpHeaders.getReadonlyHeaderMap();
+
+        String expectedValue = String.format("%s:%s", "upn", upn);
+        Assert.assertEquals(httpHeaderMap.get(HttpHeaders.X_ANCHOR_MAILBOX), expectedValue);
+    }
+
+    @Test
+    public void testHttpHeaderConstructor_userIdentifierHomeAccountId() {
+
+        PublicClientApplication app = PublicClientApplication
+                .builder("client-id")
+                .build();
+
+        IApiParameters parameters = UserNamePasswordParameters
+                .builder(Collections.singleton("scopes"), "username", "password".toCharArray())
+                .build();
+
+        String homeAccountId = "userObjectId.userTenantId";
+        RequestContext requestContext = new RequestContext(
+                app,
+                PublicApi.ACQUIRE_TOKEN_SILENTLY,
+                parameters,
+                UserIdentifier.fromHomeAccountId(homeAccountId));
+
+        HttpHeaders httpHeaders = new HttpHeaders(requestContext);
+
+        Map<String, String> httpHeaderMap = httpHeaders.getReadonlyHeaderMap();
+
+        Assert.assertEquals(httpHeaderMap.get(HttpHeaders.X_ANCHOR_MAILBOX), "oid:userObjectId@userTenantId");
+    }
+
+    @Test
+    public void testHttpHeaderConstructor_extraHttpHeadersOverwriteLibraryHeaders() {
+
+        PublicClientApplication app = PublicClientApplication
+                .builder("client-id")
+                .correlationId("correlation-id")
+                .applicationName("app-name")
+                .applicationVersion("app-version")
+                .build();
+
+        String uniqueHeaderKey = "uniqueHeader";
+        String uniqueHeaderValue = "uniqueValue";
+        String uniqueAppName = "my-unique-app-name";
+        Map<String, String> extraHttpHeaders = new HashMap<>();
+        extraHttpHeaders.put(uniqueHeaderKey, uniqueHeaderValue);
+        extraHttpHeaders.put(HttpHeaders.APPLICATION_NAME_HEADER_NAME, uniqueAppName);
+
+        IApiParameters parameters = UserNamePasswordParameters
+                .builder(Collections.singleton("scopes"), "username", "password".toCharArray())
+                .extraHttpHeaders(extraHttpHeaders)
+                .build();
+
+        RequestContext requestContext = new RequestContext(
+                app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters);
+
+        HttpHeaders httpHeaders = new HttpHeaders(requestContext);
+
+        Map<String, String> httpHeaderMap = httpHeaders.getReadonlyHeaderMap();
+
+        Assert.assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_HEADER_NAME), HttpHeaders.PRODUCT_HEADER_VALUE);
+        Assert.assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_VERSION_HEADER_NAME), HttpHeaders.PRODUCT_VERSION_HEADER_VALUE);
+        Assert.assertEquals(httpHeaderMap.get(HttpHeaders.OS_HEADER_NAME), HttpHeaders.OS_HEADER_VALUE);
+        Assert.assertEquals(httpHeaderMap.get(HttpHeaders.CPU_HEADER_NAME), HttpHeaders.CPU_HEADER_VALUE);
+        Assert.assertEquals(httpHeaderMap.get(HttpHeaders.APPLICATION_NAME_HEADER_NAME), uniqueAppName);
+        Assert.assertEquals(httpHeaderMap.get(uniqueHeaderKey), uniqueHeaderValue);
+        Assert.assertEquals(httpHeaderMap.get(HttpHeaders.APPLICATION_VERSION_HEADER_NAME), "app-version");
+        Assert.assertEquals(httpHeaderMap.get(HttpHeaders.CORRELATION_ID_HEADER_NAME), "correlation-id");
     }
 }

--- a/src/test/java/com/microsoft/aad/msal4j/HttpHeaderTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/HttpHeaderTest.java
@@ -23,7 +23,7 @@ public class HttpHeaderTest {
                 .applicationVersion("app-version")
                 .build();
 
-        IApiParameters parameters = UserNamePasswordParameters
+        IAcquireTokenParameters parameters = UserNamePasswordParameters
                 .builder(Collections.singleton("scopes"), "username", "password".toCharArray())
                 .build();
 
@@ -50,7 +50,7 @@ public class HttpHeaderTest {
                 .builder("client-id")
                 .build();
 
-        IApiParameters parameters = UserNamePasswordParameters
+        IAcquireTokenParameters parameters = UserNamePasswordParameters
                 .builder(Collections.singleton("scopes"), "username", "password".toCharArray())
                 .build();
 
@@ -77,7 +77,7 @@ public class HttpHeaderTest {
                 .builder("client-id")
                 .build();
 
-        IApiParameters parameters = UserNamePasswordParameters
+        IAcquireTokenParameters parameters = UserNamePasswordParameters
                 .builder(Collections.singleton("scopes"), "username", "password".toCharArray())
                 .build();
 
@@ -103,7 +103,7 @@ public class HttpHeaderTest {
                 .builder("client-id")
                 .build();
 
-        IApiParameters parameters = UserNamePasswordParameters
+        IAcquireTokenParameters parameters = UserNamePasswordParameters
                 .builder(Collections.singleton("scopes"), "username", "password".toCharArray())
                 .build();
 
@@ -138,7 +138,7 @@ public class HttpHeaderTest {
         extraHttpHeaders.put(uniqueHeaderKey, uniqueHeaderValue);
         extraHttpHeaders.put(HttpHeaders.APPLICATION_NAME_HEADER_NAME, uniqueAppName);
 
-        IApiParameters parameters = UserNamePasswordParameters
+        IAcquireTokenParameters parameters = UserNamePasswordParameters
                 .builder(Collections.singleton("scopes"), "username", "password".toCharArray())
                 .extraHttpHeaders(extraHttpHeaders)
                 .build();

--- a/src/test/java/com/microsoft/aad/msal4j/HttpHeaderTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/HttpHeaderTest.java
@@ -92,7 +92,7 @@ public class HttpHeaderTest {
 
         Map<String, String> httpHeaderMap = httpHeaders.getReadonlyHeaderMap();
 
-        String expectedValue = String.format("%s:%s", "upn", upn);
+        String expectedValue = String.format(HttpHeaders.X_ANCHOR_MAILBOX_UPN_FORMAT, upn);
         Assert.assertEquals(httpHeaderMap.get(HttpHeaders.X_ANCHOR_MAILBOX), expectedValue);
     }
 
@@ -131,11 +131,14 @@ public class HttpHeaderTest {
                 .applicationVersion("app-version")
                 .build();
 
+        // Adding extra header
         String uniqueHeaderKey = "uniqueHeader";
         String uniqueHeaderValue = "uniqueValue";
-        String uniqueAppName = "my-unique-app-name";
         Map<String, String> extraHttpHeaders = new HashMap<>();
         extraHttpHeaders.put(uniqueHeaderKey, uniqueHeaderValue);
+
+        // Overwriting standard header
+        String uniqueAppName = "my-unique-app-name";
         extraHttpHeaders.put(HttpHeaders.APPLICATION_NAME_HEADER_NAME, uniqueAppName);
 
         IAcquireTokenParameters parameters = UserNamePasswordParameters
@@ -150,13 +153,18 @@ public class HttpHeaderTest {
 
         Map<String, String> httpHeaderMap = httpHeaders.getReadonlyHeaderMap();
 
+        // Standard headers
         Assert.assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_HEADER_NAME), HttpHeaders.PRODUCT_HEADER_VALUE);
         Assert.assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_VERSION_HEADER_NAME), HttpHeaders.PRODUCT_VERSION_HEADER_VALUE);
         Assert.assertEquals(httpHeaderMap.get(HttpHeaders.OS_HEADER_NAME), HttpHeaders.OS_HEADER_VALUE);
         Assert.assertEquals(httpHeaderMap.get(HttpHeaders.CPU_HEADER_NAME), HttpHeaders.CPU_HEADER_VALUE);
-        Assert.assertEquals(httpHeaderMap.get(HttpHeaders.APPLICATION_NAME_HEADER_NAME), uniqueAppName);
-        Assert.assertEquals(httpHeaderMap.get(uniqueHeaderKey), uniqueHeaderValue);
         Assert.assertEquals(httpHeaderMap.get(HttpHeaders.APPLICATION_VERSION_HEADER_NAME), "app-version");
         Assert.assertEquals(httpHeaderMap.get(HttpHeaders.CORRELATION_ID_HEADER_NAME), "correlation-id");
+
+        // Overwritten standard header
+        Assert.assertEquals(httpHeaderMap.get(HttpHeaders.APPLICATION_NAME_HEADER_NAME), uniqueAppName);
+
+        // Extra header
+        Assert.assertEquals(httpHeaderMap.get(uniqueHeaderKey), uniqueHeaderValue);
     }
 }


### PR DESCRIPTION
- Adding CCS Routing information to headers
- Rename `IApiParameters` to `IAcquireTokenParameters`
- Adding extraHttpHeaders to `IAcquireTokenParameters` 

[CCS MSAL routing header one pager - information available in epic](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1331220)

[Design document](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview/pullrequest/3304?path=%2FCCS%20Routing%20Headers%2FCCSRoutingHeaders.md&discussionId=31233&_a=files)