### PR TITLE
APIs for toggling MSALRuntime's logging

### DIFF
--- a/msal4j-brokers/src/main/java/com/microsoft/aad/msal4jbrokers/MsalRuntimeBroker.java
+++ b/msal4j-brokers/src/main/java/com/microsoft/aad/msal4jbrokers/MsalRuntimeBroker.java
@@ -187,7 +187,7 @@ public class MsalRuntimeBroker implements IBroker {
      *
      * @param enableLogging true to enable MSALRuntime logs, false to disable it
      */
-    public void toggleLogging(boolean enableLogging) {
+    public void enableBrokerLogging(boolean enableLogging) {
         try {
             MsalRuntimeInterop.toggleMsalRuntimeLogging(enableLogging);
         } catch (Exception ex) {
@@ -202,7 +202,7 @@ public class MsalRuntimeBroker implements IBroker {
      *
      * @param enablePII true to allow PII to appear in logs and error messages, false to disallow it
      */
-    public void togglePII(boolean enablePII) {
+    public void enableBrokerPIILogging(boolean enablePII) {
         try {
             MsalRuntimeInterop.toggleMsalRuntimePIILogging(enablePII);
         } catch (Exception ex) {

--- a/msal4j-brokers/src/main/java/com/microsoft/aad/msal4jbrokers/MsalRuntimeBroker.java
+++ b/msal4j-brokers/src/main/java/com/microsoft/aad/msal4jbrokers/MsalRuntimeBroker.java
@@ -176,4 +176,37 @@ public class MsalRuntimeBroker implements IBroker {
             return false;
         }
     }
+
+    /**
+     * Toggles whether or not detailed MSALRuntime logs will appear in MSAL Java's normal logging framework.
+     *
+     * If enabled, you will see logs directly from MSALRuntime, containing verbose information relating to telemetry, API calls,successful/failed requests, and more.
+     * These logs will appear alongside MSAL Java's logs (with a message indicating they came from MSALRuntime), and will follow the same log level as MSAL Java's logs (info/debug/error/etc.).
+     *
+     * If disabled (default), MSAL Java will still produce some logs related to MSALRuntime, particularly in error messages, but will be much less verbose.
+     *
+     * @param enableLogging true to enable MSALRuntime logs, false to disable it
+     */
+    public void toggleLogging(boolean enableLogging) {
+        try {
+            MsalRuntimeInterop.toggleMsalRuntimeLogging(enableLogging);
+        } catch (Exception ex) {
+            throw new MsalClientException(String.format("Error occurred when calling MSALRuntime logging API: %s", ex.getMessage()), AuthenticationErrorCode.MSALRUNTIME_INTEROP_ERROR);
+        }
+    }
+
+    /**
+     * If enabled, Personal Identifiable Information (PII) can appear in logs and error messages produced by MSALRuntime.
+     *
+     * If disabled (default), PII will not be shown, and you will simply see "(PII)" or similar notes in places where PII data would have appeared.
+     *
+     * @param enablePII true to allow PII to appear in logs and error messages, false to disallow it
+     */
+    public void togglePII(boolean enablePII) {
+        try {
+            MsalRuntimeInterop.toggleMsalRuntimePIILogging(enablePII);
+        } catch (Exception ex) {
+            throw new MsalClientException(String.format("Error occurred when calling MSALRuntime PII logging API: %s", ex.getMessage()), AuthenticationErrorCode.MSALRUNTIME_INTEROP_ERROR);
+        }
+    }
 }


### PR DESCRIPTION
MSALRuntime allows logging and PII data to be toggled on and off, however in MSAL Java these are not toggleable: logging is always enabled through SLF4J, and PII is set once [when the client app is made](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/dev/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java#L55).

Making these toggleable in MSAL Java would require either a breaking change, or a parallel set of logging APIs that would be confusing or useless to anyone not using the broker. 

Because of that, this PR adds new APIs to the broker package, allowing app developers to configure MSALRuntime's logging separately from MSAL Java's. In enabled, app developers will see MSALRuntime's verbose logs through the SLF4J framework in the same way they see MSAL Java's logs.