### PR TITLE
Use SHA256 thumbprints in non-ADFS cert flows

### DIFF
--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/ClientCredentialsIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/ClientCredentialsIT.java
@@ -160,7 +160,7 @@ class ClientCredentialsIT {
                 clientId,
                 (ClientCertificate) certificate,
                 "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-                true);
+                true, false);
     }
 
     private void assertAcquireTokenCommon(String clientId, IClientCredential credential, String authority) throws Exception {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
@@ -8,8 +8,6 @@ import lombok.experimental.Accessors;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.MessageDigest;
@@ -21,7 +19,6 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.security.interfaces.RSAPrivateKey;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -53,7 +50,7 @@ final class ClientCertificate implements IClientCertificate {
             throws CertificateEncodingException, NoSuchAlgorithmException {
 
         return Base64.getEncoder().encodeToString(ClientCertificate
-                .getHash(publicKeyCertificateChain.get(0).getEncoded()));
+                .getHashSha256(publicKeyCertificateChain.get(0).getEncoded()));
     }
 
     public String publicCertificateHashSha1()
@@ -132,7 +129,7 @@ final class ClientCertificate implements IClientCertificate {
         return md.digest();
     }
 
-    private static byte[] getHash(final byte[] inputBytes) throws NoSuchAlgorithmException {
+    private static byte[] getHashSha256(final byte[] inputBytes) throws NoSuchAlgorithmException {
         final MessageDigest md = MessageDigest.getInstance("SHA-256");
         md.update(inputBytes);
         return md.digest();

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
@@ -56,6 +56,13 @@ final class ClientCertificate implements IClientCertificate {
                 .getHash(publicKeyCertificateChain.get(0).getEncoded()));
     }
 
+    public String publicCertificateHashSha1()
+            throws CertificateEncodingException, NoSuchAlgorithmException {
+
+        return Base64.getEncoder().encodeToString(ClientCertificate
+                .getHashSha1(publicKeyCertificateChain.get(0).getEncoded()));
+    }
+
     public List<String> getEncodedPublicKeyCertificateChain() throws CertificateEncodingException {
         List<String> result = new ArrayList<>();
 
@@ -119,8 +126,14 @@ final class ClientCertificate implements IClientCertificate {
         return new ClientCertificate(key, Arrays.asList(publicKeyCertificate));
     }
 
-    private static byte[] getHash(final byte[] inputBytes) throws NoSuchAlgorithmException {
+    private static byte[] getHashSha1(final byte[] inputBytes) throws NoSuchAlgorithmException {
         final MessageDigest md = MessageDigest.getInstance("SHA-1");
+        md.update(inputBytes);
+        return md.digest();
+    }
+
+    private static byte[] getHash(final byte[] inputBytes) throws NoSuchAlgorithmException {
+        final MessageDigest md = MessageDigest.getInstance("SHA-256");
         md.update(inputBytes);
         return md.digest();
     }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
@@ -101,7 +101,11 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
         } else if (clientCredential instanceof ClientCertificate) {
             this.clientCertAuthentication = true;
             this.clientCertificate = (ClientCertificate) clientCredential;
-            clientAuthentication = buildValidClientCertificateAuthority();
+            if (Authority.detectAuthorityType(this.authenticationAuthority.canonicalAuthorityUrl()) == AuthorityType.ADFS) {
+                clientAuthentication = buildValidClientCertificateAuthorityLegacySha1();
+            } else  {
+                clientAuthentication = buildValidClientCertificateAuthority();
+            }
         } else if (clientCredential instanceof ClientAssertion) {
             clientAuthentication = createClientAuthFromClientAssertion((ClientAssertion) clientCredential);
         } else {
@@ -127,7 +131,18 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
                 clientId(),
                 clientCertificate,
                 this.authenticationAuthority.selfSignedJwtAudience(),
-                sendX5c);
+                sendX5c,
+                false);
+        return createClientAuthFromClientAssertion(clientAssertion);
+    }
+
+    private ClientAuthentication buildValidClientCertificateAuthorityLegacySha1() {
+        ClientAssertion clientAssertion = JwtHelper.buildJwt(
+                clientId(),
+                clientCertificate,
+                this.authenticationAuthority.selfSignedJwtAudience(),
+                sendX5c,
+                true);
         return createClientAuthFromClientAssertion(clientAssertion);
     }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
@@ -102,7 +102,7 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
             this.clientCertAuthentication = true;
             this.clientCertificate = (ClientCertificate) clientCredential;
             if (Authority.detectAuthorityType(this.authenticationAuthority.canonicalAuthorityUrl()) == AuthorityType.ADFS) {
-                clientAuthentication = buildValidClientCertificateAuthorityLegacySha1();
+                clientAuthentication = buildValidClientCertificateAuthoritySha1();
             } else  {
                 clientAuthentication = buildValidClientCertificateAuthority();
             }
@@ -136,7 +136,9 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
         return createClientAuthFromClientAssertion(clientAssertion);
     }
 
-    private ClientAuthentication buildValidClientCertificateAuthorityLegacySha1() {
+    //The library originally used SHA-1 for thumbprints as other algorithms were not supported server-side,
+    //  and while support for SHA-256 has been added certain flows still only allow SHA-1
+    private ClientAuthentication buildValidClientCertificateAuthoritySha1() {
         ClientAssertion clientAssertion = JwtHelper.buildJwt(
                 clientId(),
                 clientCertificate,

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JwtHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JwtHelper.java
@@ -21,7 +21,8 @@ import com.nimbusds.jwt.SignedJWT;
 final class JwtHelper {
 
     static ClientAssertion buildJwt(String clientId, final ClientCertificate credential,
-                                    final String jwtAudience, boolean sendX5c) throws MsalClientException {
+                                    final String jwtAudience, boolean sendX5c,
+                                    boolean useLegacySha1) throws MsalClientException {
         if (StringHelper.isBlank(clientId)) {
             throw new IllegalArgumentException("clientId is null or empty");
         }
@@ -55,7 +56,11 @@ final class JwtHelper {
                 builder.x509CertChain(certs);
             }
 
-            builder.x509CertThumbprint(new Base64URL(credential.publicCertificateHash()));
+            if (useLegacySha1) {
+                builder.x509CertThumbprint(new Base64URL(credential.publicCertificateHashSha1()));
+            } else {
+                builder.x509CertSHA256Thumbprint(new Base64URL(credential.publicCertificateHash()));
+            }
 
             jwt = new SignedJWT(builder.build(), claimsSet);
             final RSASSASigner signer = new RSASSASigner(credential.privateKey());

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JwtHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JwtHelper.java
@@ -22,7 +22,7 @@ final class JwtHelper {
 
     static ClientAssertion buildJwt(String clientId, final ClientCertificate credential,
                                     final String jwtAudience, boolean sendX5c,
-                                    boolean useLegacySha1) throws MsalClientException {
+                                    boolean useSha1) throws MsalClientException {
         if (StringHelper.isBlank(clientId)) {
             throw new IllegalArgumentException("clientId is null or empty");
         }
@@ -56,7 +56,8 @@ final class JwtHelper {
                 builder.x509CertChain(certs);
             }
 
-            if (useLegacySha1) {
+            //SHA-256 is preferred, however certain flows still require SHA-1 due to what is supported server-side
+            if (useSha1) {
                 builder.x509CertThumbprint(new Base64URL(credential.publicCertificateHashSha1()));
             } else {
                 builder.x509CertSHA256Thumbprint(new Base64URL(credential.publicCertificateHash()));


### PR DESCRIPTION
Updates the internal thumbprint method for certificate flows from SHA-1 to SHA-256, as per https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/760

ADFS scenarios must still use SHA-1 until SHA-256 is supported server-side.