### PR TITLE
Move resource from header to query for Cloudshell

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CloudShellManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CloudShellManagedIdentitySource.java
@@ -25,10 +25,12 @@ class CloudShellManagedIdentitySource extends AbstractManagedIdentitySource{
         managedIdentityRequest.headers = new HashMap<>();
         managedIdentityRequest.headers.put("ContentType", "application/x-www-form-urlencoded");
         managedIdentityRequest.headers.put("Metadata", "true");
-        managedIdentityRequest.headers.put("resource", resource);
 
         managedIdentityRequest.bodyParameters = new HashMap<>();
         managedIdentityRequest.bodyParameters.put("resource", Collections.singletonList(resource));
+
+        managedIdentityRequest.queryParameters = new HashMap<>();
+        managedIdentityRequest.queryParameters.put("resource", Collections.singletonList(resource));
     }
 
     private CloudShellManagedIdentitySource(MsalRequest msalRequest, ServiceBundle serviceBundle, URI msiEndpoint)

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -86,7 +86,7 @@ class ManagedIdentityTests {
 
                 headers.put("ContentType", "application/x-www-form-urlencoded");
                 headers.put("Metadata", "true");
-                headers.put("resource", resource);
+                queryParameters.put("resource", Collections.singletonList(resource));
 
                 bodyParameters.put("resource", Collections.singletonList(resource));
                 return new HttpRequest(HttpMethod.POST, computeUri(endpoint, queryParameters), headers, URLUtils.serializeParameters(bodyParameters));


### PR DESCRIPTION
Per feedback from Azure SDK, the 'resource' value should be a query parameter instead of a header.