### PR TITLE
only demand RSAKey from PrivateKey implementaton

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
@@ -21,7 +21,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAKey;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -47,8 +47,8 @@ final class ClientCertificate implements IClientCertificate {
 
         this.privateKey = privateKey;
 
-        if (privateKey instanceof RSAPrivateKey) {
-            if (((RSAPrivateKey) privateKey).getModulus().bitLength() < MIN_KEY_SIZE_IN_BITS) {
+        if (privateKey instanceof RSAKey) {
+            if (((RSAKey) privateKey).getModulus().bitLength() < MIN_KEY_SIZE_IN_BITS) {
                 throw new IllegalArgumentException(
                         "certificate key size must be at least " + MIN_KEY_SIZE_IN_BITS);
             }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClientCertificateTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClientCertificateTest.java
@@ -11,10 +11,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
 
 import java.math.BigInteger;
 import java.security.PrivateKey;
 import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAKey;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ClientCertificateTest {
@@ -48,4 +50,16 @@ class ClientCertificateTest {
         final ClientCertificate kc = ClientCertificate.create(key, null);
         assertNotNull(kc);
     }
+    
+    @Test
+    void testGetClientRSAKeyIsSufficient() {
+        final PrivateKey key = mock(PrivateKey.class,withSettings().extraInterfaces(RSAKey.class));
+        final BigInteger modulus = mock(BigInteger.class);
+        doReturn(2048).when(modulus).bitLength();
+        doReturn(modulus).when((RSAKey)key).getModulus();
+
+        final ClientCertificate kc = ClientCertificate.create(key, null);
+        assertNotNull(kc);
+    }
+    
 }


### PR DESCRIPTION
MSAL4J adds a 2048 private key bitlength check.

It demands the key to implement java.security.interfaces.RSAPrivateKey to perform the bitlength check, but that is too demanding as java.security.interfaces.RSAKey (which is a sub interface of RSAPrivateKey) provides the bitlength() method . 
Some hsm-box implementations implement RSAKey only thus MSAL4J is not useable with these hsmbox providers.
The later JDK signing algorithm runs fine without RSAPrivateKey being implemented. 
