### PR TITLE
Allow PKCS12 certificates to have non-privatekey aliases

### DIFF
--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClientCertificatePkcs12Test.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClientCertificatePkcs12Test.java
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import org.easymock.EasyMock;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.security.KeyStore;
+import java.security.KeyStoreSpi;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+@Test
+public class ClientCertificatePkcs12Test extends AbstractMsalTests {
+
+    private KeyStoreSpi keyStoreSpi;
+    private KeyStore keystore;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        keyStoreSpi = EasyMock.createMock(KeyStoreSpi.class);
+        keystore = new KeyStore(keyStoreSpi, null, "PKCS12") {};
+        keystore.load(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "certificate not loaded from input stream")
+    public void testNoEntries() throws Exception {
+        EasyMock.expect(keyStoreSpi.engineAliases())
+                .andReturn(Collections.enumeration(Collections.emptyList())).times(1);
+        EasyMock.replay(keyStoreSpi);
+
+        ClientCertificate.getPrivateKeyAlias(keystore);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "certificate not loaded from input stream")
+    public void testNoPrivateKey() throws Exception {
+        EasyMock.expect(keyStoreSpi.engineAliases())
+                .andReturn(Collections.enumeration(Arrays.asList("CA_cert1", "CA_cert2"))).times(1);
+        EasyMock.expect(keyStoreSpi.engineEntryInstanceOf("CA_cert1", KeyStore.PrivateKeyEntry.class)).andReturn(false).times(1);
+        EasyMock.expect(keyStoreSpi.engineEntryInstanceOf("CA_cert2", KeyStore.PrivateKeyEntry.class)).andReturn(false).times(1);
+        EasyMock.replay(keyStoreSpi);
+
+        ClientCertificate.getPrivateKeyAlias(keystore);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "more than one certificate alias found in input stream")
+    public void testMultiplePrivateKeyAliases() throws Exception {
+        EasyMock.expect(keyStoreSpi.engineAliases())
+                .andReturn(Collections.enumeration(Arrays.asList("private_key1", "private_key2", "CA_cert"))).times(1);
+        EasyMock.expect(keyStoreSpi.engineEntryInstanceOf("private_key1", KeyStore.PrivateKeyEntry.class)).andReturn(true).times(1);
+        EasyMock.expect(keyStoreSpi.engineEntryInstanceOf("private_key2", KeyStore.PrivateKeyEntry.class)).andReturn(true).times(1);
+        EasyMock.expect(keyStoreSpi.engineEntryInstanceOf("CA_cert", KeyStore.PrivateKeyEntry.class)).andReturn(false).times(1);
+        EasyMock.replay(keyStoreSpi);
+
+        ClientCertificate.getPrivateKeyAlias(keystore);
+    }
+
+    @Test
+    public void testMultipleEntriesButOnlyOnePrivateKey() throws Exception {
+        EasyMock.expect(keyStoreSpi.engineAliases())
+                .andReturn(Collections.enumeration(Arrays.asList("CA_cert1", "private_key", "CA_cert2"))).times(1);
+        EasyMock.expect(keyStoreSpi.engineEntryInstanceOf("CA_cert1", KeyStore.PrivateKeyEntry.class)).andReturn(false).times(1);
+        EasyMock.expect(keyStoreSpi.engineEntryInstanceOf("private_key", KeyStore.PrivateKeyEntry.class)).andReturn(true).times(1);
+        EasyMock.expect(keyStoreSpi.engineEntryInstanceOf("CA_cert2", KeyStore.PrivateKeyEntry.class)).andReturn(false).times(1);
+        EasyMock.replay(keyStoreSpi);
+
+        String privateKeyAlias = ClientCertificate.getPrivateKeyAlias(keystore);
+        assertEquals("private_key", privateKeyAlias);
+    }
+
+}


### PR DESCRIPTION
Currently, when creating a client certificate using a PKCS12 certificate our library would throw an exception if there was more than 1 alias. However, what we should really be checking is if there is 1 alias for a private key, and just ignore aliases for things like CA certs.

This PR has the same changes as https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/527, and allows PKCS12 certs to be accepted even if they have non-privatekey aliases (we just put the fix made by @agostonbarna in a new PR to make the merge easier, since our library has gone through a directory restructuring since the original PR)