### PR TITLE
Update cache keys for MSI scenarios

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractApplicationBase.java
@@ -59,6 +59,10 @@ public abstract class AbstractApplicationBase implements IApplicationBase {
     @Getter
     private Integer readTimeoutForDefaultHttpClient;
 
+    @Accessors(fluent = true)
+    @Getter(AccessLevel.PACKAGE)
+    String tenant;
+
     //The following fields are set in only some applications and/or set internally by the library. To avoid excessive
     // type casting throughout the library they are defined here as package-private, but will not be part of this class's Builder
     @Accessors(fluent = true)

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
@@ -87,6 +87,8 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
         log = LoggerFactory.getLogger(ConfidentialClientApplication.class);
 
         initClientAuthentication(builder.clientCredential);
+
+        this.tenant = this.authenticationAuthority.tenant;
     }
 
     private void initClientAuthentication(IClientCredential clientCredential) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Constants.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Constants.java
@@ -13,6 +13,7 @@ final class Constants {
 
     public static final String MANAGED_IDENTITY_CLIENT_ID = "client_id";
     public static final String MANAGED_IDENTITY_RESOURCE_ID = "mi_res_id";
+    public static final String MANAGED_IDENTITY_DEFAULT_TENTANT = "managed_identity";
 
     public static final String IDENTITY_ENDPOINT = "IDENTITY_ENDPOINT";
     public static final String IDENTITY_HEADER = "IDENTITY_HEADER";

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
@@ -24,9 +24,12 @@ public class ManagedIdentityApplication extends AbstractApplicationBase implemen
 
     private ManagedIdentityApplication(Builder builder) {
         super(builder);
-        this.managedIdentityId = builder.managedIdentityId;
+
         log = LoggerFactory.getLogger(ManagedIdentityApplication.class);
         super.tokenCache = sharedTokenCache;
+
+        this.managedIdentityId = builder.managedIdentityId;
+        this.tenant = Constants.MANAGED_IDENTITY_DEFAULT_TENTANT;
     }
 
     @Override

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityParameters.java
@@ -45,7 +45,7 @@ public class ManagedIdentityParameters implements IAcquireTokenParameters {
 
     @Override
     public String tenant() {
-        return "managed_identity";
+        return Constants.MANAGED_IDENTITY_DEFAULT_TENTANT;
     }
 
     @Override

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
@@ -122,6 +122,7 @@ public class PublicClientApplication extends AbstractClientApplicationBase imple
         log = LoggerFactory.getLogger(PublicClientApplication.class);
         this.clientAuthentication = new ClientAuthenticationPost(ClientAuthenticationMethod.NONE,
                 new ClientID(clientId()));
+        this.tenant = this.authenticationAuthority.tenant;
     }
 
     @Override

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenCache.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenCache.java
@@ -252,7 +252,7 @@ public class TokenCache implements ITokenCache {
         at.environment(environmentAlias);
         at.clientId(tokenRequestExecutor.getMsalRequest().application().clientId());
         at.secret(authenticationResult.accessToken());
-        at.realm(tokenRequestExecutor.requestAuthority.tenant());
+        at.realm(tokenRequestExecutor.tenant);
 
         String scopes = !StringHelper.isBlank(authenticationResult.scopes()) ? authenticationResult.scopes() :
                 tokenRequestExecutor.getMsalRequest().msalAuthorizationGrant().getScopes();
@@ -289,7 +289,7 @@ public class TokenCache implements ITokenCache {
         idToken.environment(environmentAlias);
         idToken.clientId(tokenRequestExecutor.getMsalRequest().application().clientId());
         idToken.secret(authenticationResult.idToken());
-        idToken.realm(tokenRequestExecutor.requestAuthority.tenant());
+        idToken.realm(tokenRequestExecutor.tenant);
 
         if (tokenRequestExecutor.getMsalRequest() instanceof OnBehalfOfRequest) {
             OnBehalfOfRequest onBehalfOfRequest = (OnBehalfOfRequest) tokenRequestExecutor.getMsalRequest();

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -23,6 +23,7 @@ class TokenRequestExecutor {
     Logger log = LoggerFactory.getLogger(TokenRequestExecutor.class);
 
     final Authority requestAuthority;
+    final String tenant;
     private final MsalRequest msalRequest;
     private final ServiceBundle serviceBundle;
 
@@ -30,6 +31,9 @@ class TokenRequestExecutor {
         this.requestAuthority = requestAuthority;
         this.serviceBundle = serviceBundle;
         this.msalRequest = msalRequest;
+        this.tenant = msalRequest.requestContext().apiParameters().tenant() == null ?
+                msalRequest.application().tenant() :
+                msalRequest.requestContext().apiParameters().tenant() ;
     }
 
     AuthenticationResult executeTokenRequest() throws ParseException, IOException {


### PR DESCRIPTION
Addresses https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/710

In both MSAL .NET and MSAL Java, the cache key for access tokens contains the tenant. For .NET this tenant value is a constant "managed_identity" for MSI scenarios, however in Java we had a default authority value which we extracted the tenant from, which meant it was always "common" instead of "managed_identity"

The changes in this PR add a new 'tenant' field to Public/Confidential/ManagedIdentity apps, which is then used in the token cache instead of parsing the authority. This will allow the cache keys in Java to better match those in .NET, and hopefully be more clear about where the tenant in a cache key came from.

(tests covering both the old and new cases will be coming soon)