### PR TITLE
Version updates for 1.16.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Quick links:
 The library supports the following Java environments:
 - Java 8 (or higher)
 
-Current version - 1.16.1
+Current version - 1.16.2
 
 You can find the changes for each version in the [change log](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/main/msal4j-sdk/changelog.txt).
 
@@ -28,13 +28,13 @@ Find [the latest package in the Maven repository](https://mvnrepository.com/arti
 <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>msal4j</artifactId>
-    <version>1.16.1</version>
+    <version>1.16.2</version>
 </dependency>
 ```
 ### Gradle
 
 ```gradle
-implementation group: 'com.microsoft.azure', name: 'com.microsoft.aad.msal4j', version: '1.16.1'
+implementation group: 'com.microsoft.azure', name: 'com.microsoft.aad.msal4j', version: '1.16.2'
 ```
 
 ## Usage

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+Version 1.16.2
+=============
+- Use SHA256 thumbprints in non-ADFS cert flows (#840)
+- Reduce logging level of cache miss messages (#844)
+- Make ManagedIdentitySourceType enum public (#845)
+
 Version 1.16.1
 =============
 - Add missing refreshOn metadata (#838)

--- a/msal4j-sdk/README.md
+++ b/msal4j-sdk/README.md
@@ -16,7 +16,7 @@ Quick links:
 The library supports the following Java environments:
 - Java 8 (or higher)
 
-Current version - 1.16.1
+Current version - 1.16.2
 
 You can find the changes for each version in the [change log](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/master/changelog.txt).
 
@@ -28,13 +28,13 @@ Find [the latest package in the Maven repository](https://mvnrepository.com/arti
 <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>msal4j</artifactId>
-    <version>1.16.1</version>
+    <version>1.16.2</version>
 </dependency>
 ```
 ### Gradle
 
 ```gradle
-compile group: 'com.microsoft.azure', name: 'msal4j', version: '1.16.1'
+compile group: 'com.microsoft.azure', name: 'msal4j', version: '1.16.2'
 ```
 
 ## Usage

--- a/msal4j-sdk/bnd.bnd
+++ b/msal4j-sdk/bnd.bnd
@@ -1,2 +1,2 @@
-Export-Package: com.microsoft.aad.msal4j;version="1.16.1"
+Export-Package: com.microsoft.aad.msal4j;version="1.16.2"
 Automatic-Module-Name: com.microsoft.aad.msal4j

--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure</groupId>
 	<artifactId>msal4j</artifactId>
-	<version>1.16.1</version>
+	<version>1.16.2</version>
 	<packaging>jar</packaging>
 	<name>msal4j</name>
 	<description>

--- a/msal4j-sdk/src/samples/msal-b2c-web-sample/pom.xml
+++ b/msal4j-sdk/src/samples/msal-b2c-web-sample/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>com.microsoft.azure</groupId>
 			<artifactId>msal4j</artifactId>
-			<version>1.16.1</version>
+			<version>1.16.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.nimbusds</groupId>

--- a/msal4j-sdk/src/samples/msal-obo-sample/pom.xml
+++ b/msal4j-sdk/src/samples/msal-obo-sample/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>msal4j</artifactId>
-            <version>1.16.1</version>
+            <version>1.16.2</version>
         </dependency>
         <dependency>
             <groupId>com.nimbusds</groupId>

--- a/msal4j-sdk/src/samples/msal-web-sample/pom.xml
+++ b/msal4j-sdk/src/samples/msal-web-sample/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>com.microsoft.azure</groupId>
 			<artifactId>msal4j</artifactId>
-			<version>1.16.1</version>
+			<version>1.16.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.nimbusds</groupId>


### PR DESCRIPTION
- Use SHA256 thumbprints in non-ADFS cert flows (#840)
- Reduce logging level of cache miss messages (#844)
- Make ManagedIdentitySourceType enum public (#845)