### PR TITLE
Change Cloudshell request method from POST to GET

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractManagedIdentitySource.java
@@ -49,12 +49,11 @@ abstract class AbstractManagedIdentitySource {
         IHttpResponse response;
 
         try {
-
-            HttpRequest httpRequest = managedIdentityRequest.method.equals(HttpMethod.GET) ?
-                    new HttpRequest(HttpMethod.GET,
+            HttpRequest httpRequest = StringHelper.isNullOrBlank(managedIdentityRequest.getBodyAsString()) ?
+                    new HttpRequest(managedIdentityRequest.method,
                             managedIdentityRequest.computeURI().toString(),
                             managedIdentityRequest.headers) :
-                    new HttpRequest(HttpMethod.POST,
+                    new HttpRequest(managedIdentityRequest.method,
                             managedIdentityRequest.computeURI().toString(),
                             managedIdentityRequest.headers,
                             managedIdentityRequest.getBodyAsString());

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractManagedIdentitySource.java
@@ -49,14 +49,9 @@ abstract class AbstractManagedIdentitySource {
         IHttpResponse response;
 
         try {
-            HttpRequest httpRequest = StringHelper.isNullOrBlank(managedIdentityRequest.getBodyAsString()) ?
-                    new HttpRequest(managedIdentityRequest.method,
+            HttpRequest httpRequest = new HttpRequest(managedIdentityRequest.method,
                             managedIdentityRequest.computeURI().toString(),
-                            managedIdentityRequest.headers) :
-                    new HttpRequest(managedIdentityRequest.method,
-                            managedIdentityRequest.computeURI().toString(),
-                            managedIdentityRequest.headers,
-                            managedIdentityRequest.getBodyAsString());
+                            managedIdentityRequest.headers);
             response = serviceBundle.getHttpHelper().executeHttpRequest(httpRequest, managedIdentityRequest.requestContext(), serviceBundle);
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CloudShellManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CloudShellManagedIdentitySource.java
@@ -26,9 +26,6 @@ class CloudShellManagedIdentitySource extends AbstractManagedIdentitySource{
         managedIdentityRequest.headers.put("ContentType", "application/x-www-form-urlencoded");
         managedIdentityRequest.headers.put("Metadata", "true");
 
-        managedIdentityRequest.bodyParameters = new HashMap<>();
-        managedIdentityRequest.bodyParameters.put("resource", Collections.singletonList(resource));
-
         managedIdentityRequest.queryParameters = new HashMap<>();
         managedIdentityRequest.queryParameters.put("resource", Collections.singletonList(resource));
     }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CloudShellManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CloudShellManagedIdentitySource.java
@@ -20,15 +20,17 @@ class CloudShellManagedIdentitySource extends AbstractManagedIdentitySource{
     @Override
     public void createManagedIdentityRequest(String resource) {
         managedIdentityRequest.baseEndpoint = msiEndpoint;
-        managedIdentityRequest.method = HttpMethod.POST;
+        managedIdentityRequest.method = HttpMethod.GET;
 
         managedIdentityRequest.headers = new HashMap<>();
         managedIdentityRequest.headers.put("ContentType", "application/x-www-form-urlencoded");
         managedIdentityRequest.headers.put("Metadata", "true");
-        managedIdentityRequest.headers.put("resource", resource);
 
         managedIdentityRequest.bodyParameters = new HashMap<>();
         managedIdentityRequest.bodyParameters.put("resource", Collections.singletonList(resource));
+
+        managedIdentityRequest.queryParameters = new HashMap<>();
+        managedIdentityRequest.queryParameters.put("resource", Collections.singletonList(resource));
     }
 
     private CloudShellManagedIdentitySource(MsalRequest msalRequest, ServiceBundle serviceBundle, URI msiEndpoint)

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -86,10 +86,11 @@ class ManagedIdentityTests {
 
                 headers.put("ContentType", "application/x-www-form-urlencoded");
                 headers.put("Metadata", "true");
-                headers.put("resource", resource);
 
                 bodyParameters.put("resource", Collections.singletonList(resource));
-                return new HttpRequest(HttpMethod.POST, computeUri(endpoint, queryParameters), headers, URLUtils.serializeParameters(bodyParameters));
+
+                queryParameters.put("resource", Collections.singletonList(resource));
+                return new HttpRequest(HttpMethod.GET, computeUri(endpoint, queryParameters), headers, URLUtils.serializeParameters(bodyParameters));
             }
             case IMDS: {
                 endpoint = IMDS_ENDPOINT;


### PR DESCRIPTION
Testing by the Azure SDK team has shown an issue when making the POST request for Cloudshell, where the server responds with a error message saying the resource is missing from the request. This only occurs when using Netty, a common networking framework for Java, and POST requests work fine in other MSALs.

However, further testing has shown it works fine in Netty and other common frameworks if it is a GET request with resource as a query parameter, and this PR makes that change as a workaround. This change should not affect any existing working customers, and we should be able to swap back to a POST request in the future if we need to.