### PR TITLE
Refresh tokens when request contains claims

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
@@ -131,12 +131,13 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
     //Handles any logic to determine if a token should be refreshed, based on the request parameters and the status of cached tokens
     private boolean shouldRefresh(SilentParameters parameters, AuthenticationResult cachedResult) {
 
-        //If there is a refresh token but no access token, we should use the refresh token to get the access token
-        if (StringHelper.isBlank(cachedResult.accessToken()) && !StringHelper.isBlank(cachedResult.refreshToken())) {
+        //If forceRefresh is true, no reason to check any other option
+        if (parameters.forceRefresh()) {
             return true;
         }
 
         //If the request contains claims then the token should be refreshed, to ensure that the returned token has the correct claims
+        //  Note: these are the types of claims found in (for example) a claims challenge, and do not include client capabilities
         if (parameters.claims() != null) {
             return true;
         }
@@ -149,7 +150,11 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
             return true;
         }
 
-        //Finally, simply return the value of the request's forceRefresh parameter
-        return parameters.forceRefresh();
+        //If there is a refresh token but no access token, we should use the refresh token to get the access token
+        if (StringHelper.isBlank(cachedResult.accessToken()) && !StringHelper.isBlank(cachedResult.refreshToken())) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
@@ -136,6 +136,11 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
             return true;
         }
 
+        //If the request contains claims then the token should be refreshed, to ensure that the returned token has the correct claims
+        if (parameters.claims() != null) {
+            return true;
+        }
+
         //Certain long-lived tokens will have a 'refresh on' time that indicates a refresh should be attempted long before the token would expire
         long currTimeStampSec = new Date().getTime() / 1000;
         if (cachedResult.refreshOn() != null && cachedResult.refreshOn() > 0 &&

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenCache.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenCache.java
@@ -474,13 +474,11 @@ public class TokenCache implements ITokenCache {
             Set<String> scopes,
             String clientId,
             Set<String> environmentAliases) {
-        long currTimeStampSec = new Date().getTime() / 1000;
 
         return accessTokens.values().stream().filter(
                 accessToken ->
                         accessToken.homeAccountId.equals(account.homeAccountId()) &&
                                 environmentAliases.contains(accessToken.environment) &&
-                                Long.parseLong(accessToken.expiresOn()) > currTimeStampSec + MIN_ACCESS_TOKEN_EXPIRE_IN_SEC &&
                                 accessToken.realm.equals(authority.tenant()) &&
                                 accessToken.clientId.equals(clientId) &&
                                 isMatchingScopes(accessToken, scopes)

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AcquireTokenSilentlyTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AcquireTokenSilentlyTest.java
@@ -5,9 +5,17 @@ package com.microsoft.aad.msal4j;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -15,6 +23,9 @@ import java.util.concurrent.ExecutionException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AcquireTokenSilentlyTest {
+
+    Account basicAccount = new Account("home_account_id", "login.windows.net", "username", null);
+    String cache = readResource("/AAD_cache_data/full_cache.json");
 
     @Test
     void publicAppAcquireTokenSilently_emptyCache_MsalClientException() throws Throwable {
@@ -29,7 +40,7 @@ class AcquireTokenSilentlyTest {
 
         ExecutionException ex = assertThrows(ExecutionException.class, future::get);
 
-        assertTrue(ex.getCause() instanceof MsalClientException);
+        assertInstanceOf(MsalClientException.class, ex.getCause());
         assertTrue(ex.getMessage().contains(AuthenticationErrorMessage.NO_TOKEN_IN_CACHE));
     }
 
@@ -45,7 +56,71 @@ class AcquireTokenSilentlyTest {
 
         ExecutionException ex = assertThrows(ExecutionException.class, future::get);
 
-        assertTrue(ex.getCause() instanceof MsalClientException);
+        assertInstanceOf(MsalClientException.class, ex.getCause());
         assertTrue(ex.getMessage().contains(AuthenticationErrorMessage.NO_TOKEN_IN_CACHE));
+    }
+
+    @Test
+    void publicAppAcquireTokenSilently_claimsSkipCache() throws Throwable {
+
+        PublicClientApplication application = PublicClientApplication.builder("client_id")
+                .instanceDiscovery(false)
+                .authority("https://some.authority.com/realm")
+                .build();
+
+        application.tokenCache.deserialize(cache);
+
+        SilentParameters parameters = SilentParameters.builder(Collections.singleton("scopes"), basicAccount).build();
+
+        IAuthenticationResult result = application.acquireTokenSilently(parameters).get();
+
+        //Confirm cached dummy token returned from silent request
+        assertNotNull(result);
+        assertEquals("token", result.accessToken());
+
+        ClaimsRequest cr = new ClaimsRequest();
+        cr.requestClaimInAccessToken("something", null);
+
+        parameters = SilentParameters.builder(Collections.singleton("scopes"), basicAccount).claims(cr).build();
+        CompletableFuture<IAuthenticationResult> future = application.acquireTokenSilently(parameters);
+
+        //Confirm cached dummy token ignored when claims are part of request
+        ExecutionException ex = assertThrows(ExecutionException.class, future::get);
+        assertInstanceOf(MsalInteractionRequiredException.class, ex.getCause());
+    }
+
+    @Test
+    void confidentialAppAcquireTokenSilently_claimsSkipCache() throws Throwable {
+
+        ConfidentialClientApplication application = ConfidentialClientApplication
+                .builder("client_id", ClientCredentialFactory.createFromSecret(TestConfiguration.AAD_CLIENT_DUMMYSECRET))
+                .instanceDiscovery(false)
+                .authority("https://some.authority.com/realm").build();
+
+        application.tokenCache.deserialize(cache);
+
+        SilentParameters parameters = SilentParameters.builder(Collections.singleton("scopes"), basicAccount).build();
+
+        IAuthenticationResult result = application.acquireTokenSilently(parameters).get();
+
+        assertNotNull(result);
+        assertEquals("token", result.accessToken());
+
+        ClaimsRequest cr = new ClaimsRequest();
+        cr.requestClaimInAccessToken("something", null);
+
+        parameters = SilentParameters.builder(Collections.singleton("scopes"), basicAccount).claims(cr).build();
+        CompletableFuture<IAuthenticationResult> future = application.acquireTokenSilently(parameters);
+
+        ExecutionException ex = assertThrows(ExecutionException.class, future::get);
+        assertInstanceOf(MsalInteractionRequiredException.class, ex.getCause());
+    }
+
+    String readResource(String resource) {
+        try {
+            return new String(Files.readAllBytes(Paths.get(getClass().getResource(resource).toURI())));
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClaimsTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClaimsTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ClaimsTest {
@@ -30,30 +31,25 @@ class ClaimsTest {
         cr.requestClaimInIdToken("sub", new RequestedClaimAdditionalInfo(true, "248289761001", null));
         cr.requestClaimInIdToken("auth_time", new RequestedClaimAdditionalInfo(false, null, null));
 
-        assertEquals(cr.formatAsJSONString(), TestConfiguration.CLAIMS_REQUEST);
+        assertEquals(TestConfiguration.CLAIMS_REQUEST, cr.formatAsJSONString());
     }
 
     @Test
     void testClaimsRequest_MergeWithClientCapabilitiesAndClaimsChallenge() throws URISyntaxException {
 
-        List<String> values = new ArrayList<>();
-        values.add("urn:mace:incommon:iap:silver");
-        values.add("urn:mace:incommon:iap:bronze");
-
         ClaimsRequest cr = new ClaimsRequest();
-        cr.requestClaimInAccessToken("given_name", new RequestedClaimAdditionalInfo(true, null, null));
-        cr.requestClaimInAccessToken("email", null);
-        cr.requestClaimInIdToken("acr", new RequestedClaimAdditionalInfo(false, null, values));
-        cr.requestClaimInIdToken("sub", new RequestedClaimAdditionalInfo(true, "248289761001", null));
-        cr.requestClaimInIdToken("auth_time", new RequestedClaimAdditionalInfo(false, null, null));
+        cr.requestClaimInAccessToken("nbf", new RequestedClaimAdditionalInfo(true, "1701477303", null));
+
+        Set<String> capabilities = new HashSet<>();
+        capabilities.add("cp1");
 
         PublicClientApplication pca = PublicClientApplication.builder(
                 "client_id").
-                clientCapabilities(new HashSet<>(Collections.singletonList("llt"))).
+                clientCapabilities(capabilities).
                 build();
 
         InteractiveRequestParameters parameters = InteractiveRequestParameters.builder(new URI("http://localhost:8080"))
-                .claimsChallenge("{\"id_token\":{\"auth_time\":{\"essential\":true}},\"access_token\":{\"auth_time\":{\"essential\":true},\"xms_cc\":{\"values\":[\"abc\"]}}}")
+                .claimsChallenge(TestConfiguration.CLAIMS_CHALLENGE)
                 .claims(cr)
                 .scopes(Collections.singleton(""))
                 .build();
@@ -65,18 +61,17 @@ class ClaimsTest {
         String mergedClaimsAndChallenge = JsonHelper.mergeJSONString(claimsChallenge, claimsRequest);
         String mergedAll = JsonHelper.mergeJSONString(claimsChallenge, mergedClaimsAndCapabilities);
 
-        assertEquals(clientCapabilities, TestConfiguration.CLIENT_CAPABILITIES);
-        assertEquals(claimsChallenge, TestConfiguration.CLAIMS_CHALLENGE);
-        assertEquals(claimsRequest, TestConfiguration.CLAIMS_REQUEST);
-        assertEquals(mergedClaimsAndCapabilities, TestConfiguration.MERGED_CLAIMS_AND_CAPABILITIES);
-        assertEquals(mergedClaimsAndChallenge, TestConfiguration.MERGED_CLAIMS_AND_CHALLENGE);
-        assertEquals(mergedAll, TestConfiguration.MERGED_CLAIMS_CAPABILITIES_AND_CHALLENGE);
+        assertEquals(TestConfiguration.CLIENT_CAPABILITIES, clientCapabilities);
+        assertEquals(TestConfiguration.CLAIMS_CHALLENGE, claimsChallenge);
+        assertEquals(TestConfiguration.MERGED_CLAIMS_AND_CAPABILITIES, mergedClaimsAndCapabilities);
+        assertEquals(TestConfiguration.MERGED_CLAIMS_AND_CHALLENGE, mergedClaimsAndChallenge);
+        assertEquals(TestConfiguration.MERGED_CLAIMS_CAPABILITIES_AND_CHALLENGE, mergedAll);
     }
 
     @Test
     void testClaimsRequest_StringToClaimsRequest() {
         ClaimsRequest cr = ClaimsRequest.formatAsClaimsRequest(TestConfiguration.CLAIMS_CHALLENGE);
 
-        assertEquals(cr.formatAsJSONString(), TestConfiguration.CLAIMS_CHALLENGE);
+        assertEquals(TestConfiguration.CLAIMS_CHALLENGE, cr.formatAsJSONString());
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestConfiguration.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestConfiguration.java
@@ -80,9 +80,9 @@ public final class TestConfiguration {
             "\"suberror\":\"basic_action\"}";
 
     public final static String CLAIMS_REQUEST = "{\"id_token\":{\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\",\"urn:mace:incommon:iap:bronze\"]},\"sub\":{\"essential\":true,\"value\":\"248289761001\"},\"auth_time\":{}},\"access_token\":{\"given_name\":{\"essential\":true},\"email\":null}}";
-    public final static String CLAIMS_CHALLENGE = "{\"id_token\":{\"auth_time\":{\"essential\":true}},\"access_token\":{\"auth_time\":{\"essential\":true},\"xms_cc\":{\"values\":[\"abc\"]}}}";
-    public final static String CLIENT_CAPABILITIES = "{\"access_token\":{\"xms_cc\":{\"values\":[\"llt\"]}}}";
-    public final static String MERGED_CLAIMS_AND_CAPABILITIES = "{\"id_token\":{\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\",\"urn:mace:incommon:iap:bronze\"]},\"sub\":{\"essential\":true,\"value\":\"248289761001\"},\"auth_time\":{}},\"access_token\":{\"given_name\":{\"essential\":true},\"email\":null,\"xms_cc\":{\"values\":[\"llt\"]}}}";
-    public final static String MERGED_CLAIMS_AND_CHALLENGE = "{\"id_token\":{\"auth_time\":{\"essential\":true},\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\",\"urn:mace:incommon:iap:bronze\"]},\"sub\":{\"essential\":true,\"value\":\"248289761001\"}},\"access_token\":{\"auth_time\":{\"essential\":true},\"xms_cc\":{\"values\":[\"abc\"]},\"given_name\":{\"essential\":true},\"email\":null}}";
-    public final static String MERGED_CLAIMS_CAPABILITIES_AND_CHALLENGE = "{\"id_token\":{\"auth_time\":{\"essential\":true},\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\",\"urn:mace:incommon:iap:bronze\"]},\"sub\":{\"essential\":true,\"value\":\"248289761001\"}},\"access_token\":{\"auth_time\":{\"essential\":true},\"xms_cc\":{\"values\":[\"llt\"]},\"given_name\":{\"essential\":true},\"email\":null}}";
+    public final static String CLAIMS_CHALLENGE = "{\"access_token\":{\"nbf\":{\"essential\":true,\"value\":\"1701477303\"}}}";
+    public final static String CLIENT_CAPABILITIES = "{\"access_token\":{\"xms_cc\":{\"values\":[\"cp1\"]}}}";
+    public final static String MERGED_CLAIMS_AND_CAPABILITIES = "{\"access_token\":{\"nbf\":{\"essential\":true,\"value\":\"1701477303\"},\"xms_cc\":{\"values\":[\"cp1\"]}}}";
+    public final static String MERGED_CLAIMS_AND_CHALLENGE = "{\"access_token\":{\"nbf\":{\"essential\":true,\"value\":\"1701477303\"}}}";
+    public final static String MERGED_CLAIMS_CAPABILITIES_AND_CHALLENGE = "{\"access_token\":{\"nbf\":{\"essential\":true,\"value\":\"1701477303\"},\"xms_cc\":{\"values\":[\"cp1\"]}}}";
 }

--- a/msal4j-sdk/src/test/resources/AAD_cache_data/full_cache.json
+++ b/msal4j-sdk/src/test/resources/AAD_cache_data/full_cache.json
@@ -1,0 +1,48 @@
+{
+  "AccessToken": {
+    "home_account_id-login.windows.net-accesstoken-client_id-realm-scopes": {
+      "home_account_id": "home_account_id",
+      "environment": "login.windows.net",
+      "client_id": "client_id",
+      "secret": "token",
+      "credential_type": "AccessToken",
+      "realm": "realm",
+      "target": "scopes",
+      "cached_at": "9999999999999",
+      "expires_on": "9999999999999",
+      "extended_expires_on": "9999999999999"
+    }
+  },
+  "RefreshToken": {
+    "home_account_id-login.windows.net-refreshtoken-client_id--": {
+      "home_account_id": "home_account_id",
+      "environment": "login.windows.net",
+      "client_id": "client_id",
+      "secret": "token",
+      "credential_type": "RefreshToken"
+    }
+  },
+  "IdToken": {
+    "home_account_id-login.windows.net-idtoken-client_id-realm-": {
+      "home_account_id": "home_account_id",
+      "environment": "login.windows.net",
+      "client_id": "client_id",
+      "secret": "token",
+      "credential_type": "IdToken",
+      "realm": "realm"
+    }
+  },
+  "Account": {
+    "home_account_id-login.windows.net-realm": {
+      "home_account_id": "home_account_id",
+      "environment": "login.windows.net",
+      "realm": "realm",
+      "local_account_id": "local_account_id",
+      "username": "username",
+      "name": "name",
+      "client_info": "client_info",
+      "authority_type": "authority_type"
+    }
+  },
+  "AppMetadata": {}
+}


### PR DESCRIPTION
The first commit in this PR refactors the logic for determining when a refresh should be performed, since it had gotten complex as different scenarios and edge cases were introduced over the years. That refactor should not affect the existing refresh behavior. 

The second commit adds the existence of the claims parameter as reason to refresh, as per https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/794. With this change app developers will no longer need to explicitly use the forceRefresh() API when dealing with tokens that have claims/client capabilities/etc.