### PR TITLE
CVE-2023-1370 fix

### DIFF
--- a/msal4j-persistence-extension/pom.xml
+++ b/msal4j-persistence-extension/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>msal4j</artifactId>
-            <version>1.15.1</version>
+            <version>1.19.0</version>
         </dependency>
 
         <dependency>

--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -36,12 +36,12 @@
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
-            <version>11.18</version>
+            <version>11.23</version>
         </dependency>
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
-            <version>2.4.11</version>
+            <version>2.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
In my project where I used com.microsoft.azure:msal4j, I received Dependabot alerts that high severity CVE-2023-1370 is among my transitive dependencies. I found net.minidev:json-smart and according to the alert >= 2.5.0, < 2.5.2 are the affected version. So I upgraded it in your library and according to Dependabot security analyzis, this is fixed for now.