### PR TITLE
compatability for jpackaged modular applications

### DIFF
--- a/msal4j-sdk/bnd.bnd
+++ b/msal4j-sdk/bnd.bnd
@@ -1,2 +1,4 @@
 Export-Package: com.microsoft.aad.com.microsoft.aad.msal4j
 Automatic-Module-Name: com.microsoft.aad.msal4j
+
+-fixupmessages: \ "Classes found in the wrong directory...";is:=warning

--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -308,14 +308,16 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.8</version>
-                <configuration>
-                    <instructions>
-                        <_fixupmessages>"Classes found in the wrong directory";is:=warning</_fixupmessages>
-                    </instructions>
-                </configuration>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>6.3.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.6</version>
+            <version>1.18.24</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -161,7 +161,7 @@
             <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>
-                <version>1.18.2.0</version>
+                <version>1.18.20.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -179,9 +179,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.2.0</version>
                 <configuration>
                     <archive>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
@@ -236,11 +239,41 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
+                <version>3.10.1</version>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <release>9</release>
+                        </configuration>
+                    </execution> <execution>
+                    <id>default-compile</id>
+                    <goals>
+                        <goal>compile</goal>
+                    </goals>
+                    <configuration>
+                        <source>8</source>
+                        <target>8</target>
+                    </configuration>
+                </execution>
+                    <execution>
+                        <id>compile-java-9</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>9</release>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+                            </compileSourceRoots>
+                            <multiReleaseOutput>true</multiReleaseOutput>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -275,16 +308,14 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-maven-plugin</artifactId>
-                <version>4.3.1</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>bnd-process</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.8</version>
+                <configuration>
+                    <instructions>
+                        <_fixupmessages>"Classes found in the wrong directory";is:=warning</_fixupmessages>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/msal4j-sdk/src/main/java9/com/microsoft/aad/msal4j/HttpHeaders.java
+++ b/msal4j-sdk/src/main/java9/com/microsoft/aad/msal4j/HttpHeaders.java
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.Optional;
+import java.lang.module.ModuleDescriptor;
+
+final class HttpHeaders {
+
+    static final String PRODUCT_HEADER_NAME = "x-client-SKU";
+    static final String PRODUCT_HEADER_VALUE = "MSAL.Java";
+
+    static final String PRODUCT_VERSION_HEADER_NAME = "x-client-VER";
+    static final String PRODUCT_VERSION_HEADER_VALUE = getProductVersion();
+
+    static final String CPU_HEADER_NAME = "x-client-CPU";
+    static final String CPU_HEADER_VALUE = System.getProperty("os.arch");
+
+    static final String OS_HEADER_NAME = "x-client-OS";
+    static final String OS_HEADER_VALUE = System.getProperty("os.name");
+
+    static final String APPLICATION_NAME_HEADER_NAME = "x-app-name";
+    private final String applicationNameHeaderValue;
+
+    static final String APPLICATION_VERSION_HEADER_NAME = "x-app-ver";
+    private final String applicationVersionHeaderValue;
+
+    static final String CORRELATION_ID_HEADER_NAME = "client-request-id";
+    private final String correlationIdHeaderValue;
+
+    private static final String REQUEST_CORRELATION_ID_IN_RESPONSE_HEADER_NAME = "return-client-request-id";
+    private static final String REQUEST_CORRELATION_ID_IN_RESPONSE_HEADER_VALUE = "true";
+
+    private static final String X_MS_LIB_CAPABILITY_NAME = "x-ms-lib-capability";
+    private static final String X_MS_LIB_CAPABILITY_VALUE = "retry-after, h429";
+
+    // Used for CCS routing
+    static final String X_ANCHOR_MAILBOX = "X-AnchorMailbox";
+    static final String X_ANCHOR_MAILBOX_OID_FORMAT = "oid:%s";
+    static final String X_ANCHOR_MAILBOX_UPN_FORMAT = "upn:%s";
+    private String anchorMailboxHeaderValue = null;
+
+    private String headerValues;
+    private Map<String, String> headerMap = new HashMap<>();
+
+    HttpHeaders(final RequestContext requestContext) {
+        correlationIdHeaderValue = requestContext.correlationId();
+        applicationNameHeaderValue = requestContext.applicationName();
+        applicationVersionHeaderValue = requestContext.applicationVersion();
+
+        if (requestContext.userIdentifier() != null) {
+            String upn = requestContext.userIdentifier().upn();
+            String oid = requestContext.userIdentifier().oid();
+            if (!StringHelper.isBlank(upn)) {
+                anchorMailboxHeaderValue = String.format(X_ANCHOR_MAILBOX_UPN_FORMAT, upn);
+            } else if (!StringHelper.isBlank(oid)) {
+                anchorMailboxHeaderValue = String.format(X_ANCHOR_MAILBOX_OID_FORMAT, oid);
+            }
+        }
+
+        Map<String, String> extraHttpHeaders = requestContext.apiParameters() == null ?
+                null :
+                requestContext.apiParameters().extraHttpHeaders();
+        this.initializeHeaders(extraHttpHeaders);
+    }
+
+    private void initializeHeaders(Map<String, String> extraHttpHeaders) {
+        StringBuilder sb = new StringBuilder();
+
+        BiConsumer<String, String> init = (String key, String val) -> {
+            headerMap.put(key, val);
+            sb.append(key).append("=").append(val).append(";");
+        };
+
+        init.accept(PRODUCT_HEADER_NAME, PRODUCT_HEADER_VALUE);
+        init.accept(PRODUCT_VERSION_HEADER_NAME, PRODUCT_VERSION_HEADER_VALUE);
+        init.accept(OS_HEADER_NAME, OS_HEADER_VALUE);
+        init.accept(CPU_HEADER_NAME, CPU_HEADER_VALUE);
+        init.accept(REQUEST_CORRELATION_ID_IN_RESPONSE_HEADER_NAME, REQUEST_CORRELATION_ID_IN_RESPONSE_HEADER_VALUE);
+        init.accept(CORRELATION_ID_HEADER_NAME, this.correlationIdHeaderValue);
+
+        if (!StringHelper.isBlank(this.applicationNameHeaderValue)) {
+            init.accept(APPLICATION_NAME_HEADER_NAME, this.applicationNameHeaderValue);
+        }
+        if (!StringHelper.isBlank(this.applicationVersionHeaderValue)) {
+            init.accept(APPLICATION_VERSION_HEADER_NAME, this.applicationVersionHeaderValue);
+        }
+        if (!StringHelper.isBlank(this.anchorMailboxHeaderValue)) {
+            init.accept(X_ANCHOR_MAILBOX, this.anchorMailboxHeaderValue);
+        }
+
+        init.accept(X_MS_LIB_CAPABILITY_NAME, X_MS_LIB_CAPABILITY_VALUE);
+
+        if (extraHttpHeaders != null) {
+            extraHttpHeaders.forEach(init);
+        }
+
+        this.headerValues = sb.toString();
+    }
+
+    Map<String, String> getReadonlyHeaderMap() {
+        return Collections.unmodifiableMap(this.headerMap);
+    }
+
+    String getHeaderCorrelationIdValue() {
+        return this.correlationIdHeaderValue;
+    }
+
+    @Override
+    public String toString() {
+        return this.headerValues;
+    }
+
+    private static String getProductVersion() {
+        return Optional
+                .ofNullable(HttpHeaders.class.getModule().getDescriptor())
+                .flatMap(ModuleDescriptor::version)
+                .map(ModuleDescriptor.Version::toString)
+                .orElse("1.0");
+    }
+}


### PR DESCRIPTION
In order to use IWA in a jpackaged modular application that runs on a current JVM (e.g. 17), I propose these changes to be merged.

### Problem
MSAL4J uses
```
private static String getProductVersion() {
   if (HttpHeaders.class.getPackage().getImplementationVersion() == null) {
      return "1.0";
   }
   return HttpHeaders.class.getPackage().getImplementationVersion();
}
```
in `com.microsoft.aad.msal4j.HttpHeaders` to set the header value for  `x-client-VER`.

However, if it's set to `"1.0"` IWA fails with
`Execution of class com.microsoft.aad.msal4j.AcquireTokenByAuthorizationGrantSupplier failed. com.microsoft.aad.msal4j.MsalClientException: Password is required for managed user`
See also: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/1860

This is an issue because **`Package#getImplementationVersion` returns null in a jpackaged modular application**.

### Solution
From Java 9 onwards, [ModuleDescriptor.Version](https://docs.oracle.com/javase/9/docs/api/java/lang/module/ModuleDescriptor.Version.html) can be used to do pretty much the same. Therefore, I have set up a multi release jar build, with JVM 9+ using ModuleDescriptor.
For this to work, a few plugins needed to be updated (see pom).

### Restrictions
Due to _bnd_ not yet properly supporting multi release jars, I used `fixupmessages` as suggested in the related issue https://github.com/bndtools/bnd/issues/2227.
Errors like this one: https://github.com/projectlombok/lombok/issues/2681 made me build the project on _jdk-11.0.16.1+1_.
Furthermore, I skipped the _javadoc_ task - due to this bug https://issues.apache.org/jira/browse/MJAVADOC-586 / https://bugs.openjdk.org/browse/JDK-8220702.

**All in all, a `mvn clean package -Dmaven.javadoc.skip=true` should run on _jdk-11.0.16.1+1_.**

### Workaround for the meantime
We can exploit that extra headers passed to the builder will be passed through to HttpHeaders [and eventually override already set headers](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/050d188adcb2e27597d5e097dfc225a1e9ad74d6/src/main/java/com/microsoft/aad/msal4j/HttpHeaders.java#L97). This is not a solution, but a temporary workaround, as it relies on an implementation detail that might change some day!
In code:
```
IntegratedWindowsAuthenticationParameters.builder(...)
   .tenant(...)
   .extraHttpHeaders(getExtraHeaders())
   .build();
```
with something like
```
private Map<String, String> getExtraHeaders() {
	Optional<ModuleDescriptor.Version> version = IAuthenticationResult.class.getModule().getDescriptor().version();
	Map<String, String> extraHeaders =
		Map.of(
			"x-client-VER",
			version.map(ModuleDescriptor.Version::toString).orElse(TESTED_MSAL4J_X_CLIENT_VER_STRING)
		);
	return extraHeaders;
}
```