### PR TITLE
CVE-2023-1370 fix

### DIFF
--- a/msal4j-persistence-extension/pom.xml
+++ b/msal4j-persistence-extension/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>msal4j</artifactId>
-            <version>1.15.1</version>
+            <version>1.19.0</version>
         </dependency>
 
         <dependency>

--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
-            <version>2.4.11</version>
+            <version>2.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>11.18</version>
+            <version>11.23</version>
         </dependency>
         <dependency>
             <groupId>net.minidev</groupId>


### PR DESCRIPTION
In my other project Dependabot indicated >= 2.5.0, < 2.5.2 still impacted by CVE-2023-1370. I upgraded the libraries to achieve the indicated CVE to be resolved (confirmed by GitHub security scan).