### PR TITLE
Downgrade depdendency due to CVE alert

### DIFF
--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
-            <version>2.5.0</version>
+            <version>2.4.11</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Resolves https://github.com/AzureAD/microsoft-authentication-library-for-java/security/dependabot/42

A newer version of the affected dependency hasn't been released, so this PR downgrades it to the newest version that the CVE doesn't affect