### PR TITLE
Bump com.nimbusds.oauth2-oidc-sdk from 9.32 to 9.35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>9.32</version>
+            <version>9.35</version>
         </dependency>
         <dependency>
             <groupId>net.minidev</groupId>


### PR DESCRIPTION
- initially from oauth2-oidc-sdk 9.32 (inc nimbus-jose-jwt 9.21)
- to oauth2-oidc-sdk 9.35 (inc nimbus-jose-jwt 9.22)

- note: more recent versions are available (subject to MSAL for Java compatibility and tests)