### PR TITLE
Improve error message when Authority does not contain path

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/Authority.java
+++ b/src/main/java/com/microsoft/aad/msal4j/Authority.java
@@ -117,7 +117,7 @@ abstract class Authority {
 
         if (segments.length == 0) {
             throw new IllegalArgumentException(
-                    IllegalArgumentExceptionMessages.AUTHORITY_URI_EMPTY_PATH_SEGMENT);
+                    IllegalArgumentExceptionMessages.AUTHORITY_URI_MISSING_PATH_SEGMENT);
         }
 
         for (String segment : segments) {

--- a/src/main/java/com/microsoft/aad/msal4j/IllegalArgumentExceptionMessages.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IllegalArgumentExceptionMessages.java
@@ -7,7 +7,7 @@ class IllegalArgumentExceptionMessages {
 
     final static String AUTHORITY_URI_EMPTY_PATH_SEGMENT = "Authority Uri should not have empty path segments";
 
-    final static String AUTHORITY_URI_MISSING_PATH_SEGMENT = "Authority Uri must have a least one path segment. This is usually 'common' or the application's tenant id.";
+    final static String AUTHORITY_URI_MISSING_PATH_SEGMENT = "Authority Uri must have at least one path segment. This is usually 'common' or the application's tenant id.";
 
     final static String AUTHORITY_URI_EMPTY_PATH = "Authority Uri should have at least one segment in the path";
 

--- a/src/main/java/com/microsoft/aad/msal4j/IllegalArgumentExceptionMessages.java
+++ b/src/main/java/com/microsoft/aad/msal4j/IllegalArgumentExceptionMessages.java
@@ -7,6 +7,8 @@ class IllegalArgumentExceptionMessages {
 
     final static String AUTHORITY_URI_EMPTY_PATH_SEGMENT = "Authority Uri should not have empty path segments";
 
+    final static String AUTHORITY_URI_MISSING_PATH_SEGMENT = "Authority Uri must have a least one path segment. This is usually 'common' or the application's tenant id.";
+
     final static String AUTHORITY_URI_EMPTY_PATH = "Authority Uri should have at least one segment in the path";
 
 }


### PR DESCRIPTION
I was developing an application using `com.microsoft.azure:msal4j:1.11.3` and came across this `AUTHORITY_URI_EMPTY_PATH_SEGMENT` and thought it was misleading.

![image](https://user-images.githubusercontent.com/2856501/165153898-1aebccb5-599d-436e-82ee-fcc75df2a975.png)

You can see that there are no "empty" paths in the URL given, so the error message is no appropriate or true. The issue is that the msal4j expects the authority configured to include the path such as "common" or a tenant id.

I added a new constant to explain this case more clearly.

Also, I am new to mal4j but I think it should be more clearly stated in the documentation this library expects different configuration.  In some of the other AAD libraries you configure the authority differently, specifically the path is a separate configuration field. Notably the dotnet library https://github.com/AzureAD/microsoft-identity-web (which is likely more commonly used for Microsoft Auth) constructs the authority from two fields.

Example:
```
{
  "Instance": "https://login.microsoftonline.com/",
  "ClientId": "<removed>",
  "TenantId": "common"
}
```

However, using msal4j it expects the authority to be specified completely like this: `https://login.microsoftonline.com/common`
This difference means this error is more likely to occur and it should have a very clear error message.

