### PR TITLE
Make getManagedIdentitySource static

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
@@ -5,7 +5,6 @@ package com.microsoft.aad.msal4j;
 
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
@@ -24,7 +23,8 @@ public class ManagedIdentityApplication extends AbstractApplicationBase implemen
     @Getter
     static TokenCache sharedTokenCache = new TokenCache();
 
-    @Getter(value = AccessLevel.PUBLIC)
+    //Deprecated the field in favor of the static getManagedIdentitySource method
+    @Deprecated
     ManagedIdentitySourceType managedIdentitySource = ManagedIdentityClient.getManagedIdentitySource();
 
     @Getter(value = AccessLevel.PACKAGE)
@@ -104,5 +104,14 @@ public class ManagedIdentityApplication extends AbstractApplicationBase implemen
         protected Builder self() {
             return this;
         }
+    }
+
+    /**
+     * Returns a {@link ManagedIdentitySourceType} value, which is based primarily on environment variables set on the system.
+     *
+     * @return ManagedIdentitySourceType enum for source type
+     */
+    public static ManagedIdentitySourceType getManagedIdentitySource() {
+       return ManagedIdentityClient.getManagedIdentitySource();
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -161,7 +161,7 @@ class ManagedIdentityTests {
                 .build();
 
         ManagedIdentitySourceType miClientSourceType = ManagedIdentityClient.getManagedIdentitySource();
-        ManagedIdentitySourceType miAppSourceType = miApp.managedIdentitySource;
+        ManagedIdentitySourceType miAppSourceType = ManagedIdentityApplication.getManagedIdentitySource();
         assertEquals(expectedSource, miClientSourceType);
         assertEquals(expectedSource, miAppSourceType);
     }


### PR DESCRIPTION
Adjusts `ManagedIdentityApplication` to make the `getManagedIdentitySource` method static. This is to solve a niche issue when testing an application that uses Managed Identity, where a developer would want to test an app with multiple mocked MI sources on one machine.

Although this looks like it is adjusting public APIs, the actual change in the built package is minor and there should be no breaking change:
- Previously, the Lombok `@Getter` annotation was creating a public method called `getManagedIdentitySource` in the final package
- The changes in this PR create an explicit `getManagedIdentitySource` method that is also public, and removes the annotation for Lombok to create that same method
- Putting those two points together, this should be no different from just changing the internals of the method to return the result of `ManagedIdentityClient.getManagedIdentitySource()` rather than the current value of the `managedIdentitySource` field
- Because of all that, the values returned should be the same and the API should look no different in the actual package that gets built

Additionally, static methods can be access through an instance of a class just like a non-static method, so making this method static will at worst cause a minor warning in an IDE about using a static method improperly. The RevAPI plugin was used to ensure that this was the only part of the API that could be considered 'changed' when compared to the last released msal4j package.