### PR TITLE
Refactor instance/region discovery

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
@@ -66,9 +66,12 @@ class AadInstanceDiscoveryProvider {
         String host = authorityUrl.getHost();
 
         //If instanceDiscovery flag set to false, cache a basic instance metadata entry to skip future lookups
-        if (!msalRequest.application().instanceDiscovery() && cache.get(host) == null) {
-            log.debug("Instance discovery set to false, caching a default entry.");
-            cacheInstanceDiscoveryMetadata(host);
+        if (!msalRequest.application().instanceDiscovery()) {
+            if (cache.get(host) == null) {
+                log.debug("Instance discovery set to false, caching a default entry.");
+                cacheInstanceDiscoveryMetadata(host);
+            }
+            return cache.get(host);
         }
 
         //If a region was set by an app developer or previously found through autodetection, adjust the authority host to use it

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
@@ -66,7 +66,7 @@ class AadInstanceDiscoveryProvider {
         String host = authorityUrl.getHost();
 
         //If instanceDiscovery flag set to false, cache a basic instance metadata entry to skip future lookups
-        if (!msalRequest.application().instanceDiscovery()) {
+        if (!msalRequest.application().instanceDiscovery() && cache.get(host) == null) {
             log.debug("Instance discovery set to false, caching a default entry.");
             cacheInstanceDiscoveryMetadata(host);
         }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
@@ -708,7 +708,7 @@ public abstract class AbstractClientApplicationBase implements IClientApplicatio
         instanceDiscovery = builder.instanceDiscovery;
 
         if (aadAadInstanceDiscoveryResponse != null) {
-            AadInstanceDiscoveryProvider.cacheInstanceDiscoveryMetadata(
+            AadInstanceDiscoveryProvider.cacheInstanceDiscoveryResponse(
                     authenticationAuthority.host,
                     aadAadInstanceDiscoveryResponse);
         }


### PR DESCRIPTION
During the discussions about https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/762 it was pointed out that over the years the code flow for instance and region discovery has gotten messy and inefficient.

This PR attempts to refactor the logic around it to make the code flow clearer and avoid making unnecessary/repetitive method calls.