### PR TITLE
Allow client assertion to be a callback and a per-request parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-security-keyvault-secrets</artifactId>
-            <version>4.3.6</version>
+            <version>4.3.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/microsoft/aad/msal4j/ClientCredentialFactory.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientCredentialFactory.java
@@ -9,6 +9,11 @@ import java.security.*;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
 
@@ -29,7 +34,7 @@ public class ClientCredentialFactory {
     }
 
     /**
-     * Static method to create a {@link ClientCertificate} instance from a certificate
+     * Static method to create a {@link ClientCertificate} instance from a password-protected certificate.
      *
      * @param pkcs12Certificate InputStream containing PCKS12 formatted certificate
      * @param password          certificate password
@@ -48,7 +53,7 @@ public class ClientCredentialFactory {
     }
 
     /**
-     * Static method to create a {@link ClientCertificate} instance.
+     * Static method to create a {@link ClientCertificate} instance from a private key/public certificate pair.
      *
      * @param key                  RSA private key to sign the assertion.
      * @param publicKeyCertificate x509 public certificate used for thumbprint
@@ -61,7 +66,7 @@ public class ClientCredentialFactory {
     }
 
     /**
-     * Static method to create a {@link ClientCertificate} instance.
+     * Static method to create a {@link ClientCertificate} instance from a certificate chain.
      *
      * @param key                       RSA private key to sign the assertion.
      * @param publicKeyCertificateChain ordered with the user's certificate first followed by zero or more certificate authorities
@@ -75,12 +80,26 @@ public class ClientCredentialFactory {
     }
 
     /**
-     * Static method to create a {@link ClientAssertion} instance.
+     * Static method to create a {@link ClientAssertion} instance from a JWT token encoded as a base64 URL encoded string.
      *
-     * @param clientAssertion Jwt token encoded as a base64 URL encoded string
+     * @param clientAssertion JWT token encoded as a base64 URL encoded string
      * @return {@link ClientAssertion}
      */
     public static IClientAssertion createFromClientAssertion(String clientAssertion) {
         return new ClientAssertion(clientAssertion);
+    }
+
+    /**
+     * Static method to create a {@link ClientAssertion} instance from a provided Callable<String>.
+     *
+     * @param callable Callable<String> that produces a JWT token encoded as a base64 URL encoded string
+     * @return {@link ClientAssertion}
+     */
+    public static IClientAssertion createFromCallback(Callable<String> callable) throws ExecutionException, InterruptedException {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        Future<String> future = executor.submit(callable);
+
+        return new ClientAssertion(future.get());
     }
 }

--- a/src/main/java/com/microsoft/aad/msal4j/ClientCredentialFactory.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientCredentialFactory.java
@@ -90,9 +90,9 @@ public class ClientCredentialFactory {
     }
 
     /**
-     * Static method to create a {@link ClientAssertion} instance from a provided Callable<String>.
+     * Static method to create a {@link ClientAssertion} instance from a provided Callable.
      *
-     * @param callable Callable<String> that produces a JWT token encoded as a base64 URL encoded string
+     * @param callable Callable that produces a JWT token encoded as a base64 URL encoded string
      * @return {@link ClientAssertion}
      */
     public static IClientAssertion createFromCallback(Callable<String> callable) throws ExecutionException, InterruptedException {

--- a/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
@@ -49,6 +49,11 @@ public class ClientCredentialParameters implements IAcquireTokenParameters {
      */
     private String tenant;
 
+    /**
+     * Overrides the client credentials for this request
+     */
+    private IClientCredential clientCredential;
+
     private static ClientCredentialParametersBuilder builder() {
 
         return new ClientCredentialParametersBuilder();

--- a/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
+++ b/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
@@ -125,7 +125,7 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
         return createClientAuthFromClientAssertion(clientAssertion);
     }
 
-    private ClientAuthentication createClientAuthFromClientAssertion(
+    protected ClientAuthentication createClientAuthFromClientAssertion(
             final ClientAssertion clientAssertion) {
         final Map<String, List<String>> map = new HashMap<>();
         try {

--- a/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -73,7 +73,15 @@ class TokenRequestExecutor {
         oauthHttpRequest.setQuery(URLUtils.serializeParameters(params));
 
         if (msalRequest.application().clientAuthentication() != null) {
-            msalRequest.application().clientAuthentication().applyTo(oauthHttpRequest);
+            // If the client application has a client assertion to apply to the request, check if a new client assertion
+            //  was supplied as a request parameter. If so, use the request's assertion instead of the application's
+            if (msalRequest instanceof ClientCredentialRequest && ((ClientCredentialRequest) msalRequest).parameters.clientCredential() != null) {
+                ((ConfidentialClientApplication) msalRequest.application())
+                        .createClientAuthFromClientAssertion((ClientAssertion) ((ClientCredentialRequest) msalRequest).parameters.clientCredential())
+                        .applyTo(oauthHttpRequest);
+            } else {
+                msalRequest.application().clientAuthentication().applyTo(oauthHttpRequest);
+            }
         }
         return oauthHttpRequest;
     }


### PR DESCRIPTION
Adds a new helper method to the ClientCredentialFactory to create client assertions in a callback, and allows client credentials to be set as a per-request parameter in the client credential flow

As requested in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/466