### PR TITLE
Better redirect URI error handling and dependency upgrade

### DIFF
--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>9.35</version>
+            <version>10.7.1</version>
         </dependency>
         <dependency>
             <groupId>net.minidev</groupId>

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/InteractiveRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/InteractiveRequest.java
@@ -63,7 +63,7 @@ class InteractiveRequest extends MsalRequest {
         //Validate URI scheme. Only http is valid, as determined by the HttpListener created in AcquireTokenByInteractiveFlowSupplier.startHttpListener()
         if (scheme == null || !scheme.equals("http")) {
             throw new MsalClientException(String.format(
-                    "Only http is supported for the redirect URI of an interactive request, but \"%s\" was found. For more information about redirect URI formats, see https://aka.ms/msal4j-interactive-request", scheme),
+                    "Only http://localhost or http://localhost:port is supported for the redirect URI of an interactive request using a browser, but \"%s\" was found. For more information about redirect URI formats, see https://aka.ms/msal4j-interactive-request", scheme),
                     AuthenticationErrorCode.LOOPBACK_REDIRECT_URI);
         }
 


### PR DESCRIPTION
Improves the error handling for redirect URIs in an interactive request.

Original error handling led to null pointers and unhelpful exception messages if `InteractiveRequestParameters` wasn't configured with a valid redirect URI, but now error messages have more context about the exact issue and a link for more information.

Additionally bumps the version of oauth2-oidc-sdk to hopefully resolve the transitive dependency issues mentioned in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/611