### PR TITLE
Static token cache for MSI

### DIFF
--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenSilentIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenSilentIT.java
@@ -69,6 +69,8 @@ class AcquireTokenSilentIT {
         // Check that access and id tokens are coming from cache
         assertEquals(result.accessToken(), acquireSilentResult.accessToken());
         assertEquals(result.idToken(), acquireSilentResult.idToken());
+        assertEquals(TokenSource.IDENTITY_PROVIDER, result.metadata().tokenSource());
+        assertEquals(TokenSource.CACHE, acquireSilentResult.metadata().tokenSource());
     }
 
     @ParameterizedTest
@@ -92,6 +94,8 @@ class AcquireTokenSilentIT {
 
         // Check that new refresh and id tokens are being returned
         assertTokensAreNotEqual(result, resultAfterRefresh);
+        assertEquals(TokenSource.IDENTITY_PROVIDER, result.metadata().tokenSource());
+        assertEquals(TokenSource.IDENTITY_PROVIDER, resultAfterRefresh.metadata().tokenSource());
     }
 
     @ParameterizedTest
@@ -253,6 +257,8 @@ class AcquireTokenSilentIT {
         //Current time is after refreshOn, so token should be refreshed
         assertNotNull(resultSilentWithRefreshOn);
         assertTokensAreNotEqual(resultSilent, resultSilentWithRefreshOn);
+        assertEquals(TokenSource.CACHE, resultSilent.metadata().tokenSource());
+        assertEquals(TokenSource.IDENTITY_PROVIDER, resultSilentWithRefreshOn.metadata().tokenSource());
     }
 
     @ParameterizedTest

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
@@ -46,6 +46,9 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
                 throw new MsalClientException(AuthenticationErrorMessage.NO_TOKEN_IN_CACHE, AuthenticationErrorCode.CACHE_MISS);
             }
 
+            //Some cached tokens were found, but this metadata will be overwritten if token needs to be refreshed
+            res.metadata().tokenSource(TokenSource.CACHE);
+
             if (!StringHelper.isBlank(res.accessToken())) {
                 clientApplication.serviceBundle().getServerSideTelemetry().incrementSilentSuccessfulCount();
             }
@@ -93,6 +96,10 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
 
                     try {
                         res = acquireTokenByAuthorisationGrantSupplier.execute();
+
+                        res.metadata().tokenSource(TokenSource.IDENTITY_PROVIDER);
+
+                        log.info("Access token refreshed successfully.");
                     } catch (MsalServiceException ex) {
                         //If the token refresh attempt threw a MsalServiceException but the refresh attempt was done
                         // only because of refreshOn, then simply return the existing cached token

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResult.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResult.java
@@ -90,4 +90,7 @@ final class AuthenticationResult implements IAuthenticationResult {
     private final Date expiresOnDate = new Date(expiresOn * 1000);
 
     private final String scopes;
+
+    @Builder.Default
+    private final AuthenticationResultMetadata metadata = new AuthenticationResultMetadata();
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultMetadata.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultMetadata.java
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import java.io.Serializable;
+
+/**
+ * Contains metadata and additional context for the contents of an AuthenticationResult
+ */
+@Accessors(fluent = true)
+@Getter
+@Setter(AccessLevel.PACKAGE)
+public class AuthenticationResultMetadata implements Serializable {
+
+    private TokenSource tokenSource;
+
+    /**
+     * Sets default metadata values. Used when creating an {@link IAuthenticationResult} before the values are known.
+     */
+    AuthenticationResultMetadata() {
+    }
+
+    AuthenticationResultMetadata(TokenSource tokenSource) {
+        this.tokenSource = tokenSource;
+    }
+}

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IAuthenticationResult.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IAuthenticationResult.java
@@ -44,4 +44,9 @@ public interface IAuthenticationResult extends Serializable {
      * @return access token expiration date
      */
     java.util.Date expiresOnDate();
+
+    /**
+     * @return various metadata relating to this authentication result
+     */
+    AuthenticationResultMetadata metadata();
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
@@ -19,11 +19,14 @@ public class ManagedIdentityApplication extends AbstractApplicationBase implemen
     @Getter
     private final ManagedIdentityId managedIdentityId;
 
+    @Getter
+    static TokenCache sharedTokenCache = new TokenCache();
+
     private ManagedIdentityApplication(Builder builder) {
         super(builder);
         this.managedIdentityId = builder.managedIdentityId;
         log = LoggerFactory.getLogger(ManagedIdentityApplication.class);
-        super.tokenCache = new TokenCache();
+        super.tokenCache = sharedTokenCache;
     }
 
     @Override

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -151,6 +151,7 @@ class TokenRequestExecutor {
                     refreshOn(response.getRefreshIn() > 0 ? currTimestampSec + response.getRefreshIn() : 0).
                     accountCacheEntity(accountCacheEntity).
                     scopes(response.getScope()).
+                    metadata(new AuthenticationResultMetadata(TokenSource.IDENTITY_PROVIDER)).
                     build();
 
         } else {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenSource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenSource.java
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+/**
+ * A list of possible sources for the tokens found in an {@link IAuthenticationResult}
+ */
+public enum TokenSource {
+
+    /**
+     * Indicates tokens came from an identity provider, such as Azure AD
+     */
+    IDENTITY_PROVIDER,
+
+    /**
+     * Indicates tokens came from MSAL's cache
+     */
+    CACHE
+}


### PR DESCRIPTION
Adds a static token cache field to ManagedIdentityApplication so that the cache is shared among all ManagedIdentityApplication instances, as well as a TokenSource and AuthenticationResultMetadata classes to provide information about where tokens are coming from.

This is similar to what is being done in https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/708, however this is a simpler implementation to help ensure the behavior is correct for upcoming beta testing.