### PR TITLE
Use path of the redirect URI

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByInteractiveFlowSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByInteractiveFlowSupplier.java
@@ -59,7 +59,8 @@ class AcquireTokenByInteractiveFlowSupplier extends AuthenticationResultSupplier
             AuthorizationResponseHandler authorizationResponseHandler =
                     new AuthorizationResponseHandler(
                             authorizationResultQueue,
-                            systemBrowserOptions);
+                            systemBrowserOptions,
+                            interactiveRequest.interactiveRequestParameters().redirectUri());
 
             startHttpListener(authorizationResponseHandler);
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
@@ -15,6 +15,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.net.URI;
 import java.util.concurrent.BlockingQueue;
 import java.util.stream.Collectors;
 
@@ -34,17 +35,20 @@ class AuthorizationResponseHandler implements HttpHandler {
 
     private BlockingQueue<AuthorizationResult> authorizationResultQueue;
     private SystemBrowserOptions systemBrowserOptions;
+    private URI redirectUri;
 
     AuthorizationResponseHandler(BlockingQueue<AuthorizationResult> authorizationResultQueue,
-                                 SystemBrowserOptions systemBrowserOptions) {
+                                 SystemBrowserOptions systemBrowserOptions, URI redirectUri) {
         this.authorizationResultQueue = authorizationResultQueue;
         this.systemBrowserOptions = systemBrowserOptions;
+        this.redirectUri = redirectUri;
     }
 
     @Override
     public void handle(HttpExchange httpExchange) throws IOException {
         try {
-            if (!httpExchange.getRequestURI().getPath().equalsIgnoreCase("/")) {
+            String expectedPath = redirectUri.getPath().isEmpty() ? "/" : redirectUri.getPath();
+            if (!httpExchange.getRequestURI().getPath().equalsIgnoreCase(expectedPath)) {
                 httpExchange.sendResponseHeaders(200, 0);
                 return;
             }


### PR DESCRIPTION
Use the path as given by the redirect URI to allow for more specific redirect URIs. See issue #891.