### PR TITLE
Silent calls now use cached environment info

### DIFF
--- a/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
@@ -44,7 +44,7 @@ public class DeviceCodeIT {
                 build();
 
         Consumer<DeviceCode> deviceCodeConsumer = (DeviceCode deviceCode) -> {
-            runAutomatedDeviceCodeFlow(deviceCode, user, environment);
+            runAutomatedDeviceCodeFlow(deviceCode, user);
         };
 
         IAuthenticationResult result = pca.acquireToken(DeviceCodeFlowParameters
@@ -57,8 +57,8 @@ public class DeviceCodeIT {
         Assert.assertFalse(Strings.isNullOrEmpty(result.accessToken()));
     }
 
-    @Test(dataProvider = "environments", dataProviderClass = EnvironmentsProvider.class)
-    public void DeviceCodeFlowADFSv2019Test(String environment) throws Exception {
+    @Test()
+    public void DeviceCodeFlowADFSv2019Test() throws Exception {
 
         User user = labUserProvider.getOnPremAdfsUser(FederationProvider.ADFS_2019);
 
@@ -68,7 +68,7 @@ public class DeviceCodeIT {
                 build();
 
         Consumer<DeviceCode> deviceCodeConsumer = (DeviceCode deviceCode) -> {
-            runAutomatedDeviceCodeFlow(deviceCode, user, environment);
+            runAutomatedDeviceCodeFlow(deviceCode, user);
         };
 
         IAuthenticationResult result = pca.acquireToken(DeviceCodeFlowParameters
@@ -81,7 +81,39 @@ public class DeviceCodeIT {
         Assert.assertFalse(Strings.isNullOrEmpty(result.accessToken()));
     }
 
-    private void runAutomatedDeviceCodeFlow(DeviceCode deviceCode, User user, String environment) {
+    @Test()
+    public void DeviceCodeFlowMSATest() throws Exception {
+
+        User user = labUserProvider.getMSAUser();
+
+        PublicClientApplication pca = PublicClientApplication.builder(
+                user.getAppId()).
+                authority(TestConstants.CONSUMERS_AUTHORITY).
+                build();
+
+        Consumer<DeviceCode> deviceCodeConsumer = (DeviceCode deviceCode) -> {
+            runAutomatedDeviceCodeFlow(deviceCode, user);
+        };
+
+        IAuthenticationResult result = pca.acquireToken(DeviceCodeFlowParameters
+                .builder(Collections.singleton(""),
+                        deviceCodeConsumer)
+                .build())
+                .get();
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(Strings.isNullOrEmpty(result.accessToken()));
+
+        result = pca.acquireTokenSilently(SilentParameters.
+                builder(Collections.singleton(""), result.account()).
+                build())
+                .get();
+
+        Assert.assertNotNull(result);
+        Assert.assertFalse(Strings.isNullOrEmpty(result.accessToken()));
+    }
+
+    private void runAutomatedDeviceCodeFlow(DeviceCode deviceCode, User user) {
         boolean isRunningLocally = true;//!Strings.isNullOrEmpty(
         //System.getenv(TestConstants.LOCAL_FLAG_ENV_VAR));
 

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
@@ -24,6 +24,7 @@ public class TestConstants {
 
     public final static String ORGANIZATIONS_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "organizations/";
     public final static String COMMON_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "common/";
+    public final static String CONSUMERS_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "consumers/";
     public final static String COMMON_AUTHORITY_WITH_PORT = MICROSOFT_AUTHORITY_HOST_WITH_PORT + "msidlab4.onmicrosoft.com";
     public final static String MICROSOFT_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "microsoft.onmicrosoft.com";
     public final static String TENANT_SPECIFIC_AUTHORITY = MICROSOFT_AUTHORITY_HOST + MICROSOFT_AUTHORITY_TENANT;

--- a/src/integrationtest/java/labapi/LabUserProvider.java
+++ b/src/integrationtest/java/labapi/LabUserProvider.java
@@ -78,6 +78,13 @@ public class LabUserProvider {
         return getLabUser(query);
     }
 
+    public User getMSAUser() {
+        UserQueryParameters query = new UserQueryParameters();
+        query.parameters.put(UserQueryParameters.USER_TYPE, UserType.MSA);
+
+        return getLabUser(query);
+    }
+
     public User getUserByAzureEnvironment(String azureEnvironment) {
 
         UserQueryParameters query = new UserQueryParameters();

--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
+import java.net.URL;
 import java.util.Date;
 
 class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
@@ -69,6 +70,14 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
                 }
 
                 if (!StringHelper.isBlank(res.refreshToken())) {
+                    //There are certain scenarios where the cached authority may differ from the client app's authority,
+                    // such as when a request is instance aware. Unless overridden by SilentParameters.authorityUrl, the
+                    // cached authority should be used in the token refresh request
+                    if (silentRequest.parameters().authorityUrl() == null && !res.account().environment().equals(requestAuthority.host)) {
+                        requestAuthority = Authority.createAuthority(new URL(requestAuthority.authority().replace(requestAuthority.host(),
+                                res.account().environment())));
+                    }
+
                     RefreshTokenRequest refreshTokenRequest = new RefreshTokenRequest(
                             RefreshTokenParameters.builder(silentRequest.parameters().scopes(), res.refreshToken()).build(),
                             silentRequest.application(),

--- a/src/main/java/com/microsoft/aad/msal4j/TokenCache.java
+++ b/src/main/java/com/microsoft/aad/msal4j/TokenCache.java
@@ -584,7 +584,6 @@ public class TokenCache implements ITokenCache {
             String clientId) {
 
         AuthenticationResult.AuthenticationResultBuilder builder = AuthenticationResult.builder();
-        builder.environment(authority.host());
 
         Set<String> environmentAliases = AadInstanceDiscoveryProvider.getAliases(account.environment());
 
@@ -622,11 +621,14 @@ public class TokenCache implements ITokenCache {
 
                 if (atCacheEntity.isPresent()) {
                     builder.
+                            environment(atCacheEntity.get().environment).
                             accessToken(atCacheEntity.get().secret).
                             expiresOn(Long.parseLong(atCacheEntity.get().expiresOn()));
                     if (atCacheEntity.get().refreshOn() != null) {
                         builder.refreshOn(Long.parseLong(atCacheEntity.get().refreshOn()));
                     }
+                } else {
+                    builder.environment(authority.host());
                 }
                 idTokenCacheEntity.ifPresent(tokenCacheEntity -> builder.idToken(tokenCacheEntity.secret));
                 rtCacheEntity.ifPresent(refreshTokenCacheEntity ->


### PR DESCRIPTION
In some situations (described [here](https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview/pullrequest/1868?_a=files&path=%2F%5Bxplat%5D%20Authority%20Mapping%2FSolve%20discrepancy%20between%20request%20authority%20and%20cache%20authority.md)), the authority set in the client app may differ from the cached authority info, causing issues during silent calls such as cache misses or refresh requests sent to the wrong authority. These changes plug some of those gaps by retrieving the cached environment info during silent calls.