### PR TITLE
Fix regression issue in IClientCertificate caused by SHA256 changes

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
@@ -46,14 +46,15 @@ final class ClientCertificate implements IClientCertificate {
         this.publicKeyCertificateChain = publicKeyCertificateChain;
     }
 
-    public String publicCertificateHash()
+    @Override
+    public String publicCertificateHash256()
             throws CertificateEncodingException, NoSuchAlgorithmException {
 
         return Base64.getEncoder().encodeToString(ClientCertificate
                 .getHashSha256(publicKeyCertificateChain.get(0).getEncoded()));
     }
 
-    public String publicCertificateHashSha1()
+    public String publicCertificateHash()
             throws CertificateEncodingException, NoSuchAlgorithmException {
 
         return Base64.getEncoder().encodeToString(ClientCertificate

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
@@ -101,12 +101,7 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
         } else if (clientCredential instanceof ClientCertificate) {
             this.clientCertAuthentication = true;
             this.clientCertificate = (ClientCertificate) clientCredential;
-            if (Authority.detectAuthorityType(this.authenticationAuthority.canonicalAuthorityUrl()) == AuthorityType.ADFS) {
-                //When this was added, ADFS did not support SHA256 hashes for client certificates
-                clientAuthentication = buildValidClientCertificateAuthority(true);
-            } else  {
-                clientAuthentication = buildValidClientCertificateAuthority(false);
-            }
+            clientAuthentication = buildValidClientCertificateAuthority();
         } else if (clientCredential instanceof ClientAssertion) {
             clientAuthentication = createClientAuthFromClientAssertion((ClientAssertion) clientCredential);
         } else {
@@ -120,19 +115,17 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
             final Date currentDateTime = new Date(System.currentTimeMillis());
             final Date expirationTime = ((PrivateKeyJWT) clientAuthentication).getJWTAuthenticationClaimsSet().getExpirationTime();
             if (expirationTime.before(currentDateTime)) {
-                if (Authority.detectAuthorityType(this.authenticationAuthority.canonicalAuthorityUrl()) == AuthorityType.ADFS) {
-                    clientAuthentication = buildValidClientCertificateAuthority(true);
-                } else  {
-                    clientAuthentication = buildValidClientCertificateAuthority(false);
-                }
+                clientAuthentication = buildValidClientCertificateAuthority();
             }
         }
         return clientAuthentication;
     }
 
-    //The library originally used SHA-1 for thumbprints as other algorithms were not supported server-side,
-    //  and while support for SHA-256 has been added certain flows still only allow SHA-1
-    private ClientAuthentication buildValidClientCertificateAuthority(boolean useSha1) {
+    private ClientAuthentication buildValidClientCertificateAuthority() {
+        //The library originally used SHA-1 for thumbprints as other algorithms were not supported server-side.
+        //When this was written support for SHA-256 had been added, however ADFS scenarios still only allowed SHA-1.
+        boolean useSha1 = Authority.detectAuthorityType(this.authenticationAuthority.canonicalAuthorityUrl()) == AuthorityType.ADFS;
+
         ClientAssertion clientAssertion = JwtHelper.buildJwt(
                 clientId(),
                 clientCertificate,

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
@@ -102,9 +102,10 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
             this.clientCertAuthentication = true;
             this.clientCertificate = (ClientCertificate) clientCredential;
             if (Authority.detectAuthorityType(this.authenticationAuthority.canonicalAuthorityUrl()) == AuthorityType.ADFS) {
-                clientAuthentication = buildValidClientCertificateAuthoritySha1();
+                //When this was added, ADFS did not support SHA256 hashes for client certificates
+                clientAuthentication = buildValidClientCertificateAuthority(true);
             } else  {
-                clientAuthentication = buildValidClientCertificateAuthority();
+                clientAuthentication = buildValidClientCertificateAuthority(false);
             }
         } else if (clientCredential instanceof ClientAssertion) {
             clientAuthentication = createClientAuthFromClientAssertion((ClientAssertion) clientCredential);
@@ -119,32 +120,25 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
             final Date currentDateTime = new Date(System.currentTimeMillis());
             final Date expirationTime = ((PrivateKeyJWT) clientAuthentication).getJWTAuthenticationClaimsSet().getExpirationTime();
             if (expirationTime.before(currentDateTime)) {
-                //The asserted private jwt with the client certificate can expire so rebuild it when the
-                clientAuthentication = buildValidClientCertificateAuthority();
+                if (Authority.detectAuthorityType(this.authenticationAuthority.canonicalAuthorityUrl()) == AuthorityType.ADFS) {
+                    clientAuthentication = buildValidClientCertificateAuthority(true);
+                } else  {
+                    clientAuthentication = buildValidClientCertificateAuthority(false);
+                }
             }
         }
         return clientAuthentication;
     }
 
-    private ClientAuthentication buildValidClientCertificateAuthority() {
-        ClientAssertion clientAssertion = JwtHelper.buildJwt(
-                clientId(),
-                clientCertificate,
-                this.authenticationAuthority.selfSignedJwtAudience(),
-                sendX5c,
-                false);
-        return createClientAuthFromClientAssertion(clientAssertion);
-    }
-
     //The library originally used SHA-1 for thumbprints as other algorithms were not supported server-side,
     //  and while support for SHA-256 has been added certain flows still only allow SHA-1
-    private ClientAuthentication buildValidClientCertificateAuthoritySha1() {
+    private ClientAuthentication buildValidClientCertificateAuthority(boolean useSha1) {
         ClientAssertion clientAssertion = JwtHelper.buildJwt(
                 clientId(),
                 clientCertificate,
                 this.authenticationAuthority.selfSignedJwtAudience(),
                 sendX5c,
-                true);
+                useSha1);
         return createClientAuthFromClientAssertion(clientAssertion);
     }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IClientCertificate.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IClientCertificate.java
@@ -23,7 +23,20 @@ public interface IClientCertificate extends IClientCredential {
     PrivateKey privateKey();
 
     /**
-     * Base64 encoded hash of the the public certificate.
+     * Base64 encoded SHA-256 hash of the public certificate.
+     *
+     * @return base64 encoded string
+     * @throws CertificateEncodingException if an encoding error occurs
+     * @throws NoSuchAlgorithmException     if requested algorithm is not available in the environment
+     */
+    default String publicCertificateHash256() throws CertificateEncodingException, NoSuchAlgorithmException {
+        //Default implementation that returns null, to add backwards compatibility for those implementing this public interface.
+        //If left as null, the library will default to the older publicCertificateHash() method and SHA-1 hashing.
+        return null;
+    }
+
+    /**
+     * Base64 encoded SHA-1 hash of the public certificate.
      *
      * @return base64 encoded string
      * @throws CertificateEncodingException if an encoding error occurs

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JwtHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JwtHelper.java
@@ -58,10 +58,11 @@ final class JwtHelper {
 
             //SHA-256 is preferred, however certain flows still require SHA-1 due to what is supported server-side. If SHA-256
             // is not supported or the IClientCredential.publicCertificateHash256() method is not implemented, the library will default to SHA-1.
-            if (useSha1 || credential.publicCertificateHash256() == null) {
+            String hash256 = credential.publicCertificateHash256();
+            if (useSha1 || hash256 == null) {
                 builder.x509CertThumbprint(new Base64URL(credential.publicCertificateHash()));
             } else {
-                builder.x509CertSHA256Thumbprint(new Base64URL(credential.publicCertificateHash256()));
+                builder.x509CertSHA256Thumbprint(new Base64URL(hash256));
             }
 
             jwt = new SignedJWT(builder.build(), claimsSet);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JwtHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JwtHelper.java
@@ -56,11 +56,12 @@ final class JwtHelper {
                 builder.x509CertChain(certs);
             }
 
-            //SHA-256 is preferred, however certain flows still require SHA-1 due to what is supported server-side
-            if (useSha1) {
-                builder.x509CertThumbprint(new Base64URL(credential.publicCertificateHashSha1()));
+            //SHA-256 is preferred, however certain flows still require SHA-1 due to what is supported server-side. If SHA-256
+            // is not supported or the IClientCredential.publicCertificateHash256() method is not implemented, the library will default to SHA-1.
+            if (useSha1 || credential.publicCertificateHash256() == null) {
+                builder.x509CertThumbprint(new Base64URL(credential.publicCertificateHash()));
             } else {
-                builder.x509CertSHA256Thumbprint(new Base64URL(credential.publicCertificateHash()));
+                builder.x509CertSHA256Thumbprint(new Base64URL(credential.publicCertificateHash256()));
             }
 
             jwt = new SignedJWT(builder.build(), claimsSet);

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClientCertificateTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClientCertificateTest.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -10,16 +11,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 import java.math.BigInteger;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
+import java.security.*;
 import java.security.cert.CertificateException;
 import java.security.interfaces.RSAPrivateKey;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ClientCertificateTest {
@@ -43,7 +42,7 @@ class ClientCertificateTest {
     }
 
     @Test
-    void testIClientCertificateInterface_Sha256AndSha1() throws NoSuchAlgorithmException, CertificateException {
+    void testIClientCertificateInterface_Sha1andSha256() throws NoSuchAlgorithmException, CertificateException {
         //See https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/863 for context on this test.
         //Essentially, it aims to test compatibility for customers that implemented IClientCertificate in older versions of the library.
 
@@ -54,6 +53,40 @@ class ClientCertificateTest {
         //... but ClientCredentialFactory has an implemented version, so it should not be null.
         certificate = ClientCredentialFactory.createFromCertificate(TestHelper.getPrivateKey(), TestHelper.getX509Cert());
         assertNotNull(certificate.publicCertificateHash256());
+    }
+
+    @Test
+    void testIClientCertificateInterface_CredentialFactoryUsesSha256() throws Exception {
+        DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+
+        ConfidentialClientApplication cca =
+                ConfidentialClientApplication.builder("clientId", ClientCredentialFactory.createFromCertificate(TestHelper.getPrivateKey(), TestHelper.getX509Cert()))
+                        .authority("https://login.microsoftonline.com/tenant")
+                        .instanceDiscovery(false)
+                        .validateAuthority(false)
+                        .httpClient(httpClientMock)
+                        .build();
+
+        HashMap<String, String> tokenResponseValues = new HashMap<>();
+        tokenResponseValues.put("access_token", "accessTokenSha256");
+
+        when(httpClientMock.send(any(HttpRequest.class))).thenAnswer( parameters -> {
+            HttpRequest request = parameters.getArgument(0);
+            Set<String> headerParams = ((PrivateKeyJWT) cca.clientAuthentication()).getClientAssertion().getHeader().getIncludedParams();
+            if (request.body().contains(((PrivateKeyJWT) cca.clientAuthentication()).getClientAssertion().serialize())
+                    && headerParams.contains("x5t#S256")) {
+
+                return TestHelper.expectedResponse(200, TestHelper.getSuccessfulTokenResponse(tokenResponseValues));
+            }
+            return null;
+        });
+        
+        ClientCredentialParameters parameters = ClientCredentialParameters.builder(Collections.singleton("scopes")).build();
+
+        IAuthenticationResult result = cca.acquireToken(parameters).get();
+
+        assertNotNull(result);
+        assertEquals("accessTokenSha256", result.accessToken());
     }
 
     class TestClientCredential implements IClientCertificate {

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClientCertificateTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClientCertificateTest.java
@@ -8,13 +8,18 @@ import org.junit.jupiter.api.TestInstance;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import java.math.BigInteger;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.cert.CertificateException;
 import java.security.interfaces.RSAPrivateKey;
+import java.util.Collections;
+import java.util.List;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ClientCertificateTest {
@@ -35,5 +40,36 @@ class ClientCertificateTest {
 
         final ClientCertificate kc = ClientCertificate.create(key, null);
         assertNotNull(kc);
+    }
+
+    @Test
+    void testIClientCertificateInterface_Sha256AndSha1() throws NoSuchAlgorithmException, CertificateException {
+        //See https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/863 for context on this test.
+        //Essentially, it aims to test compatibility for customers that implemented IClientCertificate in older versions of the library.
+
+        //IClientCertificate.publicCertificateHash256() returns null by default if not implemented...
+        IClientCertificate certificate = new TestClientCredential();
+        assertNull(certificate.publicCertificateHash256());
+
+        //... but ClientCredentialFactory has an implemented version, so it should not be null.
+        certificate = ClientCredentialFactory.createFromCertificate(TestHelper.getPrivateKey(), TestHelper.getX509Cert());
+        assertNotNull(certificate.publicCertificateHash256());
+    }
+
+    class TestClientCredential implements IClientCertificate {
+        @Override
+        public PrivateKey privateKey() {
+            return null;
+        }
+
+        @Override
+        public String publicCertificateHash() {
+            return "";
+        }
+
+        @Override
+        public List<String> getEncodedPublicKeyCertificateChain() {
+            return Collections.emptyList();
+        }
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestHelper.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestHelper.java
@@ -7,6 +7,8 @@ import com.nimbusds.jose.*;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import sun.security.tools.keytool.CertAndKeyGen;
+import sun.security.x509.X500Name;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -14,6 +16,9 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.security.*;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +33,9 @@ class TestHelper {
             "\"client_id\":\"%s\",\"client_info\":\"%s\"," +
             "\"expires_on\": %d ,\"expires_in\": %d," +
             "\"token_type\":\"Bearer\"}";
+
+    static X509Certificate x509Cert = getX509Cert();
+    static PrivateKey privateKey = getPrivateKey();
 
     static String readResource(Class<?> classInstance, String resource) {
         try {
@@ -96,5 +104,35 @@ class TestHelper {
         httpResponse.addHeaders(headers);
 
         return httpResponse;
+    }
+
+    static void setPrivateKeyAndCert() {
+        try {
+            CertAndKeyGen certGen = new CertAndKeyGen("RSA", "SHA256WithRSA", null);
+            certGen.generate(2048);
+            X509Certificate cert = certGen.getSelfCertificate(
+                    new X500Name(""), 3600);
+
+            x509Cert = cert;
+            privateKey = certGen.getPrivateKey();
+        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeyException | IOException | CertificateException | SignatureException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static X509Certificate getX509Cert() {
+        if (x509Cert == null) {
+            setPrivateKeyAndCert();
+        }
+
+        return x509Cert;
+    }
+
+    static PrivateKey getPrivateKey() {
+        if (privateKey == null) {
+            setPrivateKeyAndCert();
+        }
+
+        return privateKey;
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestHelper.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestHelper.java
@@ -7,8 +7,6 @@ import com.nimbusds.jose.*;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
-import sun.security.tools.keytool.CertAndKeyGen;
-import sun.security.x509.X500Name;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -17,7 +15,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.*;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Collections;
@@ -48,6 +45,11 @@ class TestHelper {
 
     static X509Certificate x509Cert = getX509Cert();
     static PrivateKey privateKey = getPrivateKey();
+
+    public static String CERTIFICATE_ALIAS = "LabAuth.MSIDLab.com";
+    private static final String WIN_KEYSTORE = "Windows-MY";
+    private static final String KEYSTORE_PROVIDER = "SunMSCAPI";
+    private static final String MAC_KEYSTORE = "KeychainStore";
 
     static String readResource(Class<?> classInstance, String resource) {
         try {
@@ -137,15 +139,20 @@ class TestHelper {
 
     static void setPrivateKeyAndCert() {
         try {
-            CertAndKeyGen certGen = new CertAndKeyGen("RSA", "SHA256WithRSA", null);
-            certGen.generate(2048);
-            X509Certificate cert = certGen.getSelfCertificate(
-                    new X500Name(""), 3600);
+            String os = System.getProperty("os.name");
+            KeyStore keystore;
+            if (os.toLowerCase().contains("windows")) {
+                keystore = KeyStore.getInstance(WIN_KEYSTORE, KEYSTORE_PROVIDER);
+            } else {
+                keystore = KeyStore.getInstance(MAC_KEYSTORE);
+            }
 
-            x509Cert = cert;
-            privateKey = certGen.getPrivateKey();
-        } catch (NoSuchAlgorithmException | NoSuchProviderException | InvalidKeyException | IOException | CertificateException | SignatureException e) {
-            throw new RuntimeException(e);
+            keystore.load(null, null);
+            privateKey = (PrivateKey) keystore.getKey(CERTIFICATE_ALIAS, null);
+            x509Cert = (X509Certificate) keystore.getCertificate(
+                    CERTIFICATE_ALIAS);
+        } catch (Exception e) {
+            throw new RuntimeException("Error getting certificate from keystore: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
Fix for the issue described in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/863

As part of https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/840, the internal implementation of the `IClientCertificate` interface's `publicCertificateHash()` method was changed to use SHA-256, and a new `publicCertificateHashSha1()` method was added to the internal implementation to handle scenarios that still needed SHA-1. 

However, this meant that anyone who implemented their own `IClientCredential` instead of using our `ClientCredentialFactory` would have a `publicCertificateHash()` method that still used SHA-1, causing issues because our library expected that method to produce a SHA-256 hash.

This PR solves that issue by adding a new `publicCertificateHash256` method to the public interface to handle SHA-256 scenarios, and once again has `publicCertificateHash` handling the SHA-1 scenarios. 

The new interface method is given a default implementation so that it doesn't break any customer's implementations, and if it's not implemented then the library falls back to `publicCertificateHash` and SHA-1. Anyone who was always using our `ClientCredentialFactory ` should not encounter any issues from either the original changes or the ones in this PR.