### PR TITLE
Fixed localized strings for htmlMessageSuccess

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
@@ -100,9 +100,11 @@ class AuthorizationResponseHandler implements HttpHandler {
     }
 
     private void send200Response(HttpExchange httpExchange, String response) throws IOException {
-        httpExchange.sendResponseHeaders(200, response.length());
+        byte[] responseBytes = response.getBytes("UTF-8");
+        httpExchange.getResponseHeaders().set("Content-Type", "text/html; charset=UTF-8");
+        httpExchange.sendResponseHeaders(200, responseBytes.length);
         OutputStream os = httpExchange.getResponseBody();
-        os.write(response.getBytes("UTF-8"));
+        os.write(responseBytes);
         os.close();
     }
 


### PR DESCRIPTION
This PR fixes issue https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/492.

So the error happened because in `send200Response` it was setting the response length using the length of the string. This is incorrect as it should be set using the length of the response string's byte array. We also need to specify/set encoding in the response header. Otherwise by default it will decode using iso_8859_1.