### PR TITLE
Fix MSI error response parsing issue

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityErrorResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityErrorResponse.java
@@ -15,9 +15,26 @@ public class ManagedIdentityErrorResponse {
     @JsonProperty("correlationId")
     private String correlationId;
 
+    //In some MSI scenarios such as Cloud Shell, the actual error info is in a JSON within the main JSON. To parse that second
+    // JSON layer, we need to first pass it into a subclass, parse it using the usual @JsonProperty annotation, and then retrieve the values.
+    @JsonProperty("error")
+    private void parseErrorField(ErrorField errorResponse) {
+        this.error = errorResponse.code;
+        this.message = errorResponse.message;
+    }
+
     @JsonProperty("error")
     private String error;
 
     @JsonProperty("error_description")
     private String errorDescription;
+
+    @Getter
+    private static class ErrorField {
+        @JsonProperty("code")
+        private String code;
+
+        @JsonProperty("message")
+        private String message;
+    }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/EnvironmentVariablesHelper.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/EnvironmentVariablesHelper.java
@@ -12,6 +12,7 @@ public class EnvironmentVariablesHelper implements IEnvironmentVariables {
     EnvironmentVariablesHelper(ManagedIdentitySourceType source, String endpoint) {
         mockedEnvironmentVariables = new HashMap<>();
 
+        mockedEnvironmentVariables.put("SourceType", source.toString());
         switch (source) {
             case APP_SERVICE:
                 mockedEnvironmentVariables.put(Constants.IDENTITY_ENDPOINT, endpoint);


### PR DESCRIPTION
Fixes the issue described in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/744

In Cloud Shell scenarios, an error response would have the form of `{"error": {...}}`, where the actual error info was in a JSON within the main JSON. This lead to our JSON parser throwing an exception when it tried to parse the sub-JSON like a primitive value.

This PR fixes that issue with a new method and small nested class. If the `"error"` field of the response is a JSON instead of a String, the JSON parsing package we use will convert it to and `ErrorField` field object that will then have the actual error info we're looking for. If the `"error"` field of the response isn't a JSON, then the existing  `error` field will be populated and that new method won't get called.