### PR TITLE
Add support for both current and legacy B2C authority formats

### DIFF
--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenInteractiveIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenInteractiveIT.java
@@ -74,7 +74,15 @@ public class AcquireTokenInteractiveIT extends SeleniumTest {
         cfg = new Config(environment);
 
         User user = labUserProvider.getB2cUser(cfg.azureEnvironment, B2CProvider.LOCAL);
-        assertAcquireTokenB2C(user);
+        assertAcquireTokenB2C(user, TestConstants.B2C_AUTHORITY);
+    }
+
+    @Test(dataProvider = "environments", dataProviderClass = EnvironmentsProvider.class)
+    public void acquireTokenWithAuthorizationCode_B2C_LegacyFormat(String environment) {
+        cfg = new Config(environment);
+
+        User user = labUserProvider.getB2cUser(cfg.azureEnvironment, B2CProvider.LOCAL);
+        assertAcquireTokenB2C(user, TestConstants.B2C_AUTHORITY_LEGACY_FORMAT);
     }
 
     @Test
@@ -126,13 +134,13 @@ public class AcquireTokenInteractiveIT extends SeleniumTest {
         Assert.assertEquals(user.getUpn(), result.account().username());
     }
 
-    private void assertAcquireTokenB2C(User user) {
+    private void assertAcquireTokenB2C(User user, String authority) {
 
         PublicClientApplication pca;
         try {
             pca = PublicClientApplication.builder(
                     user.getAppId()).
-                    b2cAuthority(TestConstants.B2C_AUTHORITY_SIGN_IN).
+                    b2cAuthority(authority + TestConstants.B2C_SIGN_IN_POLICY).
                     build();
         } catch (MalformedURLException ex) {
             throw new RuntimeException(ex.getMessage());

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
@@ -38,8 +38,8 @@ public class TestConstants {
     public final static String ARLINGTON_GRAPH_DEFAULT_SCOPE = "https://graph.microsoft.us/.default";
 
 
-    public final static String B2C_AUTHORITY = "https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/";
-    public final static String B2C_AUTHORITY_URL = "https://msidlabb2c.b2clogin.com/msidlabb2c.onmicrosoft.com/";
+    public final static String B2C_AUTHORITY = "https://msidlabb2c.b2clogin.com/msidlabb2c.onmicrosoft.com/";
+    public final static String B2C_AUTHORITY_LEGACY_FORMAT = "https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/";
     public final static String B2C_ROPC_POLICY = "B2C_1_ROPC_Auth";
     public final static String B2C_SIGN_IN_POLICY = "B2C_1_SignInPolicy";
     public final static String B2C_AUTHORITY_SIGN_IN = B2C_AUTHORITY + B2C_SIGN_IN_POLICY;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
@@ -373,6 +373,18 @@ public abstract class AbstractClientApplicationBase implements IClientApplicatio
             return self();
         }
 
+        /**
+         * Set URL of the authenticating B2C authority from which MSAL will acquire tokens
+         *
+         * Valid B2C authorities should look like: https://<something>.b2clogin.com/<tenant>/<policy>
+         *
+         * MSAL Java also supports a legacy B2C authority format, which looks like: https://<host>/tfp/<tenant>/<policy>
+         *
+         * However, MSAL Java will eventually stop supporting the legacy format. See here for information on how to migrate to the new format: https://aka.ms/msal4j-b2c
+         *
+         * @param val a boolean value for validateAuthority
+         * @return instance of the Builder on which method was called
+         */
         public T b2cAuthority(String val) throws MalformedURLException {
             authority = Authority.enforceTrailingSlash(val);
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
@@ -376,9 +376,9 @@ public abstract class AbstractClientApplicationBase implements IClientApplicatio
         /**
          * Set URL of the authenticating B2C authority from which MSAL will acquire tokens
          *
-         * Valid B2C authorities should look like: https://<something>.b2clogin.com/<tenant>/<policy>
+         * Valid B2C authorities should look like: https://&lt;something.b2clogin.com/&lt;tenant&gt;/&lt;policy&gt;
          *
-         * MSAL Java also supports a legacy B2C authority format, which looks like: https://<host>/tfp/<tenant>/<policy>
+         * MSAL Java also supports a legacy B2C authority format, which looks like: https://&lt;host&gt;/tfp/&lt;tenant&gt;/&lt;policy&gt;
          *
          * However, MSAL Java will eventually stop supporting the legacy format. See here for information on how to migrate to the new format: https://aka.ms/msal4j-b2c
          *

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Authority.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Authority.java
@@ -20,6 +20,7 @@ abstract class Authority {
 
     private static final String ADFS_PATH_SEGMENT = "adfs";
     private static final String B2C_PATH_SEGMENT = "tfp";
+    private static final String B2C_HOST_SEGMENT = "b2clogin.com";
 
     private final static String USER_REALM_ENDPOINT = "common/userrealm";
     private final static String userRealmEndpointFormat = "https://%s/" + USER_REALM_ENDPOINT + "/%s?api-version=1.0";
@@ -79,9 +80,10 @@ abstract class Authority {
                     "authority Uri should have at least one segment in the path (i.e. https://<host>/<path>/...)");
         }
 
+        final String host = authorityUrl.getHost();
         final String firstPath = path.substring(0, path.indexOf("/"));
 
-        if (isB2CAuthority(firstPath)) {
+        if (isB2CAuthority(host, firstPath)) {
             return AuthorityType.B2C;
         } else if (isAdfsAuthority(firstPath)) {
             return AuthorityType.ADFS;
@@ -131,7 +133,11 @@ abstract class Authority {
     static String getTenant(URL authorityUrl, AuthorityType authorityType) {
         String[] segments = authorityUrl.getPath().substring(1).split("/");
         if (authorityType == AuthorityType.B2C) {
-            return segments[1];
+            if (segments.length < 3){
+                return segments[0];
+            } else {
+                return segments[1];
+            }
         }
         return segments[0];
     }
@@ -144,8 +150,8 @@ abstract class Authority {
         return firstPath.compareToIgnoreCase(ADFS_PATH_SEGMENT) == 0;
     }
 
-    private static boolean isB2CAuthority(final String firstPath) {
-        return firstPath.compareToIgnoreCase(B2C_PATH_SEGMENT) == 0;
+    private static boolean isB2CAuthority(final String host, final String firstPath) {
+        return host.contains(B2C_HOST_SEGMENT) || firstPath.compareToIgnoreCase(B2C_PATH_SEGMENT) == 0;
     }
 
     String deviceCodeEndpoint() {

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AuthorityTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AuthorityTest.java
@@ -36,9 +36,9 @@ public class AuthorityTest extends AbstractMsalTests {
 
     @Test(expectedExceptions = IllegalArgumentException.class,
             expectedExceptionsMessageRegExp =
-                    "B2C 'authority' Uri should have at least 3 segments in the path \\(i.e. https://<host>/tfp/<tenant>/<policy>/...\\)")
+                    "Valid B2C 'authority' URLs should follow either of these formats.*")
     public void testB2CAuthorityConstructor_NotEnoughSegments() throws MalformedURLException {
-        new B2CAuthority(new URL("https://something.com/tfp/somethingelse/"));
+        new B2CAuthority(new URL("https://something.com/somethingelse/"));
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "authority should use the 'https' scheme")


### PR DESCRIPTION
Originally, MSALs needed B2C URLs to contain 'tfp' in the path to identify them as B2C authorities, so they needed to look like: `https://<some host>/tfp/<tenant>/<policy>`

However, some recent changes to B2C should ensure that all URLs have 'b2cloginc.com' as part of the host, so current B2C authorities should look like: `https://<something>.b2clogin.com/<tenant>/<policy>`

This PR adds support for the newer format, while retaining support for the legacy format until we're either confident that all customers have been moved to the new format (due to future potential Azure requirements) or we're able to make a breaking change (i.e., we're releasing MSAL Java 2.0)