### PR TITLE
fix: Maven enforcer plugin needs correct versions

### DIFF
--- a/msal4j-persistence-extension/pom.xml
+++ b/msal4j-persistence-extension/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>msal4j</artifactId>
-            <version>1.15.0</version>
+            <version>1.15.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The Maven enforcer plugin currently produces an error with the following pom.xml

```xml
    <properties>
        <azure-sdk-bom.version>1.2.25</azure-sdk-bom.version>
    </properties>
    <dependencyManagement>
        <dependencies>
            <dependency>
                <groupId>com.azure</groupId>
                <artifactId>azure-sdk-bom</artifactId>
                <version>${azure-sdk-bom.version}</version>
                <type>pom</type>
                <scope>import</scope>
            </dependency>
    </dependencyManagement>
    <dependencies>
        <dependency>
            <groupId>com.azure</groupId>
            <artifactId>azure-identity</artifactId>
        </dependency>
    </dependencies>
```

```
Dependency convergence error for com.microsoft.azure:msal4j:jar:1.15.1 paths to dependency are:
+-com.example.myproject:jar:0.0.1-local
  +-com.azure:azure-identity:jar:1.13.0:compile
    +-com.microsoft.azure:msal4j:jar:1.15.1:compile
and
+-com.example.myproject:jar:0.0.1-local
  +-com.azure:azure-identity:jar:1.13.0:compile
    +-com.microsoft.azure:msal4j-persistence-extension:jar:1.3.0:compile
      +-com.microsoft.azure:msal4j:jar:1.15.0:compile
```