### PR TITLE
Improve integration tests

### DIFF
--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -49,6 +49,12 @@
             <version>1.7.36</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.6.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.6</version>

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenInteractiveIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenInteractiveIT.java
@@ -145,7 +145,7 @@ class AcquireTokenInteractiveIT extends SeleniumTest {
             throw new RuntimeException("Error acquiring token with authCode: " + e.getMessage());
         }
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
         assertEquals(user.getUpn(), result.account().username());
     }
 
@@ -157,7 +157,7 @@ class AcquireTokenInteractiveIT extends SeleniumTest {
                 pca,
                 scope);
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
         assertEquals(user.getUpn(), result.account().username());
     }
 
@@ -174,7 +174,7 @@ class AcquireTokenInteractiveIT extends SeleniumTest {
         }
 
         IAuthenticationResult result = acquireTokenInteractive(user, pca, user.getAppId());
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
     }
 
     private void assertAcquireTokenInstanceAware(User user) {
@@ -182,7 +182,7 @@ class AcquireTokenInteractiveIT extends SeleniumTest {
 
         IAuthenticationResult result = acquireTokenInteractive_instanceAware(user, pca, cfg.graphDefaultScope());
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
         assertEquals(user.getUpn(), result.account().username());
 
         //This test is using a client app with the login.microsoftonline.com config to get tokens for a login.microsoftonline.us user,
@@ -236,7 +236,7 @@ class AcquireTokenInteractiveIT extends SeleniumTest {
                 build();
 
         IAuthenticationResult result = acquireTokenInteractive(user, publicCloudPca, TestConstants.USER_READ_SCOPE);
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
         assertEquals(user.getHomeUPN(), result.account().username());
 
         publicCloudPca.removeAccount(publicCloudPca.getAccounts().join().iterator().next()).join();

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -114,9 +113,7 @@ class AuthorizationCodeIT extends SeleniumTest {
                         .build())
                 .get();
 
-        assertNotNull(result);
-        assertNotNull(result.accessToken());
-        assertNotNull(result.idToken());
+        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
         assertEquals(user.getUpn(), result.account().username());
 
         IAuthenticationResult resultSilent = pca.acquireTokenSilently(SilentParameters
@@ -124,7 +121,7 @@ class AuthorizationCodeIT extends SeleniumTest {
                         .build())
                 .get();
 
-        assertNotNull(resultSilent);
+        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
         assertEquals(resultSilent.accessToken(), result.accessToken());
         assertEquals(resultSilent.account().username(), result.account().username());
     }
@@ -146,28 +143,13 @@ class AuthorizationCodeIT extends SeleniumTest {
                 authCode,
                 Collections.singleton(TestConstants.ADFS_SCOPE));
 
-        assertNotNull(result);
-        assertNotNull(result.accessToken());
-        assertNotNull(result.idToken());
+        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
         assertEquals(user.getUpn(), result.account().username());
     }
 
     private void assertAcquireTokenAAD(User user, Map<String, Set<String>> parameters) {
 
-        PublicClientApplication pca;
-        Set<String> clientCapabilities = null;
-        if (parameters != null) {
-            clientCapabilities = parameters.getOrDefault("clientCapabilities", null);
-        }
-        try {
-            pca = PublicClientApplication.builder(
-                    user.getAppId()).
-                    authority(cfg.organizationsAuthority()).
-                    clientCapabilities(clientCapabilities).
-                    build();
-        } catch (MalformedURLException ex) {
-            throw new RuntimeException(ex.getMessage());
-        }
+        PublicClientApplication pca = IntegrationTestHelper.createPublicApp(user.getAppId(), cfg.commonAuthority());
 
         String authCode = acquireAuthorizationCodeAutomated(user, pca, parameters);
         IAuthenticationResult result = acquireTokenAuthorizationCodeFlow(
@@ -175,9 +157,7 @@ class AuthorizationCodeIT extends SeleniumTest {
                 authCode,
                 Collections.singleton(cfg.graphDefaultScope()));
 
-        assertNotNull(result);
-        assertNotNull(result.accessToken());
-        assertNotNull(result.idToken());
+        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
         assertEquals(user.getUpn(), result.account().username());
     }
 
@@ -200,9 +180,7 @@ class AuthorizationCodeIT extends SeleniumTest {
         String authCode = acquireAuthorizationCodeAutomated(user, cca, null);
         IAuthenticationResult result = acquireTokenInteractiveB2C(cca, authCode);
 
-        assertNotNull(result);
-        assertNotNull(result.accessToken());
-        assertNotNull(result.idToken());
+        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
     }
 
     private IAuthenticationResult acquireTokenAuthorizationCodeFlow(

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
@@ -113,7 +113,7 @@ class AuthorizationCodeIT extends SeleniumTest {
                         .build())
                 .get();
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
         assertEquals(user.getUpn(), result.account().username());
 
         IAuthenticationResult resultSilent = pca.acquireTokenSilently(SilentParameters
@@ -121,7 +121,7 @@ class AuthorizationCodeIT extends SeleniumTest {
                         .build())
                 .get();
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
         assertEquals(resultSilent.accessToken(), result.accessToken());
         assertEquals(resultSilent.account().username(), result.account().username());
     }
@@ -143,7 +143,7 @@ class AuthorizationCodeIT extends SeleniumTest {
                 authCode,
                 Collections.singleton(TestConstants.ADFS_SCOPE));
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
         assertEquals(user.getUpn(), result.account().username());
     }
 
@@ -157,7 +157,7 @@ class AuthorizationCodeIT extends SeleniumTest {
                 authCode,
                 Collections.singleton(cfg.graphDefaultScope()));
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
         assertEquals(user.getUpn(), result.account().username());
     }
 
@@ -180,7 +180,7 @@ class AuthorizationCodeIT extends SeleniumTest {
         String authCode = acquireAuthorizationCodeAutomated(user, cca, null);
         IAuthenticationResult result = acquireTokenInteractiveB2C(cca, authCode);
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
     }
 
     private IAuthenticationResult acquireTokenAuthorizationCodeFlow(

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/ClientCredentialsIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/ClientCredentialsIT.java
@@ -48,7 +48,6 @@ class ClientCredentialsIT {
     void acquireTokenClientCredentials_ClientSecret() throws Exception {
         AppCredentialProvider appProvider = new AppCredentialProvider(AzureEnvironment.AZURE);
         final String clientId = appProvider.getLabVaultAppId();
-        final String password = appProvider.getLabVaultPassword();
         IClientCredential credential = CertificateHelper.getClientCertificate();
 
         assertAcquireTokenCommon(clientId, credential, TestConstants.MICROSOFT_AUTHORITY);
@@ -68,7 +67,7 @@ class ClientCredentialsIT {
     @Test
     void acquireTokenClientCredentials_ClientSecret_Ciam() throws Exception {
 
-        User user = labUserProvider.getCiamUser();
+        User user = labUserProvider.getCiamCudUser();
         String clientId = user.getAppId();
 
         AppCredentialProvider appProvider = new AppCredentialProvider(AzureEnvironment.CIAM);

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/Config.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/Config.java
@@ -13,6 +13,7 @@ import lombok.experimental.Accessors;
 public class Config {
     private String organizationsAuthority;
     private String tenantSpecificAuthority;
+    private String commonAuthority;
     private String graphDefaultScope;
     AppCredentialProvider appProvider;
     private String tenant;
@@ -25,6 +26,7 @@ public class Config {
         switch (azureEnvironment) {
             case AzureEnvironment.AZURE:
                 organizationsAuthority = TestConstants.ORGANIZATIONS_AUTHORITY;
+                commonAuthority = TestConstants.COMMON_AUTHORITY;
                 tenantSpecificAuthority = TestConstants.TENANT_SPECIFIC_AUTHORITY;
                 graphDefaultScope = TestConstants.GRAPH_DEFAULT_SCOPE;
                 appProvider = new AppCredentialProvider(azureEnvironment);
@@ -33,6 +35,7 @@ public class Config {
             case AzureEnvironment.AZURE_US_GOVERNMENT:
                 organizationsAuthority = TestConstants.ARLINGTON_ORGANIZATIONS_AUTHORITY;
                 tenantSpecificAuthority = TestConstants.ARLINGTON_TENANT_SPECIFIC_AUTHORITY;
+                commonAuthority = TestConstants.ARLINGTON_COMMON_AUTHORITY;
                 graphDefaultScope = TestConstants.ARLINGTON_GRAPH_DEFAULT_SCOPE;
                 appProvider = new AppCredentialProvider(azureEnvironment);
                 tenant = TestConstants.ARLINGTON_AUTHORITY_TENANT;

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.AfterAll;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.util.Collections;
 import java.util.function.Consumer;
@@ -41,10 +40,7 @@ class DeviceCodeIT {
 
         User user = labUserProvider.getDefaultUser(cfg.azureEnvironment);
 
-        PublicClientApplication pca = PublicClientApplication.builder(
-                user.getAppId()).
-                authority(cfg.tenantSpecificAuthority()).
-                build();
+        PublicClientApplication pca = IntegrationTestHelper.createPublicApp(user.getAppId(), cfg.commonAuthority());
 
         Consumer<DeviceCode> deviceCodeConsumer = (DeviceCode deviceCode) -> runAutomatedDeviceCodeFlow(deviceCode, user);
 
@@ -54,8 +50,7 @@ class DeviceCodeIT {
                 .build())
                 .get();
 
-        assertNotNull(result);
-        assertNotNull(result.accessToken());
+        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
     }
 
     @Test()
@@ -78,8 +73,7 @@ class DeviceCodeIT {
                 .build())
                 .get();
 
-        assertNotNull(result);
-        assertNotNull(result.accessToken());
+        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
     }
 
     @Test()
@@ -87,10 +81,7 @@ class DeviceCodeIT {
 
         User user = labUserProvider.getMSAUser();
 
-        PublicClientApplication pca = PublicClientApplication.builder(
-                user.getAppId()).
-                authority(TestConstants.CONSUMERS_AUTHORITY).
-                build();
+        PublicClientApplication pca = IntegrationTestHelper.createPublicApp(user.getAppId(), TestConstants.CONSUMERS_AUTHORITY);
 
         Consumer<DeviceCode> deviceCodeConsumer = (DeviceCode deviceCode) -> {
             runAutomatedDeviceCodeFlow(deviceCode, user);

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
@@ -50,7 +50,7 @@ class DeviceCodeIT {
                 .build())
                 .get();
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
     }
 
     @Test()
@@ -73,7 +73,7 @@ class DeviceCodeIT {
                 .build())
                 .get();
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
     }
 
     @Test()

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/IntegrationTestHelper.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/IntegrationTestHelper.java
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import java.net.MalformedURLException;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class IntegrationTestHelper {
+
+    static PublicClientApplication createPublicApp(String appID, String authority) {
+        try {
+            return PublicClientApplication.builder(
+                            appID).
+                    authority(authority).
+                    build();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static void assertTokenResultNotNull(IAuthenticationResult result, boolean checkAccessToken, boolean checkIDToken) {
+        assertNotNull(result);
+        if (checkAccessToken) assertNotNull(result.accessToken());
+        if (checkIDToken) assertNotNull(result.idToken());
+    }
+}

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/IntegrationTestHelper.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/IntegrationTestHelper.java
@@ -20,9 +20,9 @@ class IntegrationTestHelper {
         }
     }
 
-    static void assertTokenResultNotNull(IAuthenticationResult result, boolean checkAccessToken, boolean checkIDToken) {
+    static void assertAccessAndIdTokensNotNull(IAuthenticationResult result) {
         assertNotNull(result);
-        if (checkAccessToken) assertNotNull(result.accessToken());
-        if (checkIDToken) assertNotNull(result.idToken());
+        assertNotNull(result.accessToken());
+        assertNotNull(result.idToken());
     }
 }

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 public class TestConstants {
     public final static String KEYVAULT_DEFAULT_SCOPE = "https://vault.azure.net/.default";
     public final static String MSIDLAB_DEFAULT_SCOPE = "https://request.msidlab.com/.default";
@@ -34,15 +30,9 @@ public class TestConstants {
     public final static String TENANT_SPECIFIC_AUTHORITY = MICROSOFT_AUTHORITY_HOST + MICROSOFT_AUTHORITY_TENANT;
     public final static String REGIONAL_MICROSOFT_AUTHORITY_BASIC_HOST_WESTUS = "westus.login.microsoft.com";
 
-    public final static String REGIONAL_MICROSOFT_AUTHORITY_BASIC_HOST_EASTUS = "eastus.login.microsoft.com";
-
-//    public final static String CIAM_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "msidlabciam1.onmicrosoft.com";
-    public final static String CIAM_AUTHORITY = "https://msidlabciam1.ciamlogin.com/" + "msidlabciam1.onmicrosoft.com";
-
-    public final static String CIAM_TEST_AUTHORITY = "https://contoso0781.ciamlogin.com/6babcaad-604b-40ac-a9d7-9fd97c0b779f/v2.0/.well-known/openid-configuration?dc=ESTS-PUB-EUS-AZ1-FD000-TEST1&ciamhost=true";
-
     public final static String ARLINGTON_ORGANIZATIONS_AUTHORITY = ARLINGTON_MICROSOFT_AUTHORITY_HOST + "organizations/";
     public final static String ARLINGTON_TENANT_SPECIFIC_AUTHORITY = ARLINGTON_MICROSOFT_AUTHORITY_HOST + ARLINGTON_AUTHORITY_TENANT;
+    public final static String ARLINGTON_COMMON_AUTHORITY = ARLINGTON_MICROSOFT_AUTHORITY_HOST + "common/";
     public final static String ARLINGTON_GRAPH_DEFAULT_SCOPE = "https://graph.microsoft.us/.default";
 
     public final static String B2C_AUTHORITY = "https://msidlabb2c.b2clogin.com/msidlabb2c.onmicrosoft.com/";
@@ -63,9 +53,5 @@ public class TestConstants {
     public final static String ADFS_SCOPE = USER_READ_SCOPE;
     public final static String ADFS_APP_ID = "PublicClientId";
 
-    public final static String CLAIMS = "{\"id_token\":{\"auth_time\":{\"essential\":true}}}";
-    public final static Set<String> CLIENT_CAPABILITIES_EMPTY = new HashSet<>(Collections.emptySet());
     public final static String AUTHORITY_PUBLIC_TENANT_SPECIFIC = "https://login.microsoftonline.com/" + MICROSOFT_AUTHORITY_TENANT;
-
-    public final static String DEFAULT_ACCESS_TOKEN = "defaultAccessToken";
 }

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/UsernamePasswordIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/UsernamePasswordIT.java
@@ -106,7 +106,7 @@ class UsernamePasswordIT {
                         .build())
                 .get();
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
     }
 
     private void assertAcquireTokenCommon(User user, String authority, String scope, String appId)
@@ -125,7 +125,7 @@ class UsernamePasswordIT {
 
                 .get();
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
         assertEquals(user.getUpn(), result.account().username());
     }
 
@@ -148,7 +148,7 @@ class UsernamePasswordIT {
                 .build())
                 .get();
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
 
         IAccount account = pca.getAccounts().join().iterator().next();
         SilentParameters.builder(Collections.singleton(TestConstants.B2C_READ_SCOPE), account);
@@ -158,7 +158,7 @@ class UsernamePasswordIT {
                         .build())
                 .get();
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
     }
 
     @Test
@@ -180,7 +180,7 @@ class UsernamePasswordIT {
                 .build())
                 .get();
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
 
         IAccount account = pca.getAccounts().join().iterator().next();
         SilentParameters.builder(Collections.singleton(TestConstants.B2C_READ_SCOPE), account);
@@ -190,6 +190,6 @@ class UsernamePasswordIT {
                         .build())
                 .get();
 
-        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
+        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
     }
 }

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/UsernamePasswordIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/UsernamePasswordIT.java
@@ -91,14 +91,12 @@ class UsernamePasswordIT {
 
     @Test
     void acquireTokenWithUsernamePassword_Ciam() throws Exception {
-
         Map<String, String> extraQueryParameters = new HashMap<>();
 
-        User user = labUserProvider.getCiamUser();
+        User user = labUserProvider.getCiamCudUser();
         PublicClientApplication pca = PublicClientApplication.builder(user.getAppId())
                 .authority("https://" + user.getLabName() + ".ciamlogin.com/")
                 .build();
-
 
         IAuthenticationResult result = pca.acquireToken(UserNamePasswordParameters.
                         builder(Collections.singleton(TestConstants.USER_READ_SCOPE),
@@ -108,12 +106,7 @@ class UsernamePasswordIT {
                         .build())
                 .get();
 
-        assertNotNull(result.accessToken());
-    }
-
-    private void assertAcquireTokenCommonAAD(User user) throws Exception {
-        assertAcquireTokenCommon(user, cfg.organizationsAuthority(), cfg.graphDefaultScope(),
-                user.getAppId());
+        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
     }
 
     private void assertAcquireTokenCommon(User user, String authority, String scope, String appId)
@@ -132,7 +125,7 @@ class UsernamePasswordIT {
 
                 .get();
 
-        assertTokenResultNotNull(result);
+        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
         assertEquals(user.getUpn(), result.account().username());
     }
 
@@ -155,7 +148,7 @@ class UsernamePasswordIT {
                 .build())
                 .get();
 
-        assertTokenResultNotNull(result);
+        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
 
         IAccount account = pca.getAccounts().join().iterator().next();
         SilentParameters.builder(Collections.singleton(TestConstants.B2C_READ_SCOPE), account);
@@ -165,7 +158,7 @@ class UsernamePasswordIT {
                         .build())
                 .get();
 
-        assertTokenResultNotNull(result);
+        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
     }
 
     @Test
@@ -187,7 +180,7 @@ class UsernamePasswordIT {
                 .build())
                 .get();
 
-        assertTokenResultNotNull(result);
+        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
 
         IAccount account = pca.getAccounts().join().iterator().next();
         SilentParameters.builder(Collections.singleton(TestConstants.B2C_READ_SCOPE), account);
@@ -197,12 +190,6 @@ class UsernamePasswordIT {
                         .build())
                 .get();
 
-        assertTokenResultNotNull(result);
-    }
-
-    private void assertTokenResultNotNull(IAuthenticationResult result) {
-        assertNotNull(result);
-        assertNotNull(result.accessToken());
-        assertNotNull(result.idToken());
+        IntegrationTestHelper.assertTokenResultNotNull(result, true, true);
     }
 }

--- a/msal4j-sdk/src/integrationtest/java/infrastructure/SeleniumExtensions.java
+++ b/msal4j-sdk/src/integrationtest/java/infrastructure/SeleniumExtensions.java
@@ -4,8 +4,6 @@
 package infrastructure;
 
 import com.microsoft.aad.msal4j.TestConstants;
-import labapi.FederationProvider;
-import labapi.LabConstants;
 import labapi.User;
 import org.apache.commons.io.FileUtils;
 import org.openqa.selenium.By;
@@ -34,8 +32,11 @@ public class SeleniumExtensions {
 
     public static WebDriver createDefaultWebDriver() {
         ChromeOptions options = new ChromeOptions();
-        //no visual rendering, remove when debugging
+
+        //No visual rendering, remove to see browser window when debugging
         options.addArguments("--headless");
+        //Add to avoid issues if your real browser's history/cookies are affecting tests, should not be needed in ADO pipelines
+        //options.addArguments("--incognito");
 
         System.setProperty("webdriver.chrome.driver", "C:/Windows/chromedriver.exe");
         ChromeDriver driver = new ChromeDriver(options);

--- a/msal4j-sdk/src/integrationtest/java/labapi/AppCredentialProvider.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/AppCredentialProvider.java
@@ -7,7 +7,6 @@ public class AppCredentialProvider {
     private KeyVaultSecretsProvider keyVaultSecretsProvider;
 
     private String labVaultClientId;
-    private String labVaultPassword;
 
     private String clientId;
 
@@ -19,7 +18,6 @@ public class AppCredentialProvider {
         keyVaultSecretsProvider = new KeyVaultSecretsProvider();
 
         labVaultClientId = keyVaultSecretsProvider.getSecret(LabConstants.APP_ID_KEY_VAULT_SECRET);
-        labVaultPassword = keyVaultSecretsProvider.getSecret(LabConstants.APP_PASSWORD_KEY_VAULT_SECRET);
 
         switch (azureEnvironment) {
             case AzureEnvironment.AZURE:
@@ -64,9 +62,5 @@ public class AppCredentialProvider {
 
     public String getLabVaultAppId() {
         return labVaultClientId;
-    }
-
-    public String getLabVaultPassword() {
-        return labVaultPassword;
     }
 }

--- a/msal4j-sdk/src/integrationtest/java/labapi/LabConstants.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/LabConstants.java
@@ -14,7 +14,7 @@ public class LabConstants {
     public final static String USER_MSA_USERNAME_URL = "https://msidlabs.vault.azure.net/secrets/MSA-MSIDLAB4-UserName";
     public final static String USER_MSA_PASSWORD_URL = "https://msidlabs.vault.azure.net/secrets/MSA-MSIDLAB4-Password";
     public final static String OBO_APP_PASSWORD_URL = "https://msidlabs.vault.azure.net/secrets/TodoListServiceV2-OBO";
-    public final static String CIAM_KEY_VAULT_SECRET_KEY = "https://msidlabs.vault.azure.net/secrets/MSIDLABCIAM2-cc";
+    public final static String CIAM_KEY_VAULT_SECRET_KEY = "https://msidlabs.vault.azure.net/secrets/MSIDLABCIAM6-cc";
 
     public final static String ARLINGTON_APP_ID = "cb7faed4-b8c0-49ee-b421-f5ed16894c83";
     public final static String ARLINGTON_OBO_APP_ID = "c0555d2d-02f2-4838-802e-3463422e571d";

--- a/msal4j-sdk/src/integrationtest/java/labapi/LabUserProvider.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/LabUserProvider.java
@@ -65,10 +65,6 @@ public class LabUserProvider {
         return getLabUser(query);
     }
 
-    public User getB2cUser(String b2cProvider) {
-        return getB2cUser(AzureEnvironment.AZURE, b2cProvider);
-    }
-
     public User getB2cUser(String azureEnvironment, String b2cProvider) {
         UserQueryParameters query = new UserQueryParameters();
         query.parameters.put(UserQueryParameters.AZURE_ENVIRONMENT, azureEnvironment);
@@ -101,14 +97,6 @@ public class LabUserProvider {
         query.parameters.put(UserQueryParameters.HOME_AZURE_ENVIRONMENT, homeEnvironment);
         query.parameters.put(UserQueryParameters.GUEST_HOME_DIN, "hostazuread");
         query.parameters.put(UserQueryParameters.SIGN_IN_AUDIENCE, "azureadmyorg");
-
-        return getLabUser(query);
-    }
-
-    public User getCiamUser() {
-
-        UserQueryParameters query = new UserQueryParameters();
-        query.parameters.put(UserQueryParameters.FEDERATION_PROVIDER, FederationProvider.CIAM);
 
         return getLabUser(query);
     }

--- a/msal4j-sdk/src/integrationtest/java/labapi/User.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/User.java
@@ -52,6 +52,9 @@ public class User {
     @JsonProperty("lastUpdatedDate")
     private String lastUpdatedDate;
 
+    @JsonProperty("tenantID")
+    private String tenantID;
+
     @Setter
     private String password;
 


### PR DESCRIPTION
Contains a number of fixes and improvements to the integration tests:
- Use 'common' authority instead of 'organizations' for ADFS tests
  - Fixes an issue caused by a change to a test app, and is also what is used in other MSALs
- Update queries to use newer labs resources
- Remove some unused code/constants/imports/etc., and refactor some common code into a new IntegrationTestHelper class
  - Just added some low-hanging fruit for now, more refactoring to come in future PRs when it makes sense