### PR TITLE
Version updates for 1.17.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Quick links:
 The library supports the following Java environments:
 - Java 8 (or higher)
 
-Current version - 1.17.2
+Current version - 1.17.3
 
 You can find the changes for each version in the [change log](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/main/msal4j-sdk/changelog.txt).
 
@@ -28,13 +28,13 @@ Find [the latest package in the Maven repository](https://mvnrepository.com/arti
 <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>msal4j</artifactId>
-    <version>1.17.2</version>
+    <version>1.17.3</version>
 </dependency>
 ```
 ### Gradle
 
 ```gradle
-implementation group: 'com.microsoft.azure', name: 'com.microsoft.aad.msal4j', version: '1.17.2'
+implementation group: 'com.microsoft.azure', name: 'com.microsoft.aad.msal4j', version: '1.17.3'
 ```
 
 ## Usage

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 1.17.3
+=============
+- Correctly set buffer for expired tokens (#875)
+- Bump commons-io dependency from 2.7 to 2.14.0 (#871)
+
 Version 1.17.2
 =============
 - Make ManagedIdentityApplication.getManagedIdentitySource static (#864)

--- a/msal4j-sdk/README.md
+++ b/msal4j-sdk/README.md
@@ -16,7 +16,7 @@ Quick links:
 The library supports the following Java environments:
 - Java 8 (or higher)
 
-Current version - 1.17.2
+Current version - 1.17.3
 
 You can find the changes for each version in the [change log](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/master/changelog.txt).
 
@@ -28,13 +28,13 @@ Find [the latest package in the Maven repository](https://mvnrepository.com/arti
 <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>msal4j</artifactId>
-    <version>1.17.2</version>
+    <version>1.17.3</version>
 </dependency>
 ```
 ### Gradle
 
 ```gradle
-compile group: 'com.microsoft.azure', name: 'msal4j', version: '1.17.2'
+compile group: 'com.microsoft.azure', name: 'msal4j', version: '1.17.3'
 ```
 
 ## Usage

--- a/msal4j-sdk/bnd.bnd
+++ b/msal4j-sdk/bnd.bnd
@@ -1,2 +1,2 @@
-Export-Package: com.microsoft.aad.msal4j;version="1.17.2"
+Export-Package: com.microsoft.aad.msal4j;version="1.17.3"
 Automatic-Module-Name: com.microsoft.aad.msal4j

--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure</groupId>
 	<artifactId>msal4j</artifactId>
-	<version>1.17.2</version>
+	<version>1.17.3</version>
 	<packaging>jar</packaging>
 	<name>msal4j</name>
 	<description>


### PR DESCRIPTION
- Correctly set buffer for expired tokens (#875)
- Bump commons-io dependency from 2.7 to 2.14.0 (#871)