### PR TITLE
Revert some changes from the old PR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,17 +37,6 @@
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
             <version>9.32</version>
-            <exclusions>
-                <exclusion>
-                    <!--
-                    com.nimbusds:oauth2-oidc-sdk:9.7 have version range: net.minidev:json-smart:[1.3.3,2.4.7].
-                    This will bring trouble to our customer.
-                    Refs: https://github.com/Azure/azure-sdk-for-java/issues/23373
-                    -->
-                    <groupId>net.minidev</groupId>
-                    <artifactId>json-smart</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.minidev</groupId>


### PR DESCRIPTION
As part of fixing Issue #428, json-smart dependency was excluded from oauth2-oidc depedency. 
This approach will require the msal4j team to take the full responsibility to keep oauth2-oidc-sdk and json-smart dependency updated at all times, else there's a risk of customers application hitting dependency conflicts.
So reverting those changes.