### PR TITLE
fix: Correct scope for test dependency in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-security-keyvault-secrets</artifactId>
-            <version>4.3.5</version>
+            <version>4.3.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -102,11 +102,7 @@
             <groupId>com.azure</groupId>
             <artifactId>azure-security-keyvault-secrets</artifactId>
             <version>4.3.5</version>
-        </dependency>
-        <dependency>
-            <groupId>com.azure</groupId>
-            <artifactId>azure-security-keyvault-secrets</artifactId>
-            <version>4.3.5</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>


### PR DESCRIPTION
The `azure-security-keyvault-secrets` test dependency was include twice and without the correct `test` scope.

Due to this, if used this library, Maven automatically included a lot of dependencies that are actually unneccasary, and in our case, this lead to problems as some of these dependencies clashed with existing ones in our project.