### PR TITLE
Make ManagedIdentitySourceType enum public

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentitySourceType.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentitySourceType.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
-enum ManagedIdentitySourceType {
+public enum ManagedIdentitySourceType {
     // Default.
     NONE,
     // The source used to acquire token for managed identity is IMDS.


### PR DESCRIPTION
In https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/823 a public API for the ManagedIdentitySourceType was added, however the existing enum that got returned in the new API was package-private. This PR makes it public.