### PR TITLE
Configurable timeout for InteractiveRequestParameters

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
@@ -86,6 +86,12 @@ public class InteractiveRequestParameters implements IAcquireTokenParameters {
     private String tenant;
 
     /**
+     * Overrides the default polling timeout value for this request, which is infinite
+     */
+    @Builder.Default
+    private int httpPollingTimeout = -1;
+
+    /**
      * If set to true, the authorization result will contain the authority for the user's home cloud, and this authority
      * will be used for the token request instead of the authority set in the application.
      */


### PR DESCRIPTION
Current polling timeout for login is hardcoded to 120s. This change allows the timeout to be configured via the InteractiveRequestParametersBuilder. Fixes #532.

Looking for suggestions on how to test this code.