### PR TITLE
Improve error messages

### DIFF
--- a/src/integrationtest/java/com.microsoft.aad.msal4j/OAuthRequestValidationUnitT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/OAuthRequestValidationUnitT.java
@@ -93,7 +93,7 @@ public class OAuthRequestValidationUnitT extends OAuthRequestValidationTest {
         Assert.assertEquals(CLIENT_ASSERTION_TYPE_JWT, queryParams.get("client_assertion_type"));
 
         // to do validate scopes
-        Assert.assertEquals("openid profile offline_access https://SomeResource.azure.net", queryParams.get("scope"));
+        Assert.assertEquals("https://SomeResource.azure.net openid profile offline_access" , queryParams.get("scope"));
 
         Assert.assertEquals(CLIENT_INFO_VALUE, queryParams.get("client_info"));
     }

--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByDeviceCodeFlowSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByDeviceCodeFlowSupplier.java
@@ -27,7 +27,7 @@ class AcquireTokenByDeviceCodeFlowSupplier extends AuthenticationResultSupplier 
         return acquireTokenWithDeviceCode(deviceCode, requestAuthority);
     }
 
-    private DeviceCode getDeviceCode(Authority requestAuthority) throws Exception{
+    private DeviceCode getDeviceCode(Authority requestAuthority) {
 
         DeviceCode deviceCode = deviceCodeFlowRequest.acquireDeviceCode(
                 requestAuthority.deviceCodeEndpoint(),

--- a/src/main/java/com/microsoft/aad/msal4j/AuthenticationErrorCode.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthenticationErrorCode.java
@@ -33,6 +33,16 @@ public class AuthenticationErrorCode {
     public final static String WSTRUST_ENDPOINT_NOT_FOUND_IN_METADATA_DOCUMENT = "wstrust_endpoint_not_found";
 
     /**
+     * WS-Trust endpoint response did not contain the required fields
+     */
+    public final static String WSTRUST_INVALID_RESPONSE = "wstrust_invalid_response";
+
+    /**
+     * WS-Trust request resulted in service error
+     */
+    public final static String WSTRUST_SERVICE_ERROR = "wstrust_service_error";
+
+    /**
      * Password is required for managed user. Will typically happen when trying to do integrated windows authentication
      * for managed users. For more information, see https://aka.ms/msal4j-iwa
      */

--- a/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowRequest.java
@@ -51,6 +51,10 @@ class DeviceCodeFlowRequest extends MsalRequest {
                 this.requestContext(),
                 serviceBundle);
 
+        if(response.statusCode() != HttpHelper.HTTP_STATUS_200){
+            throw MsalServiceExceptionFactory.fromHttpResponse(response);
+        }
+
         return parseJsonToDeviceCodeAndSetParameters(response.body(), headers, clientId);
     }
 

--- a/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
+++ b/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
@@ -25,9 +25,12 @@ class JsonHelper {
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }
 
-    static <T> T convertJsonToObject(final String json, final Class<T> clazz) {
+    private JsonHelper(){
+    }
+
+    static <T> T convertJsonToObject(final String json, final Class<T> tClass) {
         try {
-            return mapper.readValue(json, clazz);
+            return mapper.readValue(json, tClass);
         } catch (IOException e) {
             throw new MsalClientException(e);
         }
@@ -82,36 +85,6 @@ class JsonHelper {
         }
 
         mergeJSONNode(mainJson, addJson);
-
-        return mainJson.toString();
-    }
-
-    /**
-     * Merges set of given JSON strings into one Jackson JsonNode object, which is returned as a String
-     */
-    static String mergeJSONString(Set<String> jsonStrings) {
-        JsonNode mainJson;
-        JsonNode addJson;
-
-        Iterator<String> jsons = jsonStrings.iterator();
-        try {
-            if (jsons.hasNext()) {
-                mainJson = mapper.readTree(jsons.next());
-            } else {
-                return "";
-            }
-        } catch (IOException e) {
-            throw new MsalClientException(e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
-        }
-
-        while (jsons.hasNext()) {
-            try {
-                addJson = mapper.readTree(jsons.next());
-            } catch (IOException e) {
-                throw new MsalClientException(e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
-            }
-            mergeJSONNode(mainJson, addJson);
-        }
 
         return mainJson.toString();
     }

--- a/src/main/java/com/microsoft/aad/msal4j/MexParser.java
+++ b/src/main/java/com/microsoft/aad/msal4j/MexParser.java
@@ -186,7 +186,9 @@ class MexParser {
                             }
                         }
                         else {
-                            throw new Exception("no address nodes on port");
+                            throw new MsalClientException(
+                                    "Error parsing WSTrustResponse: No address nodes on port",
+                                    AuthenticationErrorCode.WSTRUST_INVALID_RESPONSE);
                         }
                     }
                 }

--- a/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -36,8 +36,7 @@ class TokenRequestExecutor {
         this.msalRequest = msalRequest;
     }
 
-    AuthenticationResult executeTokenRequest() throws ParseException,
-            MsalServiceException, SerializeException, IOException {
+    AuthenticationResult executeTokenRequest() throws ParseException, IOException {
 
         OAuthHttpRequest oAuthHttpRequest = createOauthHttpRequest();
         HTTPResponse oauthHttpResponse = oAuthHttpRequest.send();
@@ -135,7 +134,7 @@ class TokenRequestExecutor {
 
         } else {
             // http codes indicating that STS did not log request
-            if(oauthHttpResponse.getStatusCode() == 429 || oauthHttpResponse.getStatusCode() >= 500){
+            if(oauthHttpResponse.getStatusCode() == HttpHelper.HTTP_STATUS_429 || oauthHttpResponse.getStatusCode() >= HttpHelper.HTTP_STATUS_500){
                 serviceBundle.getServerSideTelemetry().previousRequests.putAll(
                         serviceBundle.getServerSideTelemetry().previousRequestInProgress);
             }

--- a/src/main/java/com/microsoft/aad/msal4j/UserDiscoveryRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/UserDiscoveryRequest.java
@@ -8,18 +8,19 @@ import java.util.Map;
 
 class UserDiscoveryRequest {
 
-    // private final static Logger log = LoggerFactory.getLogger(UserDiscoveryRequest.class);
-
-    private final static Map<String, String> HEADERS;
+    private static final Map<String, String> HEADERS;
 
     static {
         HEADERS = new HashMap<>();
         HEADERS.put("Accept", "application/json, text/javascript, */*");
     }
 
+    private UserDiscoveryRequest() {
+    }
+
     static UserDiscoveryResponse execute(
             final String uri,
-            final Map<String, String> clientDataHeaders,
+            Map<String, String> clientDataHeaders,
             RequestContext requestContext,
             ServiceBundle serviceBundle) {
 
@@ -29,6 +30,9 @@ class UserDiscoveryRequest {
         HttpRequest httpRequest = new HttpRequest(HttpMethod.GET, uri, headers);
         IHttpResponse response = HttpHelper.executeHttpRequest(httpRequest, requestContext, serviceBundle);
 
+        if (response.statusCode() != HttpHelper.HTTP_STATUS_200) {
+            throw MsalServiceExceptionFactory.fromHttpResponse(response);
+        }
         return JsonHelper.convertJsonToObject(response.body(), UserDiscoveryResponse.class);
     }
 }

--- a/src/main/java/com/microsoft/aad/msal4j/WSTrustRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/WSTrustRequest.java
@@ -59,6 +59,10 @@ class WSTrustRequest {
         HttpRequest httpRequest = new HttpRequest(HttpMethod.GET, url);
         IHttpResponse mexResponse = HttpHelper.executeHttpRequest(httpRequest, requestContext, serviceBundle);
 
+        if (mexResponse.statusCode() != HttpHelper.HTTP_STATUS_200 || StringHelper.isBlank(mexResponse.body())) {
+            throw MsalServiceExceptionFactory.fromHttpResponse(mexResponse);
+        }
+
         BindingPolicy policy = MexParser.getWsTrustEndpointFromMexResponse(mexResponse.body(), logPii);
 
         if(policy == null){

--- a/src/main/java/com/microsoft/aad/msal4j/WSTrustResponse.java
+++ b/src/main/java/com/microsoft/aad/msal4j/WSTrustResponse.java
@@ -26,10 +26,10 @@ import org.w3c.dom.NodeList;
 
 class WSTrustResponse {
 
-    private final static Logger log = LoggerFactory
+    private static final Logger log = LoggerFactory
             .getLogger(WSTrustResponse.class);
 
-    public final static String SAML1_ASSERTION = "urn:oasis:names:tc:SAML:1.0:assertion";
+    public static final String SAML1_ASSERTION = "urn:oasis:names:tc:SAML:1.0:assertion";
     private String faultMessage;
     private boolean errorFound;
     private String errorCode;

--- a/src/test/java/com/microsoft/aad/msal4j/OAuthRequestValidationTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/OAuthRequestValidationTest.java
@@ -67,6 +67,7 @@ public class OAuthRequestValidationTest extends AbstractMsalTests {
         PowerMock.mockStatic(HttpHelper.class);
         HttpResponse httpResponse = new HttpResponse();
         httpResponse.body(INSTANCE_DISCOVERY_RESPONSE);
+        httpResponse.statusCode(HttpHelper.HTTP_STATUS_200);
         EasyMock.expect(
                 HttpHelper.executeHttpRequest(
                         EasyMock.isA(HttpRequest.class),

--- a/src/test/java/com/microsoft/aad/msal4j/WSTrustResponseTest.java
+++ b/src/test/java/com/microsoft/aad/msal4j/WSTrustResponseTest.java
@@ -42,7 +42,7 @@ public class WSTrustResponseTest {
         Assert.assertNotNull(response);
     }
 
-    @Test(expectedExceptions = Exception.class, expectedExceptionsMessageRegExp = "Server returned error in RSTR - ErrorCode: RequestFailed : FaultMessage: MSIS3127: The specified request failed.")
+    @Test(expectedExceptions = MsalServiceException.class, expectedExceptionsMessageRegExp = "Server returned error in RSTR - ErrorCode: RequestFailed. FaultMessage: MSIS3127: The specified request failed.")
     public void testWSTrustResponseParseError() throws Exception {
 
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
- For HttpRequests outside of /token endpoint, MSAL was not checking status code before attempting to parse response. When getting non 200 responses from service, MSAL would error out on the parsing of the response, and would emit either an incorrect message/ unhelpful error message. For example, see #371 and #363
- Certain places where throwing generic `Exception` . Updates to throw either `MsalClientException` or `MsalServiceException`