### PR TITLE
Various fixes/improvements

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AccountsSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AccountsSupplier.java
@@ -26,9 +26,10 @@ class AccountsSupplier implements Supplier<Set<IAccount>> {
                     (clientApplication.clientId());
 
         } catch (Exception ex) {
-            clientApplication.log.error(
-                    LogHelper.createMessage("Execution of " + this.getClass() + " failed.",
-                            msalRequest.headers().getHeaderCorrelationIdValue()), ex);
+            clientApplication.log.warn(
+                    LogHelper.createMessage(
+                            String.format("Execution of %s failed: %s", this.getClass(), ex.getMessage()),
+                            msalRequest.headers().getHeaderCorrelationIdValue()));
 
             throw new CompletionException(ex);
         }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByDeviceCodeFlowSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByDeviceCodeFlowSupplier.java
@@ -53,7 +53,10 @@ class AcquireTokenByDeviceCodeFlowSupplier extends AuthenticationResultSupplier 
 
         while (getCurrentSystemTimeInSeconds() < expirationTimeInSeconds) {
             if (deviceCodeFlowRequest.futureReference().get().isCancelled()) {
-                throw new InterruptedException("Acquire token Device Code Flow was interrupted");
+                throw new InterruptedException("Device code flow was cancelled before acquiring a token");
+            }
+            if (deviceCodeFlowRequest.futureReference().get().isCompletedExceptionally()) {
+                throw new InterruptedException("Device code flow had an exception before acquiring a token");
             }
             try {
                 return acquireTokenByAuthorisationGrantSupplier.execute();

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByInteractiveFlowSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByInteractiveFlowSupplier.java
@@ -209,7 +209,7 @@ class AcquireTokenByInteractiveFlowSupplier extends AuthenticationResultSupplier
                 expirationTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) + 1;
             }
 
-            while (result == null && !interactiveRequest.futureReference().get().isCancelled()) {
+            while (result == null && !interactiveRequest.futureReference().get().isDone()) {
                 if (TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) > expirationTime) {
                     LOG.warn(String.format("Listener timed out after %S seconds, no authorization code was returned from the server during that time.", timeFromParameters));
                     break;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
@@ -109,7 +109,7 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
             throw new MsalClientException(AuthenticationErrorMessage.NO_TOKEN_IN_CACHE, AuthenticationErrorCode.CACHE_MISS);
         }
 
-        log.info("Returning token from cache");
+        log.debug("Returning token from cache");
 
         return res;
     }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultSupplier.java
@@ -95,7 +95,11 @@ abstract class AuthenticationResultSupplier implements Supplier<IAuthenticationR
                         msalRequest.requestContext().correlationId(),
                         error);
 
-                logException(ex);
+                clientApplication.log.warn(
+                        LogHelper.createMessage(
+                                String.format("Execution of %s failed: %s", this.getClass(), ex.getMessage()),
+                                msalRequest.headers().getHeaderCorrelationIdValue()));
+
                 throw new CompletionException(ex);
             }
         }
@@ -133,26 +137,6 @@ abstract class AuthenticationResultSupplier implements Supplier<IAuthenticationR
                 }
             }
         }
-    }
-
-    private void logException(Exception ex) {
-
-        String logMessage = LogHelper.createMessage(
-                "Execution of " + this.getClass() + " failed.",
-                msalRequest.headers().getHeaderCorrelationIdValue());
-
-        if (ex instanceof MsalClientException) {
-            MsalClientException exception = (MsalClientException) ex;
-            if (exception.errorCode() != null && exception.errorCode().equalsIgnoreCase(AuthenticationErrorCode.CACHE_MISS)) {
-                clientApplication.log.debug(logMessage, ex);
-                return;
-            }
-        } else if (ex instanceof MsalAzureSDKException) {
-            clientApplication.log.debug(ex.getMessage(), ex);
-            return;
-        }
-
-        clientApplication.log.error(logMessage, ex);
     }
 
     private ApiEvent initializeApiEvent(MsalRequest msalRequest) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpHeaders.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpHeaders.java
@@ -16,9 +16,6 @@ final class HttpHeaders {
     static final String PRODUCT_VERSION_HEADER_NAME = "x-client-VER";
     static final String PRODUCT_VERSION_HEADER_VALUE = getProductVersion();
 
-    static final String CPU_HEADER_NAME = "x-client-CPU";
-    static final String CPU_HEADER_VALUE = System.getProperty("os.arch");
-
     static final String OS_HEADER_NAME = "x-client-OS";
     static final String OS_HEADER_VALUE = System.getProperty("os.name");
 
@@ -78,7 +75,6 @@ final class HttpHeaders {
         init.accept(PRODUCT_HEADER_NAME, PRODUCT_HEADER_VALUE);
         init.accept(PRODUCT_VERSION_HEADER_NAME, PRODUCT_VERSION_HEADER_VALUE);
         init.accept(OS_HEADER_NAME, OS_HEADER_VALUE);
-        init.accept(CPU_HEADER_NAME, CPU_HEADER_VALUE);
         init.accept(REQUEST_CORRELATION_ID_IN_RESPONSE_HEADER_NAME, REQUEST_CORRELATION_ID_IN_RESPONSE_HEADER_VALUE);
         init.accept(CORRELATION_ID_HEADER_NAME, this.correlationIdHeaderValue);
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/LogHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/LogHelper.java
@@ -6,8 +6,7 @@ package com.microsoft.aad.msal4j;
 final class LogHelper {
 
     static String createMessage(String originalMessage, String correlationId) {
-        return String.format("[Correlation ID: %s] " + originalMessage,
-                correlationId);
+        return String.format("[Correlation ID: %s] %s", correlationId, originalMessage);
     }
 
     static String getPiiScrubbedDetails(Throwable ex) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RemoveAccountRunnable.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RemoveAccountRunnable.java
@@ -25,9 +25,10 @@ class RemoveAccountRunnable implements Runnable {
                     (clientApplication.clientId(), account);
 
         } catch (Exception ex) {
-            clientApplication.log.error(
-                    LogHelper.createMessage("Execution of " + this.getClass() + " failed.",
-                            requestContext.correlationId()), ex);
+            clientApplication.log.warn(
+                    LogHelper.createMessage(
+                            String.format("Execution of %s failed: %s", this.getClass(), ex.getMessage()),
+                            requestContext.correlationId()));
 
             throw new CompletionException(ex);
         }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/HttpHeaderTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/HttpHeaderTest.java
@@ -43,7 +43,6 @@ class HttpHeaderTest {
         assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_HEADER_NAME), HttpHeaders.PRODUCT_HEADER_VALUE);
         assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_VERSION_HEADER_NAME), HttpHeaders.PRODUCT_VERSION_HEADER_VALUE);
         assertEquals(httpHeaderMap.get(HttpHeaders.OS_HEADER_NAME), HttpHeaders.OS_HEADER_VALUE);
-        assertEquals(httpHeaderMap.get(HttpHeaders.CPU_HEADER_NAME), HttpHeaders.CPU_HEADER_VALUE);
         assertEquals(httpHeaderMap.get(HttpHeaders.APPLICATION_NAME_HEADER_NAME), "app-name");
         assertEquals(httpHeaderMap.get(HttpHeaders.APPLICATION_VERSION_HEADER_NAME), "app-version");
         assertEquals(httpHeaderMap.get(HttpHeaders.CORRELATION_ID_HEADER_NAME), "correlation-id");
@@ -70,7 +69,6 @@ class HttpHeaderTest {
         assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_HEADER_NAME), HttpHeaders.PRODUCT_HEADER_VALUE);
         assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_VERSION_HEADER_NAME), HttpHeaders.PRODUCT_VERSION_HEADER_VALUE);
         assertEquals(httpHeaderMap.get(HttpHeaders.OS_HEADER_NAME), HttpHeaders.OS_HEADER_VALUE);
-        assertEquals(httpHeaderMap.get(HttpHeaders.CPU_HEADER_NAME), HttpHeaders.CPU_HEADER_VALUE);
         assertNull(httpHeaderMap.get(HttpHeaders.APPLICATION_NAME_HEADER_NAME));
         assertNull(httpHeaderMap.get(HttpHeaders.APPLICATION_VERSION_HEADER_NAME));
         assertNotNull(httpHeaderMap.get(HttpHeaders.CORRELATION_ID_HEADER_NAME));
@@ -163,7 +161,6 @@ class HttpHeaderTest {
         assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_HEADER_NAME), HttpHeaders.PRODUCT_HEADER_VALUE);
         assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_VERSION_HEADER_NAME), HttpHeaders.PRODUCT_VERSION_HEADER_VALUE);
         assertEquals(httpHeaderMap.get(HttpHeaders.OS_HEADER_NAME), HttpHeaders.OS_HEADER_VALUE);
-        assertEquals(httpHeaderMap.get(HttpHeaders.CPU_HEADER_NAME), HttpHeaders.CPU_HEADER_VALUE);
         assertEquals(httpHeaderMap.get(HttpHeaders.APPLICATION_VERSION_HEADER_NAME), "app-version");
         assertEquals(httpHeaderMap.get(HttpHeaders.CORRELATION_ID_HEADER_NAME), "correlation-id");
 


### PR DESCRIPTION
This PR handles a number of small issues from our backlog:
- https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/726 : Removes an unnecessaries telemetry header
- https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/741 : When a future was cancelled it shut down the relevant thread, however Java 9+ introduced timeout behavior that our code didn't consider so threads would continue through a timeout. We now check for exceptions (such as TimeoutException) as well as cancellations
- https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/751 : Lowers the log level for successful cache lookup from 'info' to 'debug' to keep per-request logs more useful
- https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/662 : Reduce verbosity of logs produced right before an exception, and avoid logging at an 'error' level if an exception will be thrown anyway