### PR TITLE
upgrade oauth2-oidc-sdk

### DIFF
--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>10.7.1</version>
+            <version>11.9.1</version>
         </dependency>
         <dependency>
             <groupId>net.minidev</groupId>


### PR DESCRIPTION
upgrade oauth2-oidc-sdk (11.7.1 or higher) to fix CVE-2023-52428 in downstream com.nimbusds:nimbus-jose-jwt dep