### PR TITLE
Remove info flagged by automated build step

### DIFF
--- a/src/integrationtest/java/com.microsoft.aad.msal4j/AzureEnvironmentIT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/AzureEnvironmentIT.java
@@ -19,11 +19,6 @@ public class AzureEnvironmentIT {
     }
 
     @Test
-    public void acquireTokenWithUsernamePassword_AzureGermany() throws Exception {
-        assertAcquireTokenCommon(AzureEnvironment.AZURE_GERMANY);
-    }
-
-    @Test
     public void acquireTokenWithUsernamePassword_AzureChina() throws Exception {
         assertAcquireTokenCommon(AzureEnvironment.AZURE_CHINA);
     }

--- a/src/integrationtest/java/labapi/AzureEnvironment.java
+++ b/src/integrationtest/java/labapi/AzureEnvironment.java
@@ -8,7 +8,6 @@ public class AzureEnvironment {
     public static final String AZURE_B2C = "azureb2ccloud";
     public static final String AZURE_CHINA = "azurechinacloud";
     public static final String AZURE = "azurecloud";
-    public static final String AZURE_GERMANY = "azuregermanycloud";
     public static final String AZURE_PPE = "azureppe";
     public static final String AZURE_US_GOVERNMENT = "azureusgovernment";
 }

--- a/src/test/java/com/microsoft/aad/msal4j/TestConfiguration.java
+++ b/src/test/java/com/microsoft/aad/msal4j/TestConfiguration.java
@@ -55,11 +55,7 @@ public final class TestConfiguration {
             + "Uj0_XsCpQ4TdkPepuhzaGc-zYsfMU1POuIOB87pzW7e_VDpCdxcN1fuk-7CECPQb8nrO0L8Du8y-TZDdTSe-i_A0Alv48Zll-6tDY9cxfAR0Uy"
             + "YKl_Kf45kuHAphCWwPsjUxv4rGHhgXZPRlKFq7bkXP2Es4ixCQzb3bVLLrtQaZjkQ1yn37ngJro8NR63EbHHjHTA9lRmf8KIQ\",\"token_type\""
             + ":\"Bearer\",\"expires_in\":3600,\"expires_on\":\"1393848404\",\"resource\":\"b7a671d8-a408-42ff-86e0-aaf447fd1"
-            + "7c4\",\"refresh_token\":\"AwABAAAAvPM1KaPlrEqdFSBzjqfTGPW9BlsxWYtD0DS9hJNOPHPnq8QYbv6_FKJ3MxSHbPAIekKwJ04TnZI1NnRj"
-            + "CMhphmsy5ZFjWtLy3WN2E67b3aW2MTQ9lN06B-HdRdU0Rxi9EalB8kAlgb92Ob0zuhB90zWm3RbxshOW0vkHS3lNAV6_LQ8fZKeLTB1AuuRgLXsy-9"
-            + "2h0yYuEQw_Uvs80IbGx59j1z3hJrCMEMrqh-Hf42OnckN-uR113zMircfEOMm0qzhrQdtLleTHELS79B18647OiG6e8k8saVIvJmjpIuy79_aN-Bk5"
-            + "PRkkab-QAwn_R68via4nK0zpKHBCl0xoEvK59mqerNDEKJNY168_FHDYPiZyECaZCdlWdEqd3dLohFlnKv9zc0CnuvB_QSQHHNScqWkX53s_Us9I45"
-            + "QlRDaUPB89QXzQQaT2wZ8i3wTOb7mnEUMzrNrpsor6E4ckiviMx6WoepZmqQEZV-Yd-UUgAA\",\"scope\":\"user_impersonation\",\""
+            + "7c4\",\"refresh_token\":\"refresh_token\",\"scope\":\"user_impersonation\",\""
             + "id_token\":\"eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.ew0KICAiYXVkIjogImI2YzY5YTM3LWRmOTYtNGRiMC05MDg4LTJhYjk2ZTFkO" +
             "DIxNSIsDQogICJpc3MiOiAiaHR0cHM6Ly9sb2dpbi5taWNyb3NvZnRvbmxpbmUuY29tL2Y2NDVhZDkyLWUzOGQtNGQxYS1iNTEwLWQxYjA5YTc0YThjYS" +
             "92Mi4wIiwNCiAgImlhdCI6IDE1Mzg1Mzg0MjIsDQogICJuYmYiOiAxNTM4NTM4NDIyLA0KICAiZXhwIjogMTUzODU0MjMyMiwNCiAgIm5hbWUiOiAiQ2x" +


### PR DESCRIPTION
Seems like a step in the build pipeline has started flagging some test data that's been there since 2019, causing builds to fail. It wasn't directly referenced by any test, so this PR just removes it to get the builds working again.

Additionally removes references to old Azure Germany Cloud, since those endpoints are deprecated