### PR TITLE
Remove key size requirement for certificates

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
@@ -30,7 +30,6 @@ import java.util.List;
 
 final class ClientCertificate implements IClientCertificate {
 
-    private final static int MIN_KEY_SIZE_IN_BITS = 2048;
     public static final String DEFAULT_PKCS12_PASSWORD = "";
 
     @Accessors(fluent = true)
@@ -46,30 +45,6 @@ final class ClientCertificate implements IClientCertificate {
         }
 
         this.privateKey = privateKey;
-
-        if (privateKey instanceof RSAPrivateKey) {
-            if (((RSAPrivateKey) privateKey).getModulus().bitLength() < MIN_KEY_SIZE_IN_BITS) {
-                throw new IllegalArgumentException(
-                        "certificate key size must be at least " + MIN_KEY_SIZE_IN_BITS);
-            }
-        } else if ("sun.security.mscapi.RSAPrivateKey".equals(privateKey.getClass().getName()) ||
-                "sun.security.mscapi.CPrivateKey".equals(privateKey.getClass().getName())) {
-            try {
-                Method method = privateKey.getClass().getMethod("length");
-                method.setAccessible(true);
-                if ((int) method.invoke(privateKey) < MIN_KEY_SIZE_IN_BITS) {
-                    throw new IllegalArgumentException(
-                            "certificate key size must be at least " + MIN_KEY_SIZE_IN_BITS);
-                }
-            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ex) {
-                throw new RuntimeException("error accessing sun.security.mscapi.RSAPrivateKey length: "
-                        + ex.getMessage());
-            }
-        } else {
-            throw new IllegalArgumentException(
-                    "certificate key must be an instance of java.security.interfaces.RSAPrivateKey or" +
-                            " sun.security.mscapi.RSAPrivateKey");
-        }
 
         this.publicKeyCertificateChain = publicKeyCertificateChain;
     }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClientCertificateTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClientCertificateTest.java
@@ -27,18 +27,6 @@ class ClientCertificateTest {
     }
 
     @Test
-    void testInvalidKeysize() {
-        final RSAPrivateKey key = mock(RSAPrivateKey.class);
-        final BigInteger modulus = mock(BigInteger.class);
-        doReturn(2047).when(modulus).bitLength();
-        doReturn(modulus).when(key).getModulus();
-
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> ClientCertificate.create(key, null));
-
-        assertEquals("certificate key size must be at least 2048", ex.getMessage());
-    }
-
-    @Test
     void testGetClient() {
         final RSAPrivateKey key = mock(RSAPrivateKey.class);
         final BigInteger modulus = mock(BigInteger.class);


### PR DESCRIPTION
During some discussions on https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/747, we decided that there wasn't much of a reason for MSAL to enforce a certain key size for client certificates. Rather than change how we handle key sizes, this PR removes the requirement entirely