### PR TITLE
Reduce logging level of CACHE_MISS <GitHub Issue #833>

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultSupplier.java
@@ -95,10 +95,17 @@ abstract class AuthenticationResultSupplier implements Supplier<IAuthenticationR
                         msalRequest.requestContext().correlationId(),
                         error);
 
-                clientApplication.log.warn(
-                        LogHelper.createMessage(
-                                String.format("Execution of %s failed: %s", this.getClass(), ex.getMessage()),
-                                msalRequest.headers().getHeaderCorrelationIdValue()));
+                String logMessage = LogHelper.createMessage(
+                        String.format("Execution of %s failed: %s", this.getClass(), ex.getMessage()),
+                        msalRequest.headers().getHeaderCorrelationIdValue());
+                if (ex instanceof MsalClientException) {
+                    MsalClientException exception = (MsalClientException) ex;
+                    if (exception.errorCode() != null && exception.errorCode().equalsIgnoreCase(AuthenticationErrorCode.CACHE_MISS)) {
+                        clientApplication.log.debug(logMessage);
+                    }
+                } else {
+                    clientApplication.log.warn(logMessage);
+                }
 
                 throw new CompletionException(ex);
             }


### PR DESCRIPTION
Addresses GitHub Issue #833 by reducing the logging level of a CACHE_MISS in the AuthenticationResultSupplier to debug level.

Avery-Dunn:
> I agree that a cache miss exception should cause a debug log, since it doesn't necessarily mean that something wrong. It'll be a quick fix so will likely be in our next release, and I'll update this thread once we have some ETAs

Without this patch, the logging output is overly verbose about CACHE_MISS events.  This should resolve that issue by changing the logging level.