### PR TITLE
Use the dedicated admin consent endpoint instead of a query parameter

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
@@ -34,6 +34,9 @@ public class AuthorizationRequestUrlParameters {
     private String correlationId;
     private boolean instanceAware;
 
+    //Unlike other prompts (which are sent as query parameters), admin consent has its own endpoint format
+    private static final String ADMIN_CONSENT_ENDPOINT = "https://login.microsoftonline.com/{tenant}/adminconsent";
+
     Map<String, List<String>> requestParameters = new HashMap<>();
 
     public static Builder builder(String redirectUri,
@@ -155,7 +158,14 @@ public class AuthorizationRequestUrlParameters {
                                Map<String, List<String>> requestParameters) {
         URL authorizationRequestUrl;
         try {
-            String authorizationCodeEndpoint = authority.authorizationEndpoint();
+            String authorizationCodeEndpoint;
+            if (prompt == Prompt.ADMIN_CONSENT) {
+                authorizationCodeEndpoint = ADMIN_CONSENT_ENDPOINT
+                        .replace("{tenant}", authority.tenant);
+            } else {
+                authorizationCodeEndpoint = authority.authorizationEndpoint();
+            }
+
             String uriString = authorizationCodeEndpoint + "?" +
                     URLUtils.serializeParameters(requestParameters);
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Prompt.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Prompt.java
@@ -27,14 +27,6 @@ public enum Prompt {
 
     /**
      * An administrator should be prompted to consent on behalf of all users in their organization.
-     * <p>
-     * Deprecated, instead use Prompt.ADMIN_CONSENT
-     */
-    @Deprecated
-    ADMING_CONSENT("admin_consent"),
-
-    /**
-     * An administrator should be prompted to consent on behalf of all users in their organization.
      */
     ADMIN_CONSENT("admin_consent"),
 


### PR DESCRIPTION
As found in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/581, admin_consent is no longer valid for the 'prompt' query parameter, and instead there is a specific endpoint to send admin consent requests

This PR adjusts the way the authorization URL is built in order to use the dedicated endpoint, as well as remove the misspelled "adming_consent" Prompt enum value which has been deprecated for ~2 years