### PR TITLE
Update CIAM tests

### DIFF
--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
@@ -13,6 +13,7 @@ public class TestConstants {
     public final static String MSIDLAB_VAULT_URL = "https://msidlabs.vault.azure.net/";
     public final static String GRAPH_DEFAULT_SCOPE = "https://graph.windows.net/.default";
     public final static String USER_READ_SCOPE = "user.read";
+    public final static String DEFAULT_SCOPE = ".default";
     public final static String B2C_LAB_SCOPE = "https://msidlabb2c.onmicrosoft.com/msaapp/user_impersonation";
     public final static String B2C_CONFIDENTIAL_CLIENT_APP_SECRETID = "MSIDLABB2C-MSAapp-AppSecret";
     public final static String B2C_CONFIDENTIAL_CLIENT_LAB_APP_ID = "MSIDLABB2C-MSAapp-AppID";

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/UsernamePasswordIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/UsernamePasswordIT.java
@@ -119,6 +119,27 @@ class UsernamePasswordIT {
                 user.getAppId());
     }
 
+    @Test
+    void acquireTokenWithUsernamePassword_Ciam() throws Exception {
+
+        Map<String, String> extraQueryParameters = new HashMap<>();
+
+        User user = labUserProvider.getCiamUser();
+        PublicClientApplication pca = PublicClientApplication.builder(user.getAppId())
+                .authority("https://" + user.getLabName() + ".ciamlogin.com/")
+                .build();
+
+
+        IAuthenticationResult result = pca.acquireToken(UserNamePasswordParameters.
+                        builder(Collections.singleton(TestConstants.USER_READ_SCOPE),
+                                user.getUpn(),
+                                user.getPassword().toCharArray())
+                        .extraQueryParameters(extraQueryParameters)
+                        .build())
+                .get();
+
+        assertNotNull(result.accessToken());
+    }
 
     private void assertAcquireTokenCommonAAD(User user) throws Exception {
         assertAcquireTokenCommon(user, cfg.organizationsAuthority(), cfg.graphDefaultScope(),

--- a/msal4j-sdk/src/integrationtest/java/labapi/LabConstants.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/LabConstants.java
@@ -14,7 +14,7 @@ public class LabConstants {
     public final static String USER_MSA_USERNAME_URL = "https://msidlabs.vault.azure.net/secrets/MSA-MSIDLAB4-UserName";
     public final static String USER_MSA_PASSWORD_URL = "https://msidlabs.vault.azure.net/secrets/MSA-MSIDLAB4-Password";
     public final static String OBO_APP_PASSWORD_URL = "https://msidlabs.vault.azure.net/secrets/TodoListServiceV2-OBO";
-    public final static String CIAM_KEY_VAULT_SECRET_KEY = "https://msidlabs.vault.azure.net/secrets/MSIDLABCIAM1-cc";
+    public final static String CIAM_KEY_VAULT_SECRET_KEY = "https://msidlabs.vault.azure.net/secrets/MSIDLABCIAM2-cc";
 
     public final static String ARLINGTON_APP_ID = "cb7faed4-b8c0-49ee-b421-f5ed16894c83";
     public final static String ARLINGTON_OBO_APP_ID = "c0555d2d-02f2-4838-802e-3463422e571d";


### PR DESCRIPTION
Re-adds the CIAM tests that were failing and removed during the test framework update. The main causes of failure seemed to be the change from MSIDLABCIAM1 to MSIDLABCIAM2 and the use of .default scope instead of the simpler user.read