### PR TITLE
Bump jackson-databind dependency

### DIFF
--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.2</version>
+            <version>2.18.1</version>
         </dependency>
 
         <!-- test dependencies -->


### PR DESCRIPTION
Resolves https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/882: there is a CVE in jackson-databind that they dispute, but regardless it is causing our library to be flagged in compliance tools and it's easier for us to just update.