### PR TITLE
Set default throttling time to 5 sec

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ThrottlingCache.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ThrottlingCache.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ConcurrentHashMap;
 class ThrottlingCache {
 
     static final int MAX_THROTTLING_TIME_SEC = 3600;
-    static int DEFAULT_THROTTLING_TIME_SEC = 120;
+    static int DEFAULT_THROTTLING_TIME_SEC = 5;
     static final int CACHE_SIZE_LIMIT_TO_TRIGGER_EXPIRED_ENTITIES_REMOVAL = 100;
 
     // request hash to expiration timestamp


### PR DESCRIPTION
Currently default throttling time is set to 120 sec. This might create problems as described in this [issue](https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/716). 
While setting default throttling time does not eliminate the problem it does reduce a possible impact on the end-users.
