### PR TITLE
Cache improvements

### DIFF
--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenSilentIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenSilentIT.java
@@ -69,6 +69,10 @@ class AcquireTokenSilentIT {
         // Check that access and id tokens are coming from cache
         assertEquals(result.accessToken(), acquireSilentResult.accessToken());
         assertEquals(result.idToken(), acquireSilentResult.idToken());
+        assertEquals(TokenSource.IDENTITY_PROVIDER, result.metadata().tokenSource());
+        assertEquals(CacheRefreshReason.NOT_APPLICABLE, result.metadata().cacheRefreshReason());
+        assertEquals(TokenSource.CACHE, acquireSilentResult.metadata().tokenSource());
+        assertEquals(CacheRefreshReason.NOT_APPLICABLE, acquireSilentResult.metadata().cacheRefreshReason());
     }
 
     @ParameterizedTest
@@ -92,6 +96,10 @@ class AcquireTokenSilentIT {
 
         // Check that new refresh and id tokens are being returned
         assertTokensAreNotEqual(result, resultAfterRefresh);
+        assertEquals(TokenSource.IDENTITY_PROVIDER, result.metadata().tokenSource());
+        assertEquals(CacheRefreshReason.NOT_APPLICABLE, result.metadata().cacheRefreshReason());
+        assertEquals(TokenSource.IDENTITY_PROVIDER, resultAfterRefresh.metadata().tokenSource());
+        assertEquals(CacheRefreshReason.FORCE_REFRESH, resultAfterRefresh.metadata().cacheRefreshReason());
     }
 
     @ParameterizedTest
@@ -253,6 +261,11 @@ class AcquireTokenSilentIT {
         //Current time is after refreshOn, so token should be refreshed
         assertNotNull(resultSilentWithRefreshOn);
         assertTokensAreNotEqual(resultSilent, resultSilentWithRefreshOn);
+
+        assertEquals(TokenSource.CACHE, resultSilent.metadata().tokenSource());
+        assertEquals(CacheRefreshReason.NOT_APPLICABLE, resultSilent.metadata().cacheRefreshReason());
+        assertEquals(TokenSource.IDENTITY_PROVIDER, resultSilentWithRefreshOn.metadata().tokenSource());
+        assertEquals(CacheRefreshReason.PROACTIVE_REFRESH, resultSilentWithRefreshOn.metadata().cacheRefreshReason());
     }
 
     @ParameterizedTest

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
@@ -79,6 +79,9 @@ public abstract class AbstractClientApplicationBase implements IClientApplicatio
     protected TokenCache tokenCache;
 
     @Accessors(fluent = true)
+    protected static TokenCache sharedTokenCache = new TokenCache();
+
+    @Accessors(fluent = true)
     @Getter
     private String applicationName;
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResult.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResult.java
@@ -90,4 +90,7 @@ final class AuthenticationResult implements IAuthenticationResult {
     private final Date expiresOnDate = new Date(expiresOn * 1000);
 
     private final String scopes;
+
+    @Builder.Default
+    private final AuthenticationResultMetadata metadata = new AuthenticationResultMetadata();
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultMetadata.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultMetadata.java
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import java.io.Serializable;
+
+/**
+ * Contains metadata and additional context for the contents of an AuthenticationResult
+ */
+@Accessors(fluent = true)
+@Getter
+@Setter(AccessLevel.PACKAGE)
+public class AuthenticationResultMetadata implements Serializable {
+
+    private TokenSource tokenSource;
+    private CacheRefreshReason cacheRefreshReason;
+
+    /**
+     * Sets default metadata values. Used when creating an {@link IAuthenticationResult} before the values are known.
+     */
+    AuthenticationResultMetadata() {
+        this.tokenSource = TokenSource.UNKNOWN;
+        this.cacheRefreshReason = CacheRefreshReason.NOT_APPLICABLE;
+    }
+
+    AuthenticationResultMetadata(TokenSource tokenSource, CacheRefreshReason refreshReason) {
+        this.tokenSource = tokenSource;
+        this.cacheRefreshReason = refreshReason;
+    }
+}

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CacheRefreshReason.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CacheRefreshReason.java
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+/**
+ * List of possible reasons the tokens in an {@link IAuthenticationResult} were refreshed.
+ */
+public enum CacheRefreshReason {
+
+    /**
+     * Token did not need to be refreshed, or was retrieved in a non-silent call
+     */
+    NOT_APPLICABLE,
+    /**
+     * Silent call was made with the force refresh option
+     */
+    FORCE_REFRESH,
+    /**
+     * Access token was missing from the cache, but a valid refresh token was used to retrieve a new access token
+     */
+    NO_CACHED_ACCESS_TOKEN,
+    /**
+     * Cached access token was expired and successfully refreshed
+     */
+    EXPIRED,
+    /**
+     * Cached access token was not expired but was after the 'refresh_in' value, and was proactively refreshed before the expiration date
+     */
+    PROACTIVE_REFRESH
+}

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
@@ -43,6 +43,10 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
     @Getter
     private boolean sendX5c;
 
+    @Accessors(fluent = true)
+    @Getter
+    private boolean useSharedCache;
+
     @Override
     public CompletableFuture<IAuthenticationResult> acquireToken(ClientCredentialParameters parameters) {
         validateNotNull("parameters", parameters);
@@ -83,6 +87,8 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
         super(builder);
         sendX5c = builder.sendX5c;
         appTokenProvider = builder.appTokenProvider;
+        useSharedCache = builder.useSharedCache;
+        if (useSharedCache) tokenCache = sharedTokenCache;
 
         log = LoggerFactory.getLogger(ConfidentialClientApplication.class);
 
@@ -169,6 +175,7 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
         private IClientCredential clientCredential;
 
         private boolean sendX5c = true;
+        private boolean useSharedCache = false;
 
         private Function<AppTokenProviderParameters, CompletableFuture<TokenProviderResult>> appTokenProvider;
 
@@ -206,6 +213,12 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
             }
 
             throw new NullPointerException("appTokenProvider is null") ;
+        }
+
+        public ConfidentialClientApplication.Builder useSharedCache(boolean val) {
+            useSharedCache = val;
+
+            return self();
         }
 
         @Override

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IAuthenticationResult.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IAuthenticationResult.java
@@ -44,4 +44,9 @@ public interface IAuthenticationResult extends Serializable {
      * @return access token expiration date
      */
     java.util.Date expiresOnDate();
+
+    /**
+     * @return various metadata relating to this authentication result
+     */
+    AuthenticationResultMetadata metadata();
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RequestContext.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RequestContext.java
@@ -25,6 +25,8 @@ class RequestContext {
     private IAcquireTokenParameters apiParameters;
     private IClientApplicationBase clientApplication;
     private UserIdentifier userIdentifier;
+    @Setter(AccessLevel.PACKAGE)
+    private CacheRefreshReason refreshReason;
 
     public RequestContext(AbstractClientApplicationBase clientApplication,
                           PublicApi publicApi,

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -149,6 +149,7 @@ class TokenRequestExecutor {
                     refreshOn(response.getRefreshIn() > 0 ? currTimestampSec + response.getRefreshIn() : 0).
                     accountCacheEntity(accountCacheEntity).
                     scopes(response.getScope()).
+                    metadata(new AuthenticationResultMetadata(TokenSource.IDENTITY_PROVIDER, CacheRefreshReason.NOT_APPLICABLE)).
                     build();
 
         } else {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenSource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenSource.java
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+/**
+ * A list of possible sources for the tokens found in an {@link IAuthenticationResult}
+ */
+public enum TokenSource {
+
+    /**
+     * A default value, likely indicates tokens could not be retrieved
+     */
+    UNKNOWN,
+
+    /**
+     * Indicates tokens came from an identity provider, such as Azure AD
+     */
+    IDENTITY_PROVIDER,
+
+    /**
+     * Indicates tokens came from MSAL's cache
+     */
+    CACHE
+}


### PR DESCRIPTION
Adds an option to use a static/shared cache in ConfidentialClientApplication instead of the per-instance cache (https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/699), and adds a new field to AuthenticationResult to store helpful metadata about the result (https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/697)