### PR TITLE
Add trailing slash to authorities in silent calls

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/SilentRequest.java
+++ b/src/main/java/com/microsoft/aad/msal4j/SilentRequest.java
@@ -28,11 +28,20 @@ class SilentRequest extends MsalRequest {
         this.assertion = assertion;
         this.requestAuthority = StringHelper.isBlank(parameters.authorityUrl()) ?
                 application.authenticationAuthority :
-                Authority.createAuthority(new URL(parameters.authorityUrl()));
+                Authority.createAuthority(new URL(enforceTrailingSlash(parameters.authorityUrl())));
 
         if (parameters.forceRefresh()) {
             application.getServiceBundle().getServerSideTelemetry().getCurrentRequest().cacheInfo(
                     CacheTelemetry.REFRESH_FORCE_REFRESH.telemetryValue);
         }
+    }
+
+    protected static String enforceTrailingSlash(String authority) {
+        authority = authority.toLowerCase();
+
+        if (!authority.endsWith("/")) {
+            authority += "/";
+        }
+        return authority;
     }
 }


### PR DESCRIPTION
Copies a method used in `AbstractClientApplicationBase` to enforce a trailing slash in a `SilentRequest`

Fixes an issue mentioned in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/429, where authorities passed to silent calls would cause an exception if they didn't have a trailing slash. 