### PR TITLE
fix: added Automatic-Module-Name to MANIFEST.MF

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,1 +1,2 @@
 Export-Package: com.microsoft.aad.msal4j
+Automatic-Module-Name: msal4j


### PR DESCRIPTION
When the Automatic-Module-Name entry is not added to the jar's
manifest file, Maven issues a warning during the compilation of a
project that uses that jar.

Maven issues following warning:
"Required filename-based automodules detected: [msal4j-1.13.0.jar].
Please don't publish this project to a public artifact repository!"

Currently, only a warning is generated. However, this might cause
problems in the future, especially when a project embraces the
Java Platform Module System (JPMS).

Fixes #525 