### PR TITLE
Expose refreshon parameter in authentication result

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResult.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResult.java
@@ -92,7 +92,7 @@ final class AuthenticationResult implements IAuthenticationResult {
     private final String scopes;
 
     @Builder.Default
-    private final AuthenticationResultMetadata metadata = new AuthenticationResultMetadata();
+    private final AuthenticationResultMetadata metadata = AuthenticationResultMetadata.builder().build();
 
     @Getter(value = AccessLevel.PACKAGE)
     private final Boolean isPopAuthorization;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultMetadata.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultMetadata.java
@@ -4,6 +4,7 @@
 package com.microsoft.aad.msal4j;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -16,17 +17,9 @@ import java.io.Serializable;
 @Accessors(fluent = true)
 @Getter
 @Setter(AccessLevel.PACKAGE)
+@Builder
 public class AuthenticationResultMetadata implements Serializable {
 
     private TokenSource tokenSource;
-
-    /**
-     * Sets default metadata values. Used when creating an {@link IAuthenticationResult} before the values are known.
-     */
-    AuthenticationResultMetadata() {
-    }
-
-    AuthenticationResultMetadata(TokenSource tokenSource) {
-        this.tokenSource = tokenSource;
-    }
+    private Long refreshOn;
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -155,7 +155,10 @@ class TokenRequestExecutor {
                     refreshOn(response.getRefreshIn() > 0 ? currTimestampSec + response.getRefreshIn() : 0).
                     accountCacheEntity(accountCacheEntity).
                     scopes(response.getScope()).
-                    metadata(new AuthenticationResultMetadata(TokenSource.IDENTITY_PROVIDER)).
+                    metadata(AuthenticationResultMetadata.builder()
+                            .tokenSource(TokenSource.IDENTITY_PROVIDER)
+                            .refreshOn(response.getRefreshIn() > 0 ? currTimestampSec + response.getRefreshIn() : 0)
+                            .build()).
                     build();
 
         } else {


### PR DESCRIPTION
Exposes the refresh on parameter in the AuthenticationResultMetadata field of an AuthenticationResult, as per https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/822

Also replaces the (package-private) AuthenticationResultMetadata constructors with lombok's builder annotation to better handle setting the new refreshOn field and any others that may get added.