### PR TITLE
Fix for supplied SSLSocketFactory being ignored

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClient.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClient.java
@@ -90,9 +90,7 @@ class DefaultHttpClient implements IHttpClient {
         connection.setConnectTimeout(connectTimeout);
         connection.setReadTimeout(readTimeout);
 
-        if (connection instanceof HttpURLConnection) {
-            return (HttpURLConnection) connection;
-        } else {
+        if (connection instanceof HttpsURLConnection) {
             HttpsURLConnection httpsConnection = (HttpsURLConnection) connection;
 
             if (sslSocketFactory != null) {
@@ -100,6 +98,8 @@ class DefaultHttpClient implements IHttpClient {
             }
 
             return httpsConnection;
+        } else {
+            return (HttpURLConnection) connection;
         }
     }
 


### PR DESCRIPTION
It was checking if the connection is an instance of ```HttpURLConnection```, but since ```HttpsURLConnection``` extends ```HttpURLConnection``` it's always true and the else is never executed. 

https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/820