### PR TITLE
Rework CustomJWTAuthentication to request the oauth token correctly

### DIFF
--- a/src/integrationtest/java/com.microsoft.aad.msal4j/CertificateHelper.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/CertificateHelper.java
@@ -16,6 +16,8 @@ public class CertificateHelper {
         String os = SystemUtils.OS_NAME;
         if (os.contains("Mac")) {
             return KeyStore.getInstance("KeychainStore");
+        } else if (os.contains("Linux")) {
+            return KeyStore.getInstance(KeyStore.getDefaultType());
         } else {
             return KeyStore.getInstance("Windows-MY", "SunMSCAPI");
         }

--- a/src/integrationtest/java/com.microsoft.aad.msal4j/ConfidentialClientApplicationUnitT.java
+++ b/src/integrationtest/java/com.microsoft.aad.msal4j/ConfidentialClientApplicationUnitT.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
+import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.crypto.RSASSASigner;
@@ -10,7 +11,9 @@ import com.nimbusds.jose.util.Base64;
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.auth.JWTAuthentication;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -22,13 +25,14 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.security.*;
 import java.security.cert.CertificateException;
 import java.util.*;
 import java.util.concurrent.Future;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
+import static org.easymock.EasyMock.*;
+import static org.testng.Assert.*;
 
 @PowerMockIgnore({"javax.net.ssl.*"})
 @PrepareForTest({ConfidentialClientApplication.class,
@@ -206,29 +210,7 @@ public class ConfidentialClientApplicationUnitT extends PowerMockTestCase {
 
     @Test
     public void testClientAssertion_noException() throws Exception{
-
-        IClientCertificate certificate = CertificateHelper.getClientCertificate();
-
-        final ClientCertificate credential = (ClientCertificate) certificate;
-
-        final JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
-                .issuer("issuer")
-                .subject("subject")
-                .build();
-
-        SignedJWT jwt;
-        JWSHeader.Builder builder = new JWSHeader.Builder(JWSAlgorithm.RS256);
-
-        List<Base64> certs = new ArrayList<>();
-        for (String cert : credential.getEncodedPublicKeyCertificateChain()) {
-            certs.add(new Base64(cert));
-        }
-        builder.x509CertChain(certs);
-
-        jwt = new SignedJWT(builder.build(), claimsSet);
-        final RSASSASigner signer = new RSASSASigner(credential.privateKey());
-
-        jwt.sign(signer);
+        SignedJWT jwt = createClientAssertion("issuer");
 
         ClientAssertion clientAssertion = new ClientAssertion(jwt.serialize());
 
@@ -245,14 +227,84 @@ public class ConfidentialClientApplicationUnitT extends PowerMockTestCase {
 
     }
 
+    @Test
+    public void testClientAssertion_acquireToken() throws Exception{
+        SignedJWT jwt = createClientAssertion("issuer");
+
+        ClientAssertion clientAssertion = new ClientAssertion(jwt.serialize());
+        ConfidentialClientApplication app = ConfidentialClientApplication
+                .builder(TestConfiguration.AAD_CLIENT_ID, ClientCredentialFactory.createFromClientAssertion(clientAssertion.assertion()))
+                .authority(TestConfiguration.AAD_TENANT_ENDPOINT)
+                .build();
+
+        String scope = "requestedScope";
+        ClientCredentialRequest clientCredentialRequest = getClientCredentialRequest(app, scope);
+
+        IHttpClient httpClientMock = EasyMock.mock(IHttpClient.class);
+        Capture<HttpRequest> captureSingleArgument = newCapture();
+        expect(httpClientMock.send(capture(captureSingleArgument))).andReturn(new HttpResponse());
+        EasyMock.replay(httpClientMock);
+
+        TokenRequestExecutor tokenRequestExecutor = new TokenRequestExecutor(app.authenticationAuthority, clientCredentialRequest, mockedServiceBundle(httpClientMock));
+        try {
+            tokenRequestExecutor.executeTokenRequest();
+        } catch(Exception e) {
+            //Ignored, we only want to check the request that was send.
+        }
+        HttpRequest value = captureSingleArgument.getValue();
+        String body = value.body();
+        Assert.assertTrue(body.contains("grant_type=client_credentials"));
+        Assert.assertTrue(body.contains("client_assertion=" + clientAssertion.assertion()));
+        Assert.assertTrue(body.contains("client_assertion_type=" + URLEncoder.encode(JWTAuthentication.CLIENT_ASSERTION_TYPE, "utf-8")));
+        Assert.assertTrue(body.contains("scope=" + URLEncoder.encode("openid profile offline_access " + scope, "utf-8")));
+        Assert.assertTrue(body.contains("client_id=" + TestConfiguration.AAD_CLIENT_ID));
+    }
+
+    private ServiceBundle mockedServiceBundle(IHttpClient httpClientMock) {
+        ServiceBundle serviceBundle = new ServiceBundle(
+                null,
+                httpClientMock,
+                new TelemetryManager(null, false));
+        return serviceBundle;
+    }
+
+    private ClientCredentialRequest getClientCredentialRequest(ConfidentialClientApplication app, String scope) {
+        Set<String> scopes = new HashSet<>();
+        scopes.add(scope);
+        ClientCredentialParameters clientCredentials = ClientCredentialParameters.builder(scopes).tenant(IdToken.TENANT_IDENTIFIER).build();
+        RequestContext requestContext = new RequestContext(
+                app,
+                PublicApi.ACQUIRE_TOKEN_FOR_CLIENT,
+                clientCredentials);
+
+        ClientCredentialRequest clientCredentialRequest =
+                new ClientCredentialRequest(
+                        clientCredentials,
+                        app,
+                        requestContext);
+        return clientCredentialRequest;
+    }
+
     @Test(expectedExceptions = MsalClientException.class)
     public void testClientAssertion_throwsException() throws Exception{
+        SignedJWT jwt = createClientAssertion(null);
 
+        ClientAssertion clientAssertion = new ClientAssertion(jwt.serialize());
+
+        IClientCredential iClientCredential = ClientCredentialFactory.createFromClientAssertion(
+                clientAssertion.assertion());
+
+        ConfidentialClientApplication.builder(TestConfiguration.AAD_CLIENT_ID, iClientCredential).authority(TestConfiguration.AAD_TENANT_ENDPOINT).build();
+
+    }
+
+    private SignedJWT createClientAssertion(String issuer) throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException, UnrecoverableKeyException, NoSuchProviderException, JOSEException {
         IClientCertificate certificate = CertificateHelper.getClientCertificate();
+
         final ClientCertificate credential = (ClientCertificate) certificate;
 
         final JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
-                .issuer(null)
+                .issuer(issuer)
                 .subject("subject")
                 .build();
 
@@ -269,15 +321,7 @@ public class ConfidentialClientApplicationUnitT extends PowerMockTestCase {
         final RSASSASigner signer = new RSASSASigner(credential.privateKey());
 
         jwt.sign(signer);
-
-        ClientAssertion clientAssertion = new ClientAssertion(jwt.serialize());
-
-        IClientCredential iClientCredential = ClientCredentialFactory.createFromClientAssertion(
-                clientAssertion.assertion());
-
-        ConfidentialClientApplication.builder(TestConfiguration.AAD_CLIENT_ID, iClientCredential).authority(TestConfiguration.AAD_TENANT_ENDPOINT).build();
-
+        return jwt;
     }
-
 
 }

--- a/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
@@ -33,7 +33,6 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
 public class ConfidentialClientApplication extends AbstractClientApplicationBase implements IConfidentialClientApplication {
 
     private ClientAuthentication clientAuthentication;
-    private CustomJWTAuthentication customJWTAuthentication;
     private boolean clientCertAuthentication = false;
     private ClientCertificate clientCertificate;
 
@@ -137,22 +136,11 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
             //This library is not supposed to validate Issuer and subject values.
             //The next lines of code ensures that exception is not thrown.
             if (e.getMessage().contains("Issuer and subject in client JWT assertion must designate the same client identifier")) {
-                String clientAssertion1 = MultivaluedMapUtils.getFirstValue(map, "client_assertion");
-                Base64URL[] parts;
-                try {
-                    parts = JOSEObject.split(clientAssertion1);
-
-                SignedJWT signedJWT = new SignedJWT(parts[0], parts[1], parts[2]);
-                String subjectValue = signedJWT.getJWTClaimsSet().getSubject();
                 return new CustomJWTAuthentication(
                         ClientAuthenticationMethod.PRIVATE_KEY_JWT,
-                        new ClientID(subjectValue)
+                        clientAssertion,
+                        new ClientID(clientId())
                 );
-
-                } catch (java.text.ParseException ex) {
-                    log.error("Ideally the system should not reach here. Parse Exception while trying to build CustomJWTAuthentication.");
-                    throw new MsalClientException(e);
-                }
             }
             throw new MsalClientException(e);
         }

--- a/src/main/java/com/microsoft/aad/msal4j/CustomJWTAuthentication.java
+++ b/src/main/java/com/microsoft/aad/msal4j/CustomJWTAuthentication.java
@@ -3,19 +3,59 @@
 
 package com.microsoft.aad.msal4j;
 
+import com.nimbusds.common.contenttype.ContentType;
+import com.nimbusds.oauth2.sdk.SerializeException;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.auth.JWTAuthentication;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.util.URLUtils;
+
+import java.net.URLEncoder;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class CustomJWTAuthentication extends ClientAuthentication {
+    private ClientAssertion clientAssertion;
 
-    protected CustomJWTAuthentication(ClientAuthenticationMethod method, ClientID clientID) {
+    protected CustomJWTAuthentication(ClientAuthenticationMethod method, ClientAssertion clientAssertion, ClientID clientID) {
         super(method, clientID);
+        this.clientAssertion = clientAssertion;
     }
 
     @Override
     public void applyTo(HTTPRequest httpRequest) {
+        if (httpRequest.getMethod() != HTTPRequest.Method.POST) {
+            throw new SerializeException("The HTTP request method must be POST");
+        } else {
+            ContentType ct = httpRequest.getEntityContentType();
+            if (ct == null) {
+                throw new SerializeException("Missing HTTP Content-Type header");
+            } else if (!ct.matches(ContentType.APPLICATION_URLENCODED)) {
+                throw new SerializeException("The HTTP Content-Type header must be " + ContentType.APPLICATION_URLENCODED);
+            } else {
+                Map<String, List<String>> params = httpRequest.getQueryParameters();
+                params.putAll(this.toParameters());
+                String queryString = URLUtils.serializeParameters(params);
+                httpRequest.setQuery(queryString);
+            }
+        }
+    }
 
+    public Map<String, List<String>> toParameters() {
+        HashMap<String, List<String>> params = new HashMap<>();
+
+        try {
+            params.put("client_assertion", Collections.singletonList(this.clientAssertion.assertion()));
+        } catch (IllegalStateException var3) {
+            throw new SerializeException("Couldn't serialize JWT to a client assertion string: " + var3.getMessage(), var3);
+        }
+
+        params.put("client_assertion_type", Collections.singletonList(JWTAuthentication.CLIENT_ASSERTION_TYPE));
+        params.put("client_id", Collections.singletonList(getClientID().getValue()));
+        return params;
     }
 }


### PR DESCRIPTION
Usecase:
I am using oidc on k8s with workload-identity for spark applications and noticed that requesting a token did not work. 

Problem:
The fix for #437 is not sufficient to work with workload identity as the new CustomJwtAuthentication class does not construct the correct body for requesting a token (the applyTo method does nothing).

I use this library as follows:

```
IClientCredential credential = ClientCredentialFactory.createFromClientAssertion(tokenFileString);
ConfidentialClientApplication app = ConfidentialClientApplication.builder(clientId, credential).authority(authority).build();

Set<String> scopes = new HashSet<>();
scopes.add("https://storage.azure.com/.default");

ClientCredentialParameters parameters = ClientCredentialParameters.builder(scopes).tenant(tenantId).build();
IAuthenticationResult token = app.acquireToken(parameters).get(5, TimeUnit.SECONDS);
```


Changes that I made are:
- I updated the customJwtAuthentication to work similarly to how the JwtAuthentication class from com.nimbusds.oauth2.sdk.auth. I think this is useful for other users as well, such that they can also use workload identity with java applications.
- The clientId used, should be the azure ad application id instead of the subject in the jwt token as this is the serviceAccount and thus does not exist in azure ad. 

Note on running all tests:
I had issues running all tests as some depended on libraries I do not have on Linux. To test the relevant classes I created a custom keystore with a self signed certificate in it with a password (minimum was 6 characters). Can you describe the setup required to run all the tests locally? 