### PR TITLE
Replace jackson-databind with azure-json in HTTP response classes

### DIFF
--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -61,6 +61,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-json</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.18.1</version>

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
@@ -120,19 +120,13 @@ class AadInstanceDiscoveryProvider {
 
     static AadInstanceDiscoveryResponse parseInstanceDiscoveryMetadata(String instanceDiscoveryJson) {
 
-        AadInstanceDiscoveryResponse aadInstanceDiscoveryResponse;
         try {
-            aadInstanceDiscoveryResponse = JsonHelper.convertJsonToObject(
-                    instanceDiscoveryJson,
-                    AadInstanceDiscoveryResponse.class);
-
+            return JsonHelper.convertJsonStringToJsonSerializableObject(instanceDiscoveryJson, AadInstanceDiscoveryResponse.class);
         } catch (Exception ex) {
             throw new MsalClientException("Error parsing instance discovery response. Data must be " +
                     "in valid JSON format. For more information, see https://aka.ms/msal4j-instance-discovery",
                     AuthenticationErrorCode.INVALID_INSTANCE_DISCOVERY_METADATA);
         }
-
-        return aadInstanceDiscoveryResponse;
     }
 
     static void cacheInstanceDiscoveryResponse(String host,
@@ -150,13 +144,8 @@ class AadInstanceDiscoveryProvider {
     }
 
     static void cacheInstanceDiscoveryMetadata(String host) {
-        cache.putIfAbsent(host, InstanceDiscoveryMetadataEntry.builder().
-                preferredCache(host).
-                preferredNetwork(host).
-                aliases(Collections.singleton(host)).
-                build());
+        cache.putIfAbsent(host, new InstanceDiscoveryMetadataEntry(host, host, Collections.singleton(host)));
     }
-
 
     private static boolean shouldUseRegionalEndpoint(MsalRequest msalRequest){
         if (((AbstractClientApplicationBase) msalRequest.application()).azureRegion() != null
@@ -184,11 +173,7 @@ class AadInstanceDiscoveryProvider {
         Set<String> aliases = new HashSet<>();
         aliases.add(originalHost);
 
-        cache.putIfAbsent(regionalHost, InstanceDiscoveryMetadataEntry.builder().
-                preferredCache(originalHost).
-                preferredNetwork(regionalHost).
-                aliases(aliases).
-                build());
+        cache.putIfAbsent(regionalHost,  new InstanceDiscoveryMetadataEntry(regionalHost, originalHost, aliases));
     }
 
     private static String getRegionalizedHost(String host, String region) {
@@ -248,10 +233,10 @@ class AadInstanceDiscoveryProvider {
 
         IHttpResponse httpResponse = executeRequest(instanceDiscoveryRequestUrl, msalRequest.headers().getReadonlyHeaderMap(), msalRequest, serviceBundle);
 
-        AadInstanceDiscoveryResponse response = JsonHelper.convertJsonToObject(httpResponse.body(), AadInstanceDiscoveryResponse.class);
+        AadInstanceDiscoveryResponse response = JsonHelper.convertJsonStringToJsonSerializableObject(httpResponse.body(), AadInstanceDiscoveryResponse.class);
 
         if (httpResponse.statusCode() != HttpHelper.HTTP_STATUS_200) {
-            if(httpResponse.statusCode() == HttpHelper.HTTP_STATUS_400 && response.error().equals("invalid_instance")){
+            if (httpResponse.statusCode() == HttpHelper.HTTP_STATUS_400 && response.error().equals("invalid_instance")) {
                 // instance discovery failed due to an invalid authority, throw an exception.
                 throw MsalServiceExceptionFactory.fromHttpResponse(httpResponse);
             }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
@@ -121,7 +121,7 @@ class AadInstanceDiscoveryProvider {
     static AadInstanceDiscoveryResponse parseInstanceDiscoveryMetadata(String instanceDiscoveryJson) {
 
         try {
-            return JsonHelper.convertJsonStringToJsonSerializableObject(instanceDiscoveryJson, AadInstanceDiscoveryResponse.class);
+            return JsonHelper.convertJsonStringToJsonSerializableObject(instanceDiscoveryJson, AadInstanceDiscoveryResponse::fromJson);
         } catch (Exception ex) {
             throw new MsalClientException("Error parsing instance discovery response. Data must be " +
                     "in valid JSON format. For more information, see https://aka.ms/msal4j-instance-discovery",
@@ -233,7 +233,7 @@ class AadInstanceDiscoveryProvider {
 
         IHttpResponse httpResponse = executeRequest(instanceDiscoveryRequestUrl, msalRequest.headers().getReadonlyHeaderMap(), msalRequest, serviceBundle);
 
-        AadInstanceDiscoveryResponse response = JsonHelper.convertJsonStringToJsonSerializableObject(httpResponse.body(), AadInstanceDiscoveryResponse.class);
+        AadInstanceDiscoveryResponse response = JsonHelper.convertJsonStringToJsonSerializableObject(httpResponse.body(), AadInstanceDiscoveryResponse::fromJson);
 
         if (httpResponse.statusCode() != HttpHelper.HTTP_STATUS_200) {
             if (httpResponse.statusCode() == HttpHelper.HTTP_STATUS_400 && response.error().equals("invalid_instance")) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryResponse.java
@@ -3,30 +3,71 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
+import java.io.IOException;
+import java.util.List;
+
 @Accessors(fluent = true)
 @Getter(AccessLevel.PACKAGE)
-class AadInstanceDiscoveryResponse {
+class AadInstanceDiscoveryResponse implements JsonSerializable<AadInstanceDiscoveryResponse> {
 
-    @JsonProperty("tenant_discovery_endpoint")
     private String tenantDiscoveryEndpoint;
-
-    @JsonProperty("metadata")
-    private InstanceDiscoveryMetadataEntry[] metadata;
-
-    @JsonProperty("error_description")
+    private List<InstanceDiscoveryMetadataEntry> metadata;
     private String errorDescription;
-
-    @JsonProperty("error_codes")
-    private long[] errorCodes;
-
-    @JsonProperty("error")
+    private List<Long> errorCodes;
     private String error;
-
-    @JsonProperty("correlation_id")
     private String correlationId;
+
+    public static AadInstanceDiscoveryResponse fromJson(JsonReader jsonReader) throws IOException {
+        AadInstanceDiscoveryResponse response = new AadInstanceDiscoveryResponse();
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+                switch (fieldName) {
+                    case "tenant_discovery_endpoint":
+                        response.tenantDiscoveryEndpoint = reader.getString();
+                        break;
+                    case "metadata":
+                        response.metadata = reader.readArray(InstanceDiscoveryMetadataEntry::fromJson);
+                        break;
+                    case "error_description":
+                        response.errorDescription = reader.getString();
+                        break;
+                    case "error_codes":
+                        response.errorCodes = reader.readArray(JsonReader::getLong);
+                        break;
+                    case "error":
+                        response.error = reader.getString();
+                        break;
+                    case "correlation_id":
+                        response.correlationId = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return response;
+        });
+    }
+
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+        jsonWriter.writeStringField("tenant_discovery_endpoint", tenantDiscoveryEndpoint);
+        jsonWriter.writeArrayField("metadata", metadata, JsonWriter::writeJson);
+        jsonWriter.writeStringField("error_description", errorDescription);
+        jsonWriter.writeArrayField("error_codes", errorCodes, JsonWriter::writeLong);
+        jsonWriter.writeStringField("error", error);
+        jsonWriter.writeStringField("correlation_id", correlationId);
+        jsonWriter.writeEndObject();
+        return jsonWriter;
+    }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractManagedIdentitySource.java
@@ -101,8 +101,7 @@ abstract class AbstractManagedIdentitySource {
 
     protected ManagedIdentityResponse getSuccessfulResponse(IHttpResponse response) {
 
-        ManagedIdentityResponse managedIdentityResponse = JsonHelper
-                .convertJsonToObject(response.body(), ManagedIdentityResponse.class);
+        ManagedIdentityResponse managedIdentityResponse = JsonHelper.convertJsonStringToJsonSerializableObject(response.body(), ManagedIdentityResponse.class);
 
         if (managedIdentityResponse == null || managedIdentityResponse.getAccessToken() == null
                 || managedIdentityResponse.getAccessToken().isEmpty() || managedIdentityResponse.getExpiresOn() == null

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractManagedIdentitySource.java
@@ -101,7 +101,7 @@ abstract class AbstractManagedIdentitySource {
 
     protected ManagedIdentityResponse getSuccessfulResponse(IHttpResponse response) {
 
-        ManagedIdentityResponse managedIdentityResponse = JsonHelper.convertJsonStringToJsonSerializableObject(response.body(), ManagedIdentityResponse.class);
+        ManagedIdentityResponse managedIdentityResponse = JsonHelper.convertJsonStringToJsonSerializableObject(response.body(), ManagedIdentityResponse::fromJson);
 
         if (managedIdentityResponse == null || managedIdentityResponse.getAccessToken() == null
                 || managedIdentityResponse.getAccessToken().isEmpty() || managedIdentityResponse.getExpiresOn() == null

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/InstanceDiscoveryMetadataEntry.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/InstanceDiscoveryMetadataEntry.java
@@ -3,10 +3,14 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 import lombok.*;
 import lombok.experimental.Accessors;
 
+import java.io.IOException;
 import java.util.*;
 
 @Accessors(fluent = true)
@@ -14,14 +18,43 @@ import java.util.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-class InstanceDiscoveryMetadataEntry {
+class InstanceDiscoveryMetadataEntry implements JsonSerializable<InstanceDiscoveryMetadataEntry> {
 
-    @JsonProperty("preferred_network")
     String preferredNetwork;
-
-    @JsonProperty("preferred_cache")
     String preferredCache;
-
-    @JsonProperty("aliases")
     Set<String> aliases;
+
+    public static InstanceDiscoveryMetadataEntry fromJson(JsonReader jsonReader) throws IOException {
+        InstanceDiscoveryMetadataEntry entry = new InstanceDiscoveryMetadataEntry();
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+                switch (fieldName) {
+                    case "preferred_network":
+                        entry.preferredNetwork = reader.getString();
+                        break;
+                    case "preferred_cache":
+                        entry.preferredCache = reader.getString();
+                        break;
+                    case "aliases":
+                        entry.aliases = new HashSet<>(reader.readArray(JsonReader::getString));
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return entry;
+        });
+    }
+
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+        jsonWriter.writeStringField("preferred_network", preferredNetwork);
+        jsonWriter.writeStringField("preferred_cache", preferredCache);
+        jsonWriter.writeArrayField("aliases", aliases, JsonWriter::writeString);
+        jsonWriter.writeEndObject();
+        return jsonWriter;
+    }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
@@ -6,6 +6,7 @@ package com.microsoft.aad.msal4j;
 import com.azure.json.JsonProviders;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
+import com.azure.json.ReadValueCallback;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -40,9 +41,9 @@ class JsonHelper {
     }
 
     //This method is used to convert a JSON string to an object which implements the JsonSerializable interface from com.azure.json
-    static <T extends JsonSerializable<T>> T convertJsonStringToJsonSerializableObject(String jsonResponse, Class<T> tClass) {
+    static <T extends JsonSerializable<T>> T convertJsonStringToJsonSerializableObject(String jsonResponse, ReadValueCallback<JsonReader, T> readFunction) {
         try (JsonReader jsonReader = JsonProviders.createReader(jsonResponse)) {
-            return (T) tClass.getDeclaredMethod("fromJson", JsonReader.class).invoke(null, jsonReader);
+            return readFunction.read(jsonReader);
         } catch (IOException e) {
             throw new MsalClientException(e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
         } catch (Exception e) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
@@ -3,6 +3,9 @@
 
 package com.microsoft.aad.msal4j;
 
+import com.azure.json.JsonProviders;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -33,6 +36,17 @@ class JsonHelper {
             return mapper.readValue(json, tClass);
         } catch (IOException e) {
             throw new MsalClientException(e);
+        }
+    }
+
+    //This method is used to convert a JSON string to an object which implements the JsonSerializable interface from com.azure.json
+    static <T extends JsonSerializable<T>> T convertJsonStringToJsonSerializableObject(String jsonResponse, Class<T> tClass) {
+        try (JsonReader jsonReader = JsonProviders.createReader(jsonResponse)) {
+            return (T) tClass.getDeclaredMethod("fromJson", JsonReader.class).invoke(null, jsonReader);
+        } catch (IOException e) {
+            throw new MsalClientException(e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
+        } catch (Exception e) {
+            throw new MsalClientException("Error parsing JSON response: " + e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
         }
     }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityResponse.java
@@ -3,42 +3,67 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+
 @Getter
-class ManagedIdentityResponse {
+class ManagedIdentityResponse implements JsonSerializable<ManagedIdentityResponse> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ManagedIdentityResponse.class);
 
-    @JsonProperty(value = "token_type")
     String tokenType;
-
-    @JsonProperty(value = "access_token")
     String accessToken;
-
-    @JsonProperty(value = "expires_on")
     String expiresOn;
-
     String resource;
-
-    @JsonProperty(value = "client_id")
     String clientId;
 
-    /**
-     * Creates an access token instance.
-     *
-     * @param token the token string.
-     * @param expiresOn the expiration time.
-     */
-    @JsonCreator
-    private ManagedIdentityResponse(
-            @JsonProperty(value = "access_token") String token,
-            @JsonProperty(value = "expires_on") String expiresOn) {
-        this.accessToken = token;
-        this.expiresOn =  expiresOn;
+    public static ManagedIdentityResponse fromJson(JsonReader jsonReader) throws IOException {
+        ManagedIdentityResponse response = new ManagedIdentityResponse();
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+                switch (fieldName) {
+                    case "token_type":
+                        response.tokenType = reader.getString();
+                        break;
+                    case "access_token":
+                        response.accessToken = reader.getString();
+                        break;
+                    case "expires_on":
+                        response.expiresOn = reader.getString();
+                        break;
+                    case "resource":
+                        response.resource = reader.getString();
+                        break;
+                    case "client_id":
+                        response.clientId = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return response;
+        });
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+        jsonWriter.writeStringField("token_type", tokenType);
+        jsonWriter.writeStringField("access_token", accessToken);
+        jsonWriter.writeStringField("expires_on", expiresOn);
+        jsonWriter.writeStringField("resource", resource);
+        jsonWriter.writeStringField("client_id", clientId);
+        jsonWriter.writeEndObject();
+        return jsonWriter;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OidcDiscoveryProvider.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OidcDiscoveryProvider.java
@@ -12,7 +12,7 @@ class OidcDiscoveryProvider {
 
         IHttpResponse httpResponse = ((HttpHelper)clientApplication.serviceBundle.getHttpHelper()).executeHttpRequest(httpRequest);
 
-        OidcDiscoveryResponse response = JsonHelper.convertJsonStringToJsonSerializableObject(httpResponse.body(), OidcDiscoveryResponse.class);
+        OidcDiscoveryResponse response = JsonHelper.convertJsonStringToJsonSerializableObject(httpResponse.body(), OidcDiscoveryResponse::fromJson);
 
         if (httpResponse.statusCode() != HttpHelper.HTTP_STATUS_200) {
             throw MsalServiceExceptionFactory.fromHttpResponse(httpResponse);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OidcDiscoveryProvider.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OidcDiscoveryProvider.java
@@ -12,7 +12,7 @@ class OidcDiscoveryProvider {
 
         IHttpResponse httpResponse = ((HttpHelper)clientApplication.serviceBundle.getHttpHelper()).executeHttpRequest(httpRequest);
 
-        OidcDiscoveryResponse response = JsonHelper.convertJsonToObject(httpResponse.body(), OidcDiscoveryResponse.class);
+        OidcDiscoveryResponse response = JsonHelper.convertJsonStringToJsonSerializableObject(httpResponse.body(), OidcDiscoveryResponse.class);
 
         if (httpResponse.statusCode() != HttpHelper.HTTP_STATUS_200) {
             throw MsalServiceExceptionFactory.fromHttpResponse(httpResponse);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OidcDiscoveryResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OidcDiscoveryResponse.java
@@ -3,21 +3,55 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
+import java.io.IOException;
+
 @Accessors(fluent = true)
 @Getter(AccessLevel.PACKAGE)
-class OidcDiscoveryResponse {
+class OidcDiscoveryResponse implements JsonSerializable<OidcDiscoveryResponse> {
 
-    @JsonProperty("authorization_endpoint")
     private String authorizationEndpoint;
-
-    @JsonProperty("token_endpoint")
     private String tokenEndpoint;
-
-    @JsonProperty("device_authorization_endpoint")
     private String deviceCodeEndpoint;
+
+    public static OidcDiscoveryResponse fromJson(JsonReader jsonReader) throws IOException {
+        OidcDiscoveryResponse response = new OidcDiscoveryResponse();
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+                switch (fieldName) {
+                    case "authorization_endpoint":
+                        response.authorizationEndpoint = reader.getString();
+                        break;
+                    case "token_endpoint":
+                        response.tokenEndpoint = reader.getString();
+                        break;
+                    case "device_authorization_endpoint":
+                        response.deviceCodeEndpoint = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return response;
+        });
+    }
+
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+        jsonWriter.writeStringField("authorization_endpoint", authorizationEndpoint);
+        jsonWriter.writeStringField("token_endpoint", tokenEndpoint);
+        jsonWriter.writeStringField("device_authorization_endpoint", deviceCodeEndpoint);
+        jsonWriter.writeEndObject();
+        return jsonWriter;
+    }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserDiscoveryRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserDiscoveryRequest.java
@@ -33,6 +33,6 @@ class UserDiscoveryRequest {
             throw MsalServiceExceptionFactory.fromHttpResponse(response);
         }
 
-        return JsonHelper.convertJsonStringToJsonSerializableObject(response.body(), UserDiscoveryResponse.class);
+        return JsonHelper.convertJsonStringToJsonSerializableObject(response.body(), UserDiscoveryResponse::fromJson);
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserDiscoveryRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserDiscoveryRequest.java
@@ -23,7 +23,6 @@ class UserDiscoveryRequest {
             Map<String, String> clientDataHeaders,
             RequestContext requestContext,
             ServiceBundle serviceBundle) {
-
         HashMap<String, String> headers = new HashMap<>(HEADERS);
         headers.putAll(clientDataHeaders);
 
@@ -33,6 +32,7 @@ class UserDiscoveryRequest {
         if (response.statusCode() != HttpHelper.HTTP_STATUS_200) {
             throw MsalServiceExceptionFactory.fromHttpResponse(response);
         }
-        return JsonHelper.convertJsonToObject(response.body(), UserDiscoveryResponse.class);
+
+        return JsonHelper.convertJsonStringToJsonSerializableObject(response.body(), UserDiscoveryResponse.class);
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserDiscoveryResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserDiscoveryResponse.java
@@ -3,31 +3,25 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
+import java.io.IOException;
+
 @Accessors(fluent = true)
 @Getter(AccessLevel.PACKAGE)
-class UserDiscoveryResponse {
+class UserDiscoveryResponse implements JsonSerializable<UserDiscoveryResponse> {
 
-    @JsonProperty("ver")
     private float version;
-
-    @JsonProperty("account_type")
     private String accountType;
-
-    @JsonProperty("federation_metadata_url")
     private String federationMetadataUrl;
-
-    @JsonProperty("federation_protocol")
     private String federationProtocol;
-
-    @JsonProperty("federation_active_auth_url")
     private String federationActiveAuthUrl;
-
-    @JsonProperty("cloud_audience_urn")
     private String cloudAudienceUrn;
 
     boolean isAccountFederated() {
@@ -38,5 +32,51 @@ class UserDiscoveryResponse {
     boolean isAccountManaged() {
         return !StringHelper.isBlank(this.accountType)
                 && this.accountType.equalsIgnoreCase("Managed");
+    }
+
+    public static UserDiscoveryResponse fromJson(JsonReader jsonReader) throws IOException {
+        UserDiscoveryResponse response = new UserDiscoveryResponse();
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+                switch (fieldName) {
+                    case "ver":
+                        response.version = Float.parseFloat(reader.getString());
+                        break;
+                    case "account_type":
+                        response.accountType = reader.getString();
+                        break;
+                    case "federation_metadata_url":
+                        response.federationMetadataUrl = reader.getString();
+                        break;
+                    case "federation_protocol":
+                        response.federationProtocol = reader.getString();
+                        break;
+                    case "federation_active_auth_url":
+                        response.federationActiveAuthUrl = reader.getString();
+                        break;
+                    case "cloud_audience_urn":
+                        response.cloudAudienceUrn = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return response;
+        });
+    }
+
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+        jsonWriter.writeFloatField("ver", version);
+        jsonWriter.writeStringField("account_type", accountType);
+        jsonWriter.writeStringField("federation_metadata_url", federationMetadataUrl);
+        jsonWriter.writeStringField("federation_protocol", federationProtocol);
+        jsonWriter.writeStringField("federation_active_auth_url", federationActiveAuthUrl);
+        jsonWriter.writeStringField("cloud_audience_urn", cloudAudienceUrn);
+        jsonWriter.writeEndObject();
+        return jsonWriter;
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryTest.java
@@ -54,10 +54,7 @@ class AadInstanceDiscoveryTest {
                 new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters));
 
         URL authority = new URL(app.authority());
-
-        AadInstanceDiscoveryResponse expectedResponse = JsonHelper.convertJsonToObject(
-                instanceDiscoveryValidResponse,
-                AadInstanceDiscoveryResponse.class);
+        AadInstanceDiscoveryResponse expectedResponse= JsonHelper.convertJsonStringToJsonSerializableObject(instanceDiscoveryValidResponse, AadInstanceDiscoveryResponse.class);
 
         try (MockedStatic<AadInstanceDiscoveryProvider> mockedInstanceDiscoveryProvider = mockStatic(AadInstanceDiscoveryProvider.class, CALLS_REAL_METHODS)) {
 

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryTest.java
@@ -54,7 +54,7 @@ class AadInstanceDiscoveryTest {
                 new RequestContext(app, PublicApi.ACQUIRE_TOKEN_BY_AUTHORIZATION_CODE, parameters));
 
         URL authority = new URL(app.authority());
-        AadInstanceDiscoveryResponse expectedResponse= JsonHelper.convertJsonStringToJsonSerializableObject(instanceDiscoveryValidResponse, AadInstanceDiscoveryResponse.class);
+        AadInstanceDiscoveryResponse expectedResponse= JsonHelper.convertJsonStringToJsonSerializableObject(instanceDiscoveryValidResponse, AadInstanceDiscoveryResponse::fromJson);
 
         try (MockedStatic<AadInstanceDiscoveryProvider> mockedInstanceDiscoveryProvider = mockStatic(AadInstanceDiscoveryProvider.class, CALLS_REAL_METHODS)) {
 


### PR DESCRIPTION
This PR begins the process of replacing the com.fasterxml.jackson.core dependency with azure-json, #909

There are a lot of added and deleted lines, but for the most part the changes are:
- Adjust classes to implement azure-json's [JsonSerializable](https://learn.microsoft.com/en-us/java/api/com.azure.json.jsonserializable?view=azure-java-stable) interface
- Remove jackson-databind's JSON annotations from those classes
- Add a new method to JsonHelper which converts a JSON string to a class which implements the JsonSerializable interface

To help keep the PR focused and lower the risk of a breaking change in behavior, this first PR covers various package-private classes and methods. Follow-up PRs will finish the job of removing com.fasterxml.jackson.core, as well as use RevAPI to ensure no changes are made to the API