### PR TITLE
Refactoring to suppress CodeQL false positives

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClientManagedIdentity.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClientManagedIdentity.java
@@ -29,18 +29,14 @@ import java.security.cert.X509Certificate;
  */
 class DefaultHttpClientManagedIdentity extends DefaultHttpClient {
 
-    // CodeQL [SM03767] False positive: in addTrustedCertificateThumbprint() we create a TrustManager that only trusts a certificate with specified thumbprint.
-    public static final HostnameVerifier ALL_HOSTS_ACCEPT_HOSTNAME_VERIFIER;
-
-    static {
-        ALL_HOSTS_ACCEPT_HOSTNAME_VERIFIER = new HostnameVerifier() {
-            @SuppressWarnings("BadHostnameVerifier")
-            @Override
-            public boolean verify(String hostname, SSLSession session) {
-                return true;
-            }
-        };
-    }
+    // CodeQL [SM03767] False positive: in addTrustedCertificateThumbprint() we create a TrustManager that only trusts a certificate with a specific thumbprint.
+    public static final HostnameVerifier ALL_HOSTS_ACCEPT_HOSTNAME_VERIFIER = new HostnameVerifier() {
+        @SuppressWarnings("BadHostnameVerifier")
+        @Override
+        public boolean verify(String hostname, SSLSession session) {
+            return true; // Allow all hostnames, however the TrustManager created later on will only trust a certificate with a specific thumbprint.
+        }
+    };
 
     DefaultHttpClientManagedIdentity(Proxy proxy, SSLSocketFactory sslSocketFactory, Integer connectTimeout, Integer readTimeout) {
         super(proxy, sslSocketFactory, connectTimeout, readTimeout);
@@ -164,5 +160,4 @@ class DefaultHttpClientManagedIdentity extends DefaultHttpClient {
             throw new MsalClientException("NoSuchAlgorithmException when extracting certificate thumbprint: ", e.getMessage());
         }
     }
-
 }

--- a/msal4j-sdk/src/samples/msal-b2c-web-sample/src/main/java/com/microsoft/azure/msalwebsample/CookieHelper.java
+++ b/msal4j-sdk/src/samples/msal-b2c-web-sample/src/main/java/com/microsoft/azure/msalwebsample/CookieHelper.java
@@ -32,7 +32,7 @@ public class CookieHelper {
         Cookie stateCookie = new Cookie(MSAL_WEB_APP_STATE_COOKIE, "");
         stateCookie.setMaxAge(0);
 
-        // CodeQL [java/insecure-cookie]: Suppressing CodeQL warning since this is just a sample
+        // CodeQL [SM00710]: CodeQL flagged this as the 'secure' flag was not set on this cookie, however this is just a sample to help with manual testing.
         httpResponse.addCookie(stateCookie);
 
         Cookie nonceCookie = new Cookie(MSAL_WEB_APP_NONCE_COOKIE, "");


### PR DESCRIPTION
https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/904 added suppressions for various CodeQL issues described in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/899, however, after it was merged into main and scanned again two of the issues were still not suppressed.

This PR does some small refactoring to try to suppress the remaining false-positive flags:
 - `DefaultHttpClientManagedIdentity`: the suppression comment was originally above the flagged variable, though the behavior that caused the flag was assigned to the variable elsewhere
   - This has been refactored so the problematic block of code all begins on the same line, which will hopefully be correctly picked up by the scanner
 - Samples folder: there are two samples (meant for manual testing by devs) that use a class called `CookieHelper` and the same suppression comment was added to both lines of flagged code, however only one of the flags were suppressed
   - The suppression comment that did not work now has the ID of the CodeQL issue rather than the name, and the wording in the comment adjusted in case the scanner has some sort of issue with duplicate comments