### PR TITLE
Bump com.nimbusds.oauth2-oidc-sdk from 11.9.1 to 11.18

### DIFF
--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>11.9.1</version>
+            <version>11.18</version>
         </dependency>
         <dependency>
             <groupId>net.minidev</groupId>


### PR DESCRIPTION
Vulnerabilities from dependencies:
[CVE-2024-34447](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-34447)
[CVE-2024-30172](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-30172)
[CVE-2024-30171](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-30171)
[CVE-2024-29857](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-29857)