### PR TITLE
Allow tenant to be provided when requesting tokens

### DIFF
--- a/src/integrationtest/java/com.microsoft.aad.msal4j/Config.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/Config.java
@@ -15,6 +15,7 @@ public class Config {
     private String tenantSpecificAuthority;
     private String graphDefaultScope;
     AppCredentialProvider appProvider;
+    private String tenant;
 
     String azureEnvironment;
 
@@ -27,12 +28,14 @@ public class Config {
                 tenantSpecificAuthority = TestConstants.TENANT_SPECIFIC_AUTHORITY;
                 graphDefaultScope = TestConstants.GRAPH_DEFAULT_SCOPE;
                 appProvider = new AppCredentialProvider(azureEnvironment);
+                tenant = TestConstants.MICROSOFT_AUTHORITY_TENANT;
                 break;
             case AzureEnvironment.AZURE_US_GOVERNMENT :
                 organizationsAuthority = TestConstants.ARLINGTON_ORGANIZATIONS_AUTHORITY;
                 tenantSpecificAuthority = TestConstants.ARLINGTON_TENANT_SPECIFIC_AUTHORITY;
                 graphDefaultScope = TestConstants.ARLINGTON_GRAPH_DEFAULT_SCOPE;
                 appProvider = new AppCredentialProvider(azureEnvironment);
+                tenant = TestConstants.ARLINGTON_AUTHORITY_TENANT;
                 break;
             default:
                 throw new UnsupportedOperationException("Azure Environment - " + azureEnvironment + " unsupported");

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
@@ -18,15 +18,17 @@ public class TestConstants {
 
     public final static String MICROSOFT_AUTHORITY_HOST = "https://login.microsoftonline.com/";
     public final static String ARLINGTON_MICROSOFT_AUTHORITY_HOST = "https://login.microsoftonline.us/";
+    public final static String MICROSOFT_AUTHORITY_TENANT = "msidlab4.onmicrosoft.com";
+    public final static String ARLINGTON_AUTHORITY_TENANT = "arlmsidlab1.onmicrosoft.us";
 
     public final static String ORGANIZATIONS_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "organizations/";
     public final static String COMMON_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "common/";
     public final static String MICROSOFT_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "microsoft.onmicrosoft.com";
-    public final static String TENANT_SPECIFIC_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "msidlab4.onmicrosoft.com";
+    public final static String TENANT_SPECIFIC_AUTHORITY = MICROSOFT_AUTHORITY_HOST + MICROSOFT_AUTHORITY_TENANT;
 
     public final static String ARLINGTON_ORGANIZATIONS_AUTHORITY = ARLINGTON_MICROSOFT_AUTHORITY_HOST + "organizations/";
     public final static String ARLINGTON_COMMON_AUTHORITY = ARLINGTON_MICROSOFT_AUTHORITY_HOST + "common/";
-    public final static String ARLINGTON_TENANT_SPECIFIC_AUTHORITY = ARLINGTON_MICROSOFT_AUTHORITY_HOST + "arlmsidlab1.onmicrosoft.us";
+    public final static String ARLINGTON_TENANT_SPECIFIC_AUTHORITY = ARLINGTON_MICROSOFT_AUTHORITY_HOST + ARLINGTON_AUTHORITY_TENANT;
     public final static String ARLINGTON_GRAPH_DEFAULT_SCOPE = "https://graph.microsoft.us/.default";
 
 
@@ -52,7 +54,7 @@ public class TestConstants {
     public final static Set<String> CLIENT_CAPABILITIES_LLT = new HashSet<String>(Collections.singletonList("llt"));
 
     // cross cloud b2b settings
-    public final static String AUTHORITY_ARLINGTON = "https://login.microsoftonline.us/arlmsidlab1.onmicrosoft.us";
+    public final static String AUTHORITY_ARLINGTON = "https://login.microsoftonline.us/" + ARLINGTON_AUTHORITY_TENANT;
     public final static String AUTHORITY_MOONCAKE = "https://login.chinacloudapi.cn/mncmsidlab1.partner.onmschina.cn";
-    public final static String AUTHORITY_PUBLIC_TENANT_SPECIFIC = "https://login.microsoftonline.com/msidlab4.onmicrosoft.com";
+    public final static String AUTHORITY_PUBLIC_TENANT_SPECIFIC = "https://login.microsoftonline.com/" + MICROSOFT_AUTHORITY_TENANT;
 }

--- a/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
@@ -637,7 +637,7 @@ abstract class AbstractClientApplicationBase implements IClientApplicationBase {
          * If region information could not be verified, the library will fall back to using the global endpoint, which is also
          *  the default behavior if this value is not set.
          *
-         * @param val boolean (default is false)
+         * @param val String region name
          * @return instance of the Builder on which method was called
          */
         public T azureRegion(String val) {

--- a/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultSupplier.java
@@ -28,6 +28,12 @@ abstract class AuthenticationResultSupplier implements Supplier<IAuthenticationR
 
         URL authorityUrl = new URL(authority);
 
+        if (msalRequest.requestContext().apiParameters().tenant() != null) {
+            authorityUrl = new URL(authority.replace(
+                    Authority.getTenant(authorityUrl, Authority.detectAuthorityType(authorityUrl)),
+                    msalRequest.requestContext().apiParameters().tenant()));
+        }
+
         InstanceDiscoveryMetadataEntry discoveryMetadataEntry =
                 AadInstanceDiscoveryProvider.getMetadataEntry(
                         authorityUrl,

--- a/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeParameters.java
@@ -57,6 +57,11 @@ public class AuthorizationCodeParameters implements IAcquireTokenParameters {
      */
     private Map<String, String> extraHttpHeaders;
 
+    /**
+     * Overrides the tenant value in the authority URL for this request
+     */
+    private String tenant;
+
     private static AuthorizationCodeParametersBuilder builder() {
 
         return new AuthorizationCodeParametersBuilder();

--- a/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
@@ -44,6 +44,11 @@ public class ClientCredentialParameters implements IAcquireTokenParameters {
      */
     private Map<String, String> extraHttpHeaders;
 
+    /**
+     * Overrides the tenant value in the authority URL for this request
+     */
+    private String tenant;
+
     private static ClientCredentialParametersBuilder builder() {
 
         return new ClientCredentialParametersBuilder();

--- a/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowParameters.java
@@ -49,6 +49,11 @@ public class DeviceCodeFlowParameters implements IAcquireTokenParameters {
      */
     private Map<String, String> extraHttpHeaders;
 
+    /**
+     * Overrides the tenant value in the authority URL for this request
+     */
+    private String tenant;
+
     private static DeviceCodeFlowParametersBuilder builder() {
 
         return new DeviceCodeFlowParametersBuilder();

--- a/src/main/java/com/microsoft/aad/msal4j/IAcquireTokenParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IAcquireTokenParameters.java
@@ -13,4 +13,5 @@ interface IAcquireTokenParameters {
     Set<String> scopes();
     ClaimsRequest claims();
     Map<String, String> extraHttpHeaders();
+    String tenant();
 }

--- a/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthenticationParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthenticationParameters.java
@@ -46,6 +46,10 @@ public class IntegratedWindowsAuthenticationParameters implements IAcquireTokenP
      */
     private Map<String, String> extraHttpHeaders;
 
+    /**
+     * Overrides the tenant value in the authority URL for this request
+     */
+    private String tenant;
 
     private static IntegratedWindowsAuthenticationParametersBuilder builder() {
 

--- a/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
@@ -81,6 +81,11 @@ public class InteractiveRequestParameters implements IAcquireTokenParameters {
     private Map<String, String> extraHttpHeaders;
 
     /**
+     * Overrides the tenant value in the authority URL for this request
+     */
+    private String tenant;
+
+    /**
      * If set to true, the authorization result will contain the authority for the user's home cloud, and this authority
      * will be used for the token request instead of the authority set in the application.
      */

--- a/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfParameters.java
@@ -46,6 +46,11 @@ public class OnBehalfOfParameters implements IAcquireTokenParameters {
      */
     private Map<String, String> extraHttpHeaders;
 
+    /**
+     * Overrides the tenant value in the authority URL for this request
+     */
+    private String tenant;
+
     private static OnBehalfOfParametersBuilder builder() {
 
         return new OnBehalfOfParametersBuilder();

--- a/src/main/java/com/microsoft/aad/msal4j/RefreshTokenParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/RefreshTokenParameters.java
@@ -48,6 +48,11 @@ public class RefreshTokenParameters implements IAcquireTokenParameters {
      */
     private Map<String, String> extraHttpHeaders;
 
+    /**
+     * Overrides the tenant value in the authority URL for this request
+     */
+    private String tenant;
+
     private static RefreshTokenParametersBuilder builder() {
 
         return new RefreshTokenParametersBuilder();

--- a/src/main/java/com/microsoft/aad/msal4j/SilentParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/SilentParameters.java
@@ -55,6 +55,11 @@ public class SilentParameters implements IAcquireTokenParameters {
      */
     private Map<String, String> extraHttpHeaders;
 
+    /**
+     * Overrides the tenant value in the authority URL for this request
+     */
+    private String tenant;
+
     private static SilentParametersBuilder builder() {
 
         return new SilentParametersBuilder();

--- a/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordParameters.java
@@ -52,6 +52,11 @@ public class UserNamePasswordParameters implements IAcquireTokenParameters {
      */
     private Map<String, String> extraHttpHeaders;
 
+    /**
+     * Overrides the tenant value in the authority URL for this request
+     */
+    private String tenant;
+
     public char[] password(){
         return password.clone();
     }


### PR DESCRIPTION
Allows devs to pass in a tenant value when requesting a token, which will override the tenant defined in the authority URL when the client app was made, as requested in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/393