### PR TITLE
Add missing refreshOn metadata

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByAppProviderSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByAppProviderSupplier.java
@@ -87,6 +87,9 @@ class AcquireTokenByAppProviderSupplier extends AuthenticationResultSupplier {
                 .idToken(null)
                 .expiresOn(tokenProviderResult.getExpiresInSeconds())
                 .refreshOn(tokenProviderResult.getRefreshInSeconds())
+                .metadata(AuthenticationResultMetadata.builder()
+                        .refreshOn(tokenProviderResult.getRefreshInSeconds() > 0 ? tokenProviderResult.getRefreshInSeconds() : 0)
+                        .build())
                 .build();
     }
 }


### PR DESCRIPTION
A new field of auth result metadata was recently added to AuthenticationResults in https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/829

However, as described in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/836, there are some other code paths where the AuthenticationResult is built and was missing the metadata object in the builder. 