### PR TITLE
Produce code coverage reports for pipelines

### DIFF
--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -239,9 +239,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.10</version>
+                <version>3.5.2</version>
                 <configuration>
-                    <argLine>-noverify</argLine>
+                    <argLine>@{argLine} -noverify</argLine>
                 </configuration>
             </plugin>
 
@@ -328,6 +328,25 @@
                     <execution>
                         <goals>
                             <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-site</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ServiceFabricManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ServiceFabricManagedIdentitySource.java
@@ -24,8 +24,8 @@ class ServiceFabricManagedIdentitySource extends AbstractManagedIdentitySource {
     //Service Fabric requires a special check for an environment variable containing a certificate thumbprint used for validating requests.
     //No other flow need this and an app developer may not be aware of it, so it was decided that for the Service Fabric flow we will simply override
     // any HttpClient that may have been set by the app developer with our own client which performs the validation logic.
-    private final IHttpClient httpClient = new DefaultHttpClientManagedIdentity(null, null, null, null);
-    private final HttpHelper httpHelper = new HttpHelper(httpClient);
+    private static IHttpClient httpClient = new DefaultHttpClientManagedIdentity(null, null, null, null);
+    private static HttpHelper httpHelper = new HttpHelperManagedIdentity(httpClient);
 
     @Override
     public void createManagedIdentityRequest(String resource) {
@@ -117,4 +117,10 @@ class ServiceFabricManagedIdentitySource extends AbstractManagedIdentitySource {
         }
     }
 
+    //The HttpClient is not normally customizable in this flow, as it requires special behavior for certificate validation.
+    //However, unit tests often need to mock HttpClient and need a way to inject the mocked object into this class.
+    static void setHttpClient(IHttpClient client) {
+        httpClient = client;
+        httpHelper = new HttpHelperManagedIdentity(httpClient);
+    }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -71,7 +71,6 @@ class ManagedIdentityTests {
         String endpoint = null;
         Map<String, String> headers = new HashMap<>();
         Map<String, List<String>> queryParameters = new HashMap<>();
-        Map<String, List<String>> bodyParameters = new HashMap<>();
 
         switch (source) {
             case APP_SERVICE: {
@@ -89,10 +88,8 @@ class ManagedIdentityTests {
                 headers.put("ContentType", "application/x-www-form-urlencoded");
                 headers.put("Metadata", "true");
 
-                bodyParameters.put("resource", singletonList(resource));
-
                 queryParameters.put("resource", singletonList(resource));
-                return new HttpRequest(HttpMethod.GET, computeUri(endpoint, queryParameters), headers, URLUtils.serializeParameters(bodyParameters));
+                break;
             }
             case IMDS: {
                 endpoint = IMDS_ENDPOINT;
@@ -110,11 +107,14 @@ class ManagedIdentityTests {
                 headers.put("Metadata", "true");
                 break;
             }
-            case SERVICE_FABRIC:
+            case SERVICE_FABRIC: {
                 endpoint = serviceFabricEndpoint;
                 queryParameters.put("api-version", singletonList("2019-07-01-preview"));
                 queryParameters.put("resource", singletonList(resource));
+
+                headers.put("secret", "secret");
                 break;
+            }
         }
 
         switch (id.getIdType()) {
@@ -172,6 +172,9 @@ class ManagedIdentityTests {
         IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(source, endpoint);
         ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
         DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+        if (source == SERVICE_FABRIC) {
+            ServiceFabricManagedIdentitySource.setHttpClient(httpClientMock);
+        }
 
         when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(200, getSuccessfulResponse(resource)));
 
@@ -206,6 +209,9 @@ class ManagedIdentityTests {
         IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(source, endpoint);
         ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
         DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+        if (source == SERVICE_FABRIC) {
+            ServiceFabricManagedIdentitySource.setHttpClient(httpClientMock);
+        }
 
         when(httpClientMock.send(expectedRequest(source, resource, id))).thenReturn(expectedResponse(200, getSuccessfulResponse(resource)));
 
@@ -294,6 +300,9 @@ class ManagedIdentityTests {
         IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(source, endpoint);
         ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
         DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+        if (source == SERVICE_FABRIC) {
+            ServiceFabricManagedIdentitySource.setHttpClient(httpClientMock);
+        }
 
         when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(200, getSuccessfulResponse(resource)));
         when(httpClientMock.send(expectedRequest(source, anotherResource))).thenReturn(expectedResponse(200, getSuccessfulResponse(resource)));
@@ -327,6 +336,9 @@ class ManagedIdentityTests {
         IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(source, endpoint);
         ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
         DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+        if (source == SERVICE_FABRIC) {
+            ServiceFabricManagedIdentitySource.setHttpClient(httpClientMock);
+        }
 
         if (environmentVariables.getEnvironmentVariable("SourceType").equals(ManagedIdentitySourceType.CLOUD_SHELL.toString())) {
             when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(500, getMsiErrorResponseCloudShell()));
@@ -364,7 +376,11 @@ class ManagedIdentityTests {
     void managedIdentityTest_Retry(ManagedIdentitySourceType source, String endpoint, String resource) throws Exception {
         IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(source, endpoint);
         ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
-        DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+
+        DefaultHttpClientManagedIdentity httpClientMock = mock(DefaultHttpClientManagedIdentity.class);
+        if (source == SERVICE_FABRIC) {
+            ServiceFabricManagedIdentitySource.setHttpClient(httpClientMock);
+        }
 
         miApp = ManagedIdentityApplication
                 .builder(ManagedIdentityId.systemAssigned())
@@ -415,6 +431,9 @@ class ManagedIdentityTests {
         IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(source, endpoint);
         ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
         DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+        if (source == SERVICE_FABRIC) {
+            ServiceFabricManagedIdentitySource.setHttpClient(httpClientMock);
+        }
 
         when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(500, ""));
 
@@ -449,7 +468,9 @@ class ManagedIdentityTests {
         IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(source, endpoint);
         ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
         DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
-
+        if (source == SERVICE_FABRIC) {
+            ServiceFabricManagedIdentitySource.setHttpClient(httpClientMock);
+        }
         when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(200, ""));
 
         miApp = ManagedIdentityApplication
@@ -483,6 +504,9 @@ class ManagedIdentityTests {
         IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(source, endpoint);
         ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
         DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+        if (source == SERVICE_FABRIC) {
+            ServiceFabricManagedIdentitySource.setHttpClient(httpClientMock);
+        }
 
         when(httpClientMock.send(expectedRequest(source, resource))).thenThrow(new SocketException("A socket operation was attempted to an unreachable network."));
 
@@ -517,6 +541,9 @@ class ManagedIdentityTests {
         IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(source, endpoint);
         ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
         DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+        if (source == SERVICE_FABRIC) {
+            ServiceFabricManagedIdentitySource.setHttpClient(httpClientMock);
+        }
 
         when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(200, getSuccessfulResponse(resource)));
 


### PR DESCRIPTION
This PR adds the jacoco plugin to produce code coverage reports in a format that the ADO pipelines accept, and updates the surefire plugin (which runs unit tests) as the current version wasn't compatible.

Additionally, some managed unit identity tests were producing warnings that became build-breaking errors in the new plugin versions. These were mainly related to Service Fabric and how HttpClient objects were mocked, so this PR also fixes those tests and adds a new internal setter to help those tests handle Service Fabric scenarios.