### PR TITLE
Adjust retry policy for Managed Identity flows

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpHelper.java
@@ -92,7 +92,7 @@ class HttpHelper implements IHttpHelper {
                 getRetryAfterHeader(httpResponse) == null;
     }
 
-    private IHttpResponse executeHttpRequestWithRetries(HttpRequest httpRequest, IHttpClient httpClient)
+    IHttpResponse executeHttpRequestWithRetries(HttpRequest httpRequest, IHttpClient httpClient)
             throws Exception {
         IHttpResponse httpResponse = null;
         for (int i = 0; i < RETRY_NUM; i++) {

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -336,8 +336,9 @@ class ManagedIdentityTests {
         } catch (Exception exception) {
             assert(exception.getCause() instanceof MsalManagedIdentityException);
 
-            //MSAL retries certain calls once, so there two be two invocations of HttpClient's send method: the original call, and the retry
-            verify(httpClientMock, times(2)).send(any());
+            //There should be three retries for certain MSI error codes, so there will be four invocations of
+            // HttpClient's send method: the original call, and the three retries
+            verify(httpClientMock, times(4)).send(any());
         }
 
         clearInvocations(httpClientMock);


### PR DESCRIPTION
For SDK consistency, this PR adjusts the retry logic for Managed Identity flows: it now attempts 3 retries, with a 1 second delay between each.