### PR TITLE
Add CodeQL suppressions for false positives

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByInteractiveFlowSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByInteractiveFlowSupplier.java
@@ -163,6 +163,7 @@ class AcquireTokenByInteractiveFlowSupplier extends AuthenticationResultSupplier
     private static void openDefaultSystemBrowserInMac(URL url){
         Runtime runtime = Runtime.getRuntime();
         try {
+            // CodeQL [SM00680] False positive: this URL is validated earlier in the interactive flow
             runtime.exec("open " + url);
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -182,6 +183,7 @@ class AcquireTokenByInteractiveFlowSupplier extends AuthenticationResultSupplier
             if (openToolPath != null) {
                 Runtime runtime = Runtime.getRuntime();
                 try {
+                    // CodeQL [SM00680] False positive: this URL is validated earlier in the interactive flow
                     runtime.exec(openTool + " " + url);
                 } catch (IOException e) {
                     throw new RuntimeException(e);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClientManagedIdentity.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClientManagedIdentity.java
@@ -29,6 +29,7 @@ import java.security.cert.X509Certificate;
  */
 class DefaultHttpClientManagedIdentity extends DefaultHttpClient {
 
+    // CodeQL [SM03767] False positive: in addTrustedCertificateThumbprint() we create a TrustManager that only trusts a certificate with specified thumbprint.
     public static final HostnameVerifier ALL_HOSTS_ACCEPT_HOSTNAME_VERIFIER;
 
     static {

--- a/msal4j-sdk/src/samples/msal-b2c-web-sample/src/main/java/com/microsoft/azure/msalwebsample/CookieHelper.java
+++ b/msal4j-sdk/src/samples/msal-b2c-web-sample/src/main/java/com/microsoft/azure/msalwebsample/CookieHelper.java
@@ -32,6 +32,7 @@ public class CookieHelper {
         Cookie stateCookie = new Cookie(MSAL_WEB_APP_STATE_COOKIE, "");
         stateCookie.setMaxAge(0);
 
+        // CodeQL [java/insecure-cookie]: Suppressing CodeQL warning since this is just a sample
         httpResponse.addCookie(stateCookie);
 
         Cookie nonceCookie = new Cookie(MSAL_WEB_APP_NONCE_COOKIE, "");

--- a/msal4j-sdk/src/samples/msal-obo-sample/src/main/java/com/microsoft/azure/msalobosample/ApiController.java
+++ b/msal4j-sdk/src/samples/msal-obo-sample/src/main/java/com/microsoft/azure/msalobosample/ApiController.java
@@ -25,6 +25,7 @@ public class ApiController {
 
         String oboAccessToken = msalAuthHelper.getOboToken("https://graph.microsoft.com/.default");
 
+        // CodeQL [java/xss]: Suppressing CodeQL warning since this is just a sample
         return callMicrosoftGraphMeEndpoint(oboAccessToken);
     }
 

--- a/msal4j-sdk/src/samples/msal-web-sample/src/main/java/com/microsoft/azure/msalwebsample/CookieHelper.java
+++ b/msal4j-sdk/src/samples/msal-web-sample/src/main/java/com/microsoft/azure/msalwebsample/CookieHelper.java
@@ -32,6 +32,7 @@ public class CookieHelper {
         Cookie stateCookie = new Cookie(MSAL_WEB_APP_STATE_COOKIE, "");
         stateCookie.setMaxAge(0);
 
+        // CodeQL [java/insecure-cookie]: Suppressing CodeQL warning since this is just a sample
         httpResponse.addCookie(stateCookie);
 
         Cookie nonceCookie = new Cookie(MSAL_WEB_APP_NONCE_COOKIE, "");


### PR DESCRIPTION
Fixes the CodeQL issues from https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/899:
- Three issues in the samples folder: suppressed since they are only meant to help manual testing during development, and the code is not included in any released package
- Two issues `AcquireTokenByInteractiveFlowSupplier`: the issue was String concatenation with user input, however the URL is validated earlier in the interactive flow
- One issue in `DefaultHttpClientManagedIdentity`: the issue was setting a `HostnameVerifier` that accepts all host names, however the `TrustManager` that uses the verifier only accepts a specific certificate thumbprint (this code was copied from the Azure Identity Java SDK and I discussed this behavior with them)