### PR TITLE
Fix java.io.IOException: too many bytes written

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
@@ -102,7 +102,7 @@ class AuthorizationResponseHandler implements HttpHandler {
     private void send200Response(HttpExchange httpExchange, String response) throws IOException {
         httpExchange.sendResponseHeaders(200, response.length());
         OutputStream os = httpExchange.getResponseBody();
-        os.write(response.getBytes());
+        os.write(response.getBytes("UTF-8"));
         os.close();
     }
 
@@ -117,6 +117,6 @@ class AuthorizationResponseHandler implements HttpHandler {
         if (systemBrowserOptions == null || systemBrowserOptions.htmlMessageError() == null) {
             return DEFAULT_FAILURE_MESSAGE;
         }
-        return systemBrowserOptions().htmlMessageSuccess();
+        return systemBrowserOptions().htmlMessageError();
     }
 }


### PR DESCRIPTION
Current implementation relies on system location for getting bytes, and if it is not "UTF-8" underlying outputstream will error with 
```java.io.IOException: too many bytes written```

Also fixed minor bug with wrong message being output