### PR TITLE
API fixes

### DIFF
--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -172,6 +172,33 @@
         <sourceDirectory>${project.build.directory}/delombok</sourceDirectory>
         <plugins>
             <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+                <version>0.15.0</version>
+                <configuration>
+                    <analysisConfiguration>
+                        <revapi.java>
+                            <checks>
+                                <failBuildOnProblemsFound>false</failBuildOnProblemsFound>
+                            </checks>
+                        </revapi.java>
+                    </analysisConfiguration>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.revapi</groupId>
+                        <artifactId>revapi-java</artifactId>
+                        <version>0.28.1</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>check</id>
+                        <goals><goal>check</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>
                 <version>1.18.2.0</version>

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
@@ -426,6 +426,100 @@ public abstract class AbstractClientApplicationBase extends AbstractApplicationB
             return self();
         }
 
+        /**
+         * Set logPii - boolean value, which determines
+         * whether Pii (personally identifiable information) will be logged in.
+         * The default value is false.
+         *
+         * @param val a boolean value for logPii
+         * @return instance of the Builder on which method was called
+         */
+        public T logPii(boolean val) {
+            return super.logPii(val);
+        }
+
+        /**
+         * Sets the connect timeout value used in HttpsURLConnection connections made by {@link DefaultHttpClient},
+         * and is not needed if using a custom HTTP client
+         *
+         * @param val timeout value in milliseconds
+         * @return instance of the Builder on which method was called
+         */
+        public T connectTimeoutForDefaultHttpClient(Integer val) {
+            return super.connectTimeoutForDefaultHttpClient(val);
+        }
+
+        /**
+         * Sets the read timeout value used in HttpsURLConnection connections made by {@link DefaultHttpClient},
+         * and is not needed if using a custom HTTP client
+         *
+         * @param val timeout value in milliseconds
+         * @return instance of the Builder on which method was called
+         */
+        public T readTimeoutForDefaultHttpClient(Integer val) {
+            return super.readTimeoutForDefaultHttpClient(val);
+        }
+
+        /**
+         * Sets HTTP client to be used by the client application for all HTTP requests. Allows for fine
+         * grained configuration of HTTP client.
+         *
+         * @param val Implementation of {@link IHttpClient}
+         * @return instance of the Builder on which method was called
+         */
+        public T httpClient(IHttpClient val) {
+            return super.httpClient(val);
+        }
+
+        /**
+         * Sets SSLSocketFactory to be used by the client application for all network communication.
+         * If HTTP client is set on the client application (via ClientApplication.builder().httpClient()),
+         * any configuration of SSL should be done on the HTTP client and not through this method.
+         *
+         * @param val an instance of SSLSocketFactory
+         * @return instance of the Builder on which method was called
+         */
+        public T sslSocketFactory(SSLSocketFactory val) {
+            return super.sslSocketFactory(val);
+        }
+
+        /**
+         * Sets ExecutorService to be used to execute the requests.
+         * Developer is responsible for maintaining the lifecycle of the ExecutorService.
+         *
+         * @param val an instance of ExecutorService
+         * @return instance of the Builder on which method was called
+         */
+        public T executorService(ExecutorService val) {
+            return super.executorService(val);
+        }
+
+        /**
+         * Sets Proxy configuration to be used by the client application (MSAL4J by default uses
+         * {@link javax.net.ssl.HttpsURLConnection}) for all network communication.
+         * If no proxy value is passed in, system defined properties are used. If HTTP client is set on
+         * the client application (via ClientApplication.builder().httpClient()),
+         * proxy configuration should be done on the HTTP client object being passed in,
+         * and not through this method.
+         *
+         * @param val an instance of Proxy
+         * @return instance of the Builder on which method was called
+         */
+        public T proxy(Proxy val) {
+            return super.proxy(val);
+        }
+
+        /**
+         * Set optional correlation id to be used by the API.
+         * If not provided, the API generates a random UUID.
+         *
+         * @param val a string value of correlation id
+         * @return instance of the Builder on which method was called
+         */
+        public T correlationId(String val) {
+            return super.correlationId(val);
+        }
+
         abstract AbstractClientApplicationBase build();
     }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IAuthenticationResult.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IAuthenticationResult.java
@@ -48,5 +48,7 @@ public interface IAuthenticationResult extends Serializable {
     /**
      * @return various metadata relating to this authentication result
      */
-    AuthenticationResultMetadata metadata();
+    default AuthenticationResultMetadata metadata() {
+        return new AuthenticationResultMetadata();
+    }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IAuthenticationResult.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IAuthenticationResult.java
@@ -49,6 +49,6 @@ public interface IAuthenticationResult extends Serializable {
      * @return various metadata relating to this authentication result
      */
     default AuthenticationResultMetadata metadata() {
-        return new AuthenticationResultMetadata();
+        return AuthenticationResultMetadata.builder().build();
     }
 }


### PR DESCRIPTION
Public and confidential applications have a number of configurable options that are not relevant for managed identity applications, so as part of some refactoring (https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/715) a new parent abstract class was made to contain only configs that applied to all application types. 

Doing so meant moving several public APIs in a builder class up to the new parent class's builder, and this caused a breaking change in 1.15.0 that was not caught during beta testing: as described in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/806, if you used msal4j 1.15.0 and a dependency compiled with a pre-1.15.0 version, then your project would compile fine but you would hit a NoSuchMethodError at runtime if the dependency referenced one of the moved APIs. 

This PR restores the APIs to the original abstract class to be compatible with pre-1.15.0 versions, and leaves the newer APIs as-is to be compatible with those using 1.15.0. Although this creates a bit of duplicate code, it was the simplest way to ensure compatibility with all versions.

Additionally, this PR adds a default method for a new API that was introduced into an interface in 1.15.0, and adds the [revapi](https://revapi.org/revapi-site/main/index.html) plugin in order catch these sorts of breaking API changes going forward.