### PR TITLE
Improve region support and add region telemetry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>9.4</version>
+            <version>9.7</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
@@ -100,6 +100,10 @@ abstract class AbstractClientApplicationBase implements IClientApplicationBase {
     @Getter
     private boolean autoDetectRegion;
 
+    @Accessors(fluent = true)
+    @Getter
+    private String azureRegion;
+
     @Override
     public CompletableFuture<IAuthenticationResult> acquireToken(AuthorizationCodeParameters parameters) {
 
@@ -306,6 +310,7 @@ abstract class AbstractClientApplicationBase implements IClientApplicationBase {
         private AadInstanceDiscoveryResponse aadInstanceDiscoveryResponse;
         private String clientCapabilities;
         private boolean autoDetectRegion;
+        private String azureRegion;
         private Integer connectTimeoutForDefaultHttpClient;
         private Integer readTimeoutForDefaultHttpClient;
 
@@ -603,6 +608,21 @@ abstract class AbstractClientApplicationBase implements IClientApplicationBase {
             return self();
         }
 
+        /**
+         * Indicates that the library should attempt to fetch the instance discovery metadata from the specified Azure region.
+         *
+         * If the region is valid, token requests will be sent to the regional ESTS endpoint rather than the global endpoint.
+         * If region information could not be verified, the library will fall back to using the global endpoint, which is also
+         *  the default behavior if this value is not set.
+         *
+         * @param val boolean (default is false)
+         * @return instance of the Builder on which method was called
+         */
+        public T azureRegion(String val) {
+            azureRegion = val;
+            return self();
+        }
+
         abstract AbstractClientApplicationBase build();
     }
 
@@ -630,6 +650,7 @@ abstract class AbstractClientApplicationBase implements IClientApplicationBase {
         aadAadInstanceDiscoveryResponse = builder.aadInstanceDiscoveryResponse;
         clientCapabilities = builder.clientCapabilities;
         autoDetectRegion = builder.autoDetectRegion;
+        azureRegion = builder.azureRegion;
 
         if(aadAadInstanceDiscoveryResponse != null){
             AadInstanceDiscoveryProvider.cacheInstanceDiscoveryMetadata(

--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
@@ -53,7 +53,8 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
 
             if (silentRequest.parameters().forceRefresh() || afterRefreshOn || StringHelper.isBlank(res.accessToken())) {
 
-                //Set telemetry info for reason behind the refresh
+                //As of version 3 of the telemetry schema, there is a field for collecting data about why a token was refreshed,
+                // so here we set the telemetry value based on the cause of the refresh
                 if (silentRequest.parameters().forceRefresh()) {
                     clientApplication.getServiceBundle().getServerSideTelemetry().getCurrentRequest().cacheInfo(
                             CacheTelemetry.REFRESH_FORCE_REFRESH.telemetryValue);

--- a/src/main/java/com/microsoft/aad/msal4j/CacheTelemetry.java
+++ b/src/main/java/com/microsoft/aad/msal4j/CacheTelemetry.java
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+/**
+ * Telemetry values covering the use of the cache in the library
+ */
+enum CacheTelemetry {
+    /**
+     * These values represent reasons why a token needed to be refreshed: either the flow does not use cached tokens (0),
+     * the force refresh parameter was set (1), there was no cached access token (2), the cached access token expired (3),
+     * or the cached token's refresh in time has passed (4)
+     */
+    REFRESH_CACHE_NOT_USED(0),
+    REFRESH_FORCE_REFRESH(1),
+    REFRESH_NO_ACCESS_TOKEN(2),
+    REFRESH_ACCESS_TOKEN_EXPIRED(3),
+    REFRESH_REFRESH_IN(4);
+
+    final int telemetryValue;
+
+    CacheTelemetry(int telemetryValue){
+        this.telemetryValue = telemetryValue;
+    }
+}

--- a/src/main/java/com/microsoft/aad/msal4j/CurrentRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/CurrentRequest.java
@@ -16,6 +16,15 @@ class CurrentRequest {
     @Setter
     private boolean forceRefresh = false;
 
+    @Setter
+    private String regionUsed = StringHelper.EMPTY_STRING;
+
+    @Setter
+    private int regionSource = 0;
+
+    @Setter
+    private int regionOutcome = 0;
+
     CurrentRequest(PublicApi publicApi){
         this.publicApi = publicApi;
     }

--- a/src/main/java/com/microsoft/aad/msal4j/CurrentRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/CurrentRequest.java
@@ -14,7 +14,7 @@ class CurrentRequest {
     private final PublicApi publicApi;
 
     @Setter
-    private boolean forceRefresh = false;
+    private int cacheInfo = -1;
 
     @Setter
     private String regionUsed = StringHelper.EMPTY_STRING;

--- a/src/main/java/com/microsoft/aad/msal4j/RegionTelemetry.java
+++ b/src/main/java/com/microsoft/aad/msal4j/RegionTelemetry.java
@@ -32,5 +32,4 @@ enum RegionTelemetry {
     RegionTelemetry(int telemetryValue){
         this.telemetryValue = telemetryValue;
     }
-
 }

--- a/src/main/java/com/microsoft/aad/msal4j/RegionTelemetry.java
+++ b/src/main/java/com/microsoft/aad/msal4j/RegionTelemetry.java
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+/**
+ * Telemetry values covering the use of regions in the library
+ */
+enum RegionTelemetry {
+    /**
+     * These values represent the source of the region info: either from the cache (2), environment variables (3), or the IMDS endpoint (4)
+     * One value is used for the failure cause when region autodetection was requested but a region could not be found (1)
+     */
+    REGION_SOURCE_FAILED_AUTODETECT(1),
+    REGION_SOURCE_CACHE(2),
+    REGION_SOURCE_ENV_VARIABLE(3),
+    REGION_SOURCE_IMDS(4),
+    /**
+     * These values represent the result of the attempt to find region info
+     * Three values cover cases where developer provided a region and either it matches the autodetected region (1),
+     *   autodetection failed (2), or the autodetected region does not match the developer provided region (3)
+     * Two values cover cases where developer just requested autodetection, and we either detected the region (4) or failed (5)
+     */
+    REGION_OUTCOME_DEVELOPER_AUTODETECT_MATCH(1),
+    REGION_OUTCOME_DEVELOPER_AUTODETECT_FAILED(2),
+    REGION_OUTCOME_DEVELOPER_AUTODETECT_MISMATCH(3),
+    REGION_OUTCOME_AUTODETECT_SUCCESS(4),
+    REGION_OUTCOME_AUTODETECT_FAILED(5);
+
+    final int telemetryValue;
+
+    RegionTelemetry(int telemetryValue){
+        this.telemetryValue = telemetryValue;
+    }
+
+}

--- a/src/main/java/com/microsoft/aad/msal4j/ServerSideTelemetry.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ServerSideTelemetry.java
@@ -67,7 +67,7 @@ class ServerSideTelemetry {
         String currentRequestHeader = SCHEMA_VERSION + SCHEMA_PIPE_DELIMITER +
                 currentRequest.publicApi().getApiId() +
                 SCHEMA_COMMA_DELIMITER +
-                currentRequest.forceRefresh() +
+                (currentRequest.cacheInfo() == -1 ? "" : currentRequest.cacheInfo()) +
                 SCHEMA_COMMA_DELIMITER +
                 currentRequest.regionUsed() +
                 SCHEMA_COMMA_DELIMITER +

--- a/src/main/java/com/microsoft/aad/msal4j/ServerSideTelemetry.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ServerSideTelemetry.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Array;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -17,7 +16,7 @@ class ServerSideTelemetry {
 
     private final static Logger log = LoggerFactory.getLogger(ServerSideTelemetry.class);
 
-    private final static String SCHEMA_VERSION = "2";
+    private final static String SCHEMA_VERSION = "5";
     private final static String SCHEMA_PIPE_DELIMITER = "|";
     private final static String SCHEMA_COMMA_DELIMITER = ",";
     private final static String CURRENT_REQUEST_HEADER_NAME = "x-client-current-telemetry";
@@ -69,6 +68,12 @@ class ServerSideTelemetry {
                 currentRequest.publicApi().getApiId() +
                 SCHEMA_COMMA_DELIMITER +
                 currentRequest.forceRefresh() +
+                SCHEMA_COMMA_DELIMITER +
+                currentRequest.regionUsed() +
+                SCHEMA_COMMA_DELIMITER +
+                currentRequest.regionSource() +
+                SCHEMA_COMMA_DELIMITER +
+                currentRequest.regionOutcome() +
                 SCHEMA_PIPE_DELIMITER;
 
         if (currentRequestHeader.getBytes(StandardCharsets.UTF_8).length > CURRENT_REQUEST_MAX_SIZE) {

--- a/src/main/java/com/microsoft/aad/msal4j/SilentRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/SilentRequest.java
@@ -30,7 +30,9 @@ class SilentRequest extends MsalRequest {
                 application.authenticationAuthority :
                 Authority.createAuthority(new URL(parameters.authorityUrl()));
 
-        application.getServiceBundle().getServerSideTelemetry().getCurrentRequest().forceRefresh(
-                parameters.forceRefresh());
+        if (parameters.forceRefresh()) {
+            application.getServiceBundle().getServerSideTelemetry().getCurrentRequest().cacheInfo(
+                    CacheTelemetry.REFRESH_FORCE_REFRESH.telemetryValue);
+        }
     }
 }

--- a/src/test/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryTest.java
@@ -177,7 +177,7 @@ public class AadInstanceDiscoveryTest extends PowerMockTestCase {
                 app.getServiceBundle());
 
         //Region detection will have been performed in the expected discoverRegion method, but these tests (likely) aren't
-        // being run in an Azure VM and nstance discovery will fall back to the global endpoint (login.microsoftonline.com)
+        // being run in an Azure VM and instance discovery will fall back to the global endpoint (login.microsoftonline.com)
         Assert.assertEquals(entry.preferredNetwork(), "login.microsoftonline.com");
         Assert.assertEquals(entry.preferredCache(), "login.windows.net");
         Assert.assertEquals(entry.aliases().size(), 4);

--- a/src/test/java/com/microsoft/aad/msal4j/ServerTelemetryTests.java
+++ b/src/test/java/com/microsoft/aad/msal4j/ServerTelemetryTests.java
@@ -8,6 +8,7 @@ import org.testng.annotations.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -17,7 +18,7 @@ import java.util.concurrent.Executors;
 
 public class ServerTelemetryTests {
 
-    private static final String SCHEMA_VERSION = "2";
+    private static final String SCHEMA_VERSION = "5";
     private final static String CURRENT_REQUEST_HEADER_NAME = "x-client-current-telemetry";
     private final static String LAST_REQUEST_HEADER_NAME = "x-client-last-telemetry";
 
@@ -41,7 +42,7 @@ public class ServerTelemetryTests {
         //Current request tests
         List<String> currentRequestHeader = Arrays.asList(headers.get(CURRENT_REQUEST_HEADER_NAME).split("\\|"));
 
-        // ["2", "831, false"]
+        // ["5", "831, false"]
         Assert.assertEquals(currentRequestHeader.size(), 2);
         Assert.assertEquals(currentRequestHeader.get(0), SCHEMA_VERSION);
 
@@ -54,7 +55,7 @@ public class ServerTelemetryTests {
         // Previous request test
         List<String> previousRequestHeader = Arrays.asList(headers.get(LAST_REQUEST_HEADER_NAME).split("\\|"));
 
-        // ["2","0","831,936732c6-74b9-4783-aad9-fa205eae8763","invalid_grant"]
+        // ["5","0","831,936732c6-74b9-4783-aad9-fa205eae8763","invalid_grant"]
         Assert.assertEquals(previousRequestHeader.size(), 4);
         Assert.assertEquals(previousRequestHeader.get(0), SCHEMA_VERSION);
         Assert.assertEquals(previousRequestHeader.get(1), "0");
@@ -76,7 +77,7 @@ public class ServerTelemetryTests {
 
         Map<String, String> headers = serverSideTelemetry.getServerTelemetryHeaderMap();
 
-        Assert.assertEquals(headers.get(LAST_REQUEST_HEADER_NAME), "2|3|||");
+        Assert.assertEquals(headers.get(LAST_REQUEST_HEADER_NAME), "5|3|||");
     }
 
     @Test
@@ -149,6 +150,54 @@ public class ServerTelemetryTests {
 
         Assert.assertTrue(secondRequest.get(LAST_REQUEST_HEADER_NAME).getBytes(StandardCharsets.UTF_8).length  < 350);
 
+    }
+
+    @Test
+    public void serverTelemetryHeaders_testRegionTelemetry() throws Exception{
+
+        CurrentRequest currentRequest = new CurrentRequest(PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE);
+        ServerSideTelemetry serverSideTelemetry = new ServerSideTelemetry();
+        serverSideTelemetry.setCurrentRequest(currentRequest);
+
+        Map<String, String> headers = serverSideTelemetry.getServerTelemetryHeaderMap();
+
+        Assert.assertEquals(headers.get(CURRENT_REQUEST_HEADER_NAME), "5|831,false,,0,0|");
+
+        serverSideTelemetry.getCurrentRequest().regionUsed("westus");
+        serverSideTelemetry.getCurrentRequest().regionSource(RegionTelemetry.REGION_SOURCE_IMDS.telemetryValue);
+        serverSideTelemetry.getCurrentRequest().regionOutcome(RegionTelemetry.REGION_OUTCOME_AUTODETECT_SUCCESS.telemetryValue);
+
+        headers = serverSideTelemetry.getServerTelemetryHeaderMap();
+
+        Assert.assertEquals(headers.get(CURRENT_REQUEST_HEADER_NAME), "5|831,false,westus,4,4|");
+
+        serverSideTelemetry.getCurrentRequest().regionUsed("centralus");
+        serverSideTelemetry.getCurrentRequest().regionSource(RegionTelemetry.REGION_SOURCE_ENV_VARIABLE.telemetryValue);
+        serverSideTelemetry.getCurrentRequest().regionOutcome(RegionTelemetry.REGION_OUTCOME_DEVELOPER_AUTODETECT_MISMATCH.telemetryValue);
+        headers = serverSideTelemetry.getServerTelemetryHeaderMap();
+
+        Assert.assertEquals(headers.get(CURRENT_REQUEST_HEADER_NAME), "5|831,false,centralus,3,3|");
+
+        PublicClientApplication pca = PublicClientApplication.builder(
+                "client").
+                authority(TestConstants.ORGANIZATIONS_AUTHORITY).azureRegion("westus").autoDetectRegion(true).
+                build();
+
+        try {
+            //This token call doesn't need to succeed to reach the AadInstanceDiscoveryProvider class where the region telemetry is set
+            pca.acquireToken(UserNamePasswordParameters.
+                    builder(Collections.singleton("https://graph.windows.net/.default"),
+                            "user",
+                            "password".toCharArray())
+                    .build())
+                    .get();
+
+            Assert.fail("Expected MsalException was not thrown");
+        } catch (Exception ex) {
+            headers = pca.getServiceBundle().getServerSideTelemetry().getServerTelemetryHeaderMap();
+
+            Assert.assertEquals(headers.get(CURRENT_REQUEST_HEADER_NAME), "5|300,false,,1,2|");
+        }
     }
 
     class FailedRequestRunnable implements Runnable {

--- a/src/test/java/com/microsoft/aad/msal4j/ServerTelemetryTests.java
+++ b/src/test/java/com/microsoft/aad/msal4j/ServerTelemetryTests.java
@@ -160,7 +160,7 @@ public class ServerTelemetryTests {
 
         Map<String, String> headers = serverSideTelemetry.getServerTelemetryHeaderMap();
 
-        Assert.assertEquals(headers.get(CURRENT_REQUEST_HEADER_NAME), "5|831,false,,0,0|");
+        Assert.assertEquals(headers.get(CURRENT_REQUEST_HEADER_NAME), "5|831,,,0,0|");
 
         serverSideTelemetry.getCurrentRequest().regionUsed("westus");
         serverSideTelemetry.getCurrentRequest().regionSource(RegionTelemetry.REGION_SOURCE_IMDS.telemetryValue);
@@ -168,14 +168,14 @@ public class ServerTelemetryTests {
 
         headers = serverSideTelemetry.getServerTelemetryHeaderMap();
 
-        Assert.assertEquals(headers.get(CURRENT_REQUEST_HEADER_NAME), "5|831,false,westus,4,4|");
+        Assert.assertEquals(headers.get(CURRENT_REQUEST_HEADER_NAME), "5|831,,westus,4,4|");
 
         serverSideTelemetry.getCurrentRequest().regionUsed("centralus");
         serverSideTelemetry.getCurrentRequest().regionSource(RegionTelemetry.REGION_SOURCE_ENV_VARIABLE.telemetryValue);
         serverSideTelemetry.getCurrentRequest().regionOutcome(RegionTelemetry.REGION_OUTCOME_DEVELOPER_AUTODETECT_MISMATCH.telemetryValue);
         headers = serverSideTelemetry.getServerTelemetryHeaderMap();
 
-        Assert.assertEquals(headers.get(CURRENT_REQUEST_HEADER_NAME), "5|831,false,centralus,3,3|");
+        Assert.assertEquals(headers.get(CURRENT_REQUEST_HEADER_NAME), "5|831,,centralus,3,3|");
 
         PublicClientApplication pca = PublicClientApplication.builder(
                 "client").
@@ -195,7 +195,7 @@ public class ServerTelemetryTests {
         } catch (Exception ex) {
             headers = pca.getServiceBundle().getServerSideTelemetry().getServerTelemetryHeaderMap();
 
-            Assert.assertEquals(headers.get(CURRENT_REQUEST_HEADER_NAME), "5|300,false,,1,2|");
+            Assert.assertEquals(headers.get(CURRENT_REQUEST_HEADER_NAME), "5|300,,,1,2|");
         }
     }
 

--- a/src/test/java/com/microsoft/aad/msal4j/ServerTelemetryTests.java
+++ b/src/test/java/com/microsoft/aad/msal4j/ServerTelemetryTests.java
@@ -29,7 +29,6 @@ public class ServerTelemetryTests {
     public void serverTelemetryHeaders_correctSchema(){
 
         CurrentRequest currentRequest = new CurrentRequest(PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE);
-        currentRequest.forceRefresh(false);
 
         ServerSideTelemetry serverSideTelemetry = new ServerSideTelemetry();
         serverSideTelemetry.setCurrentRequest(currentRequest);
@@ -42,14 +41,14 @@ public class ServerTelemetryTests {
         //Current request tests
         List<String> currentRequestHeader = Arrays.asList(headers.get(CURRENT_REQUEST_HEADER_NAME).split("\\|"));
 
-        // ["5", "831, false"]
+        // ["5", "831,"]
         Assert.assertEquals(currentRequestHeader.size(), 2);
         Assert.assertEquals(currentRequestHeader.get(0), SCHEMA_VERSION);
 
-        // ["831", "false"]
+        // ["831", ""]
         List<String> secondSegment = Arrays.asList(currentRequestHeader.get(1).split(","));
         Assert.assertEquals(secondSegment.get(0), String.valueOf(PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE.getApiId()));
-        Assert.assertEquals(secondSegment.get(1), "false");
+        Assert.assertEquals(secondSegment.get(1), "");
 
 
         // Previous request test


### PR DESCRIPTION
Improves support for Azure regions and updates telemetry to follow the most recent schema, as per [this region design doc](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=%2FPinAuthToRegion%2FAAD%20SDK%20Proposal%20to%20Pin%20Auth%20to%20region.md&_a=preview) and [this telemetry design doc](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview?path=%2FTelemetry%2FMSALServerSideTelemetry.md&version=GBdev&_a=preview).

Additionally, updates the oauth2-oidc-sdk dependency to fix an issue with the transitive json-smart dependency mentioned in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/394