### PR TITLE
Allow interactive request timeout to be configurable

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByInteractiveFlowSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByInteractiveFlowSupplier.java
@@ -124,8 +124,11 @@ class AcquireTokenByInteractiveFlowSupplier extends AuthenticationResultSupplier
     private AuthorizationResult getAuthorizationResultFromHttpListener() {
         AuthorizationResult result = null;
         try {
-            LOG.debug("Listening for authorization result");
-            long expirationTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) + 120;
+            LOG.debug(String.format("Listening for authorization result. Listener will timeout after %S seconds.",
+                    interactiveRequest.interactiveRequestParameters().httpPollingTimeoutInSeconds()));
+
+            long expirationTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) +
+                    interactiveRequest.interactiveRequestParameters().httpPollingTimeoutInSeconds();
 
             while (result == null && !interactiveRequest.futureReference().get().isCancelled() &&
                     TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) < expirationTime) {

--- a/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByInteractiveFlowSupplier.java
+++ b/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByInteractiveFlowSupplier.java
@@ -124,11 +124,16 @@ class AcquireTokenByInteractiveFlowSupplier extends AuthenticationResultSupplier
     private AuthorizationResult getAuthorizationResultFromHttpListener() {
         AuthorizationResult result = null;
         try {
-            LOG.debug(String.format("Listening for authorization result. Listener will timeout after %S seconds.",
-                    interactiveRequest.interactiveRequestParameters().httpPollingTimeoutInSeconds()));
+            int timeFromParameters = interactiveRequest.interactiveRequestParameters().httpPollingTimeoutInSeconds();
+            long expirationTime;
 
-            long expirationTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) +
-                    interactiveRequest.interactiveRequestParameters().httpPollingTimeoutInSeconds();
+            if (timeFromParameters > 0) {
+                LOG.debug(String.format("Listening for authorization result. Listener will timeout after %S seconds.", timeFromParameters));
+                expirationTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) + timeFromParameters;
+            } else {
+                LOG.warn("Listening for authorization result. Timeout configured to less than 1 second, listener will use a 1 second timeout instead.");
+                expirationTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) + 1;
+            }
 
             while (result == null && !interactiveRequest.futureReference().get().isCancelled() &&
                     TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) < expirationTime) {

--- a/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
@@ -86,6 +86,14 @@ public class InteractiveRequestParameters implements IAcquireTokenParameters {
     private String tenant;
 
     /**
+     * Overrides the polling timeout value for this request, which by default is 120 seconds
+     *
+     * If this timeout is set to 0 or less, polling will end immediately
+     */
+    @Builder.Default
+    private int httpPollingTimeoutInSeconds = 120;
+
+    /**
      * If set to true, the authorization result will contain the authority for the user's home cloud, and this authority
      * will be used for the token request instead of the authority set in the application.
      */

--- a/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
+++ b/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
@@ -86,9 +86,10 @@ public class InteractiveRequestParameters implements IAcquireTokenParameters {
     private String tenant;
 
     /**
-     * Overrides the polling timeout value for this request, which by default is 120 seconds
+     * The amount of time in seconds that the library will wait for an authentication result. 120 seconds is the default timeout,
+     * unless overridden here with some other positive integer
      *
-     * If this timeout is set to 0 or less, polling will end immediately
+     * If this timeout is set to 0 or less it will be ignored, and the library will use a 1 second timeout instead
      */
     @Builder.Default
     private int httpPollingTimeoutInSeconds = 120;


### PR DESCRIPTION
Add a new field `httpPollingTimeoutInSeconds` to `InteractiveRequestParameters` to allow an app developer to override the timeout for receiving an auth result. Previously the timeout was hardcoded to 120 seconds, but 120 seconds is now just the default. Also adjusts the logging to include the timeout value.

This addresses the request from https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/532, and adds the same core functionality as in https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/533