### PR TITLE
Fix potential null pointer exception during cache lookup

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenCache.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenCache.java
@@ -477,7 +477,8 @@ public class TokenCache implements ITokenCache {
 
         return accessTokens.values().stream().filter(
                 accessToken ->
-                        accessToken.homeAccountId.equals(account.homeAccountId()) &&
+                        accessToken.homeAccountId != null &&
+                                accessToken.homeAccountId.equals(account.homeAccountId()) &&
                                 environmentAliases.contains(accessToken.environment) &&
                                 accessToken.realm.equals(authority.tenant()) &&
                                 accessToken.clientId.equals(clientId) &&
@@ -552,6 +553,7 @@ public class TokenCache implements ITokenCache {
 
         return refreshTokens.values().stream().filter(
                 refreshToken ->
+                        refreshToken.homeAccountId != null &&
                         refreshToken.homeAccountId.equals(account.homeAccountId()) &&
                                 environmentAliases.contains(refreshToken.environment) &&
                                 refreshToken.clientId.equals(clientId)

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 @Getter(AccessLevel.PACKAGE)
@@ -118,9 +119,15 @@ class TokenRequestExecutor {
             }
 
             AccountCacheEntity accountCacheEntity = null;
+            if (!StringHelper.isNullOrBlank(tokens.getIDTokenString())) {
+                String idTokenJson;
+                try {
+                    idTokenJson = new String(Base64.getDecoder().decode(tokens.getIDTokenString().split("\\.")[1]), StandardCharsets.UTF_8);
+                } catch (ArrayIndexOutOfBoundsException e) {
+                    throw new MsalServiceException("Error parsing ID token, missing payload section. Ensure that the ID token is following the JWT format.",
+                            AuthenticationErrorCode.INVALID_JWT);
+                }
 
-            if (tokens.getIDToken() != null) {
-                String idTokenJson = tokens.getIDToken().getParsedParts()[1].decodeToString();
                 IdToken idToken = JsonHelper.convertJsonToObject(idTokenJson, IdToken.class);
 
                 AuthorityType type = msalRequest.application().authenticationAuthority.authorityType;

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheTests.java
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CacheTests {
+
+    @Test
+    void cacheLookup_MixAccountBasedAndAssertionBasedSilentFlows() throws Exception {
+        DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+
+        ConfidentialClientApplication cca =
+                ConfidentialClientApplication.builder("clientId", ClientCredentialFactory.createFromSecret("password"))
+                        .authority("https://login.microsoftonline.com/tenant/")
+                        .instanceDiscovery(false)
+                        .validateAuthority(false)
+                        .httpClient(httpClientMock)
+                        .build();
+
+        HashMap<String, String> responseParameters = new HashMap<>();
+        //Acquire a token with no ID token/account associated with it
+        responseParameters.put("access_token", "accessTokenNoAccount");
+
+        ClientCredentialParameters clientCredentialParameters = ClientCredentialParameters.builder(Collections.singleton("someScopes")).build();
+        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(200, TestHelper.getSuccessfulTokenResponse(responseParameters)));
+        IAuthenticationResult resultNoAccount = cca.acquireToken(clientCredentialParameters).get();
+
+        //Ensure there is one token in the cache, and the result had no account
+        assertEquals(1, cca.tokenCache.accessTokens.size());
+        assertNull(resultNoAccount.account());
+        verify(httpClientMock, times(1)).send(any());
+
+        //Acquire a second token, this time with an ID token/account
+        responseParameters.put("access_token", "accessTokenWithAccount");
+        responseParameters.put("id_token", TestHelper.createIdToken(new HashMap<>()));
+
+        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(200, TestHelper.getSuccessfulTokenResponse(responseParameters)));
+        OnBehalfOfParameters onBehalfOfParametersarameters = OnBehalfOfParameters.builder(Collections.singleton("someOtherScopes"), new UserAssertion(TestHelper.signedAssertion)).build();
+        IAuthenticationResult resultWithAccount = cca.acquireToken(onBehalfOfParametersarameters).get();
+
+        //Ensure there are now two tokens in the cache, and the result has an account
+        assertEquals(2, cca.tokenCache.accessTokens.size());
+        assertNull(resultNoAccount.account());
+        verify(httpClientMock, times(2)).send(any());
+
+        //Make two silent calls, one with the account and one without
+        SilentParameters silentParametersNoAccount = SilentParameters.builder(Collections.singleton("someScopes")).build();
+        SilentParameters silentParametersWithAccount = SilentParameters.builder(Collections.singleton("someOtherScopes"), resultWithAccount.account()).build();
+
+        resultNoAccount = cca.acquireTokenSilently(silentParametersNoAccount).get();
+        resultWithAccount = cca.acquireTokenSilently(silentParametersWithAccount).get();
+
+        //Ensure the correct access tokens were returned from each silent call
+        assertEquals("accessTokenNoAccount", resultNoAccount.accessToken());
+        assertEquals("accessTokenWithAccount", resultWithAccount.accessToken());
+    }
+}

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestHelper.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestHelper.java
@@ -7,13 +7,13 @@ import com.nimbusds.jose.*;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +28,17 @@ class TestHelper {
             "\"client_id\":\"%s\",\"client_info\":\"%s\"," +
             "\"expires_on\": %d ,\"expires_in\": %d," +
             "\"token_type\":\"Bearer\"}";
+
+    static final String idTokenFormat = "{\"aud\": \"%s\"," +
+            "\"iss\": \"%s\"," +
+            "\"iat\": 1455833828," + "\"nbf\": 1455833828," + "\"exp\": 1455837728," +
+            "\"ipaddr\": \"131.107.159.117\"," +
+            "\"name\": \"%s\"," +
+            "\"oid\": \"%s\"," +
+            "\"preferred_username\": \"%s\"," +
+            "\"sub\": \"%s\"," +
+            "\"tid\": \"%s\"," +
+            "\"ver\": \"2.0\"}";
 
     static String readResource(Class<?> classInstance, String resource) {
         try {
@@ -76,10 +87,10 @@ class TestHelper {
 
         return String.format(successfulResponseFormat,
                 responseValues.getOrDefault("access_token", "access_token"),
-                responseValues.getOrDefault("id_token", "id_token"),
+                responseValues.getOrDefault("id_token", ""),
                 responseValues.getOrDefault("refresh_token", "refresh_token"),
                 responseValues.getOrDefault("client_id", "client_id"),
-                responseValues.getOrDefault("client_info", "client_info"),
+                responseValues.getOrDefault("client_info", "eyJ1aWQiOiI1OTdmODZjZC0xM2YzLTQ0YzAtYmVjZS1hMWU3N2JhNDMyMjgiLCJ1dGlkIjoiZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhIn0"),
                 expiresOn,
                 expiresIn
         );
@@ -96,5 +107,22 @@ class TestHelper {
         httpResponse.addHeaders(headers);
 
         return httpResponse;
+    }
+
+    //Maps various values to the idTokenFormat string
+    static String createIdToken(HashMap<String, String> idTokenValues) {
+        String tokenValues = String.format(idTokenFormat,
+                idTokenValues.getOrDefault("aud", "e854a4a7-6c34-449c-b237-fc7a28093d84"),
+                idTokenValues.getOrDefault("iss", "https://login.microsoftonline.com/6c3d51dd-f0e5-4959-b4ea-a80c4e36fe5e/v2.0/"),
+                idTokenValues.getOrDefault("name", "name"),
+                idTokenValues.getOrDefault("oid", "oid"),
+                idTokenValues.getOrDefault("preferred_username", "preferred_username"),
+                idTokenValues.getOrDefault("sub", "K4_SGGxKqW1SxUAmhg6C1F6VPiFzcx-Qd80ehIEdFus"),
+                idTokenValues.getOrDefault("client_info", "eyJ1aWQiOiI1OTdmODZjZC0xM2YzLTQ0YzAtYmVjZS1hMWU3N2JhNDMyMjgiLCJ1dGlkIjoiZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhIn0")
+        );
+
+        String encodedTokenValues = Base64.getUrlEncoder().encodeToString(tokenValues.getBytes());
+
+        return String.format("someheader.%s.somesignature", encodedTokenValues);
     }
 }


### PR DESCRIPTION
Fixes the issue described in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/869. The issue was caused by mixing flows that do and don't use ID tokens:
- If the flow uses ID tokens, then the result will have an Account object and the tokens in the cache will be associated with a `homeAccountId` value
- If that Account object is provided to `acquireTokenSilently()`, then one of the filters used during the cache lookup is `accessToken.homeAccountId.equals(account.homeAccountId())`
- But if the cache is also filled with access tokens that have no related ID token then `accessToken.homeAccountId` will be null, leading to a null pointer exception

This PR adds some simple null checks to the cache lookup to prevent that NPE. It also improves the unit test infrastructure related to ID tokens, and adjusts some of the ID token parsing behavior to better handle improperly formatted ID tokens and reduce the usage of com.nimbusds (see https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/889)