### PR TITLE
Remove Lombok from several Parameters classes

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AppTokenProviderParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AppTokenProviderParameters.java
@@ -3,15 +3,8 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
-
 import java.util.Set;
 
-@Getter
-@Setter
-@AllArgsConstructor
 /// The authentication parameters provided to the app token provider callback.
 public class AppTokenProviderParameters {
 
@@ -23,4 +16,43 @@ public class AppTokenProviderParameters {
     public String claims;
     /// tenant id
     public String tenantId;
+
+    public AppTokenProviderParameters(Set<String> scopes, String correlationId, String claims, String tenantId) {
+        this.scopes = scopes;
+        this.correlationId = correlationId;
+        this.claims = claims;
+        this.tenantId = tenantId;
+    }
+
+    public Set<String> getScopes() {
+        return this.scopes;
+    }
+
+    public String getCorrelationId() {
+        return this.correlationId;
+    }
+
+    public String getClaims() {
+        return this.claims;
+    }
+
+    public String getTenantId() {
+        return this.tenantId;
+    }
+
+    public void setScopes(Set<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
+    }
+
+    public void setClaims(String claims) {
+        this.claims = claims;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeParameters.java
@@ -3,69 +3,49 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.*;
-import lombok.experimental.Accessors;
-
 import java.net.URI;
 import java.util.Map;
 import java.util.Set;
 
 import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotBlank;
+import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
 
 /**
  * Object containing parameters for authorization code flow. Can be used as parameter to
  * {@link PublicClientApplication#acquireToken(AuthorizationCodeParameters)} or to
  * {@link ConfidentialClientApplication#acquireToken(AuthorizationCodeParameters)}
  */
-@Builder
-@Accessors(fluent = true)
-@Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthorizationCodeParameters implements IAcquireTokenParameters {
 
-    /**
-     * Authorization code acquired in the first step of OAuth2.0 authorization code flow. For more
-     * details, see https://aka.ms/msal4j-authorization-code-flow
-     */
-    @NonNull
     private String authorizationCode;
 
-    /**
-     * Redirect URI registered in the Azure portal, and which was used in the first step of OAuth2.0
-     * authorization code flow. For more details, see https://aka.ms/msal4j-authorization-code-flow
-     */
-    @NonNull
     private URI redirectUri;
 
-    /**
-     * Scopes to which the application is requesting access
-     */
     private Set<String> scopes;
 
-    /**
-     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
-     */
     private ClaimsRequest claims;
 
-    /**
-     * Code verifier used for PKCE. For more details, see https://tools.ietf.org/html/rfc7636
-     */
     private String codeVerifier;
 
-    /**
-     * Adds additional headers to the token request
-     */
     private Map<String, String> extraHttpHeaders;
 
-    /**
-     * Adds additional query parameters to the token request
-     */
     private Map<String, String> extraQueryParameters;
 
-    /**
-     * Overrides the tenant value in the authority URL for this request
-     */
     private String tenant;
+
+    private AuthorizationCodeParameters(String authorizationCode, URI redirectUri,
+                                        Set<String> scopes, ClaimsRequest claims,
+                                        String codeVerifier, Map<String, String> extraHttpHeaders,
+                                        Map<String, String> extraQueryParameters, String tenant) {
+        this.authorizationCode = authorizationCode;
+        this.redirectUri = redirectUri;
+        this.scopes = scopes;
+        this.claims = claims;
+        this.codeVerifier = codeVerifier;
+        this.extraHttpHeaders = extraHttpHeaders;
+        this.extraQueryParameters = extraQueryParameters;
+        this.tenant = tenant;
+    }
 
     private static AuthorizationCodeParametersBuilder builder() {
 
@@ -86,5 +66,133 @@ public class AuthorizationCodeParameters implements IAcquireTokenParameters {
         return builder()
                 .authorizationCode(authorizationCode)
                 .redirectUri(redirectUri);
+    }
+
+    public String authorizationCode() {
+        return this.authorizationCode;
+    }
+
+    public URI redirectUri() {
+        return this.redirectUri;
+    }
+
+    public Set<String> scopes() {
+        return this.scopes;
+    }
+
+    public ClaimsRequest claims() {
+        return this.claims;
+    }
+
+    public String codeVerifier() {
+        return this.codeVerifier;
+    }
+
+    public Map<String, String> extraHttpHeaders() {
+        return this.extraHttpHeaders;
+    }
+
+    public Map<String, String> extraQueryParameters() {
+        return this.extraQueryParameters;
+    }
+
+    public String tenant() {
+        return this.tenant;
+    }
+
+    public static class AuthorizationCodeParametersBuilder {
+        private String authorizationCode;
+        private URI redirectUri;
+        private Set<String> scopes;
+        private ClaimsRequest claims;
+        private String codeVerifier;
+        private Map<String, String> extraHttpHeaders;
+        private Map<String, String> extraQueryParameters;
+        private String tenant;
+
+        AuthorizationCodeParametersBuilder() {
+        }
+
+        /**
+         * Authorization code acquired in the first step of OAuth2.0 authorization code flow. For more
+         * details, see https://aka.ms/msal4j-authorization-code-flow
+         * <p>
+         * Cannot be null.
+         */
+        public AuthorizationCodeParametersBuilder authorizationCode(String authorizationCode) {
+            validateNotNull("authorizationCode", authorizationCode);
+
+            this.authorizationCode = authorizationCode;
+            return this;
+        }
+
+        /**
+         * Redirect URI registered in the Azure portal, and which was used in the first step of OAuth2.0
+         * authorization code flow. For more details, see https://aka.ms/msal4j-authorization-code-flow
+         * <p>
+         * Cannot be null.
+         */
+        public AuthorizationCodeParametersBuilder redirectUri(URI redirectUri) {
+            validateNotNull("redirectUri", redirectUri);
+
+            this.redirectUri = redirectUri;
+            return this;
+        }
+
+        /**
+         * Scopes to which the application is requesting access
+         */
+        public AuthorizationCodeParametersBuilder scopes(Set<String> scopes) {
+            this.scopes = scopes;
+            return this;
+        }
+
+        /**
+         * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
+         */
+        public AuthorizationCodeParametersBuilder claims(ClaimsRequest claims) {
+            this.claims = claims;
+            return this;
+        }
+
+        /**
+         * Code verifier used for PKCE. For more details, see https://tools.ietf.org/html/rfc7636
+         */
+        public AuthorizationCodeParametersBuilder codeVerifier(String codeVerifier) {
+            this.codeVerifier = codeVerifier;
+            return this;
+        }
+
+        /**
+         * Adds additional headers to the token request
+         */
+        public AuthorizationCodeParametersBuilder extraHttpHeaders(Map<String, String> extraHttpHeaders) {
+            this.extraHttpHeaders = extraHttpHeaders;
+            return this;
+        }
+
+        /**
+         * Adds additional query parameters to the token request
+         */
+        public AuthorizationCodeParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
+            this.extraQueryParameters = extraQueryParameters;
+            return this;
+        }
+
+        /**
+         * Overrides the tenant value in the authority URL for this request
+         */
+        public AuthorizationCodeParametersBuilder tenant(String tenant) {
+            this.tenant = tenant;
+            return this;
+        }
+
+        public AuthorizationCodeParameters build() {
+            return new AuthorizationCodeParameters(this.authorizationCode, this.redirectUri, this.scopes, this.claims, this.codeVerifier, this.extraHttpHeaders, this.extraQueryParameters, this.tenant);
+        }
+
+        public String toString() {
+            return "AuthorizationCodeParameters.AuthorizationCodeParametersBuilder(authorizationCode=" + this.authorizationCode + ", redirectUri=" + this.redirectUri + ", scopes=" + this.scopes + ", claims=" + this.claims + ", codeVerifier=" + this.codeVerifier + ", extraHttpHeaders=" + this.extraHttpHeaders + ", extraQueryParameters=" + this.extraQueryParameters + ", tenant=" + this.tenant + ")";
+        }
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
@@ -3,9 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.*;
-import lombok.experimental.Accessors;
-
 import java.util.Map;
 import java.util.Set;
 
@@ -15,49 +12,31 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
  * Object containing parameters for client credential flow. Can be used as parameter to
  * {@link ConfidentialClientApplication#acquireToken(ClientCredentialParameters)}
  */
-@Builder
-@Accessors(fluent = true)
-@Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ClientCredentialParameters implements IAcquireTokenParameters {
 
-    /**
-     * Scopes for which the application is requesting access to.
-     */
-    @NonNull
     private Set<String> scopes;
 
-    /**
-     * Indicates whether the request should skip looking into the token cache. Be default it is
-     * set to false.
-     */
-    @Builder.Default
     private Boolean skipCache = false;
 
-    /**
-     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
-     */
     private ClaimsRequest claims;
 
-    /**
-     * Adds additional headers to the token request
-     */
     private Map<String, String> extraHttpHeaders;
 
-    /**
-     * Adds additional query parameters to the token request
-     */
     private Map<String, String> extraQueryParameters;
 
-    /**
-     * Overrides the tenant value in the authority URL for this request
-     */
     private String tenant;
 
-    /**
-     * Overrides the client credentials for this request
-     */
     private IClientCredential clientCredential;
+
+    private ClientCredentialParameters(Set<String> scopes, Boolean skipCache, ClaimsRequest claims, Map<String, String> extraHttpHeaders, Map<String, String> extraQueryParameters, String tenant, IClientCredential clientCredential) {
+        this.scopes = scopes;
+        this.skipCache = skipCache;
+        this.claims = claims;
+        this.extraHttpHeaders = extraHttpHeaders;
+        this.extraQueryParameters = extraQueryParameters;
+        this.tenant = tenant;
+        this.clientCredential = clientCredential;
+    }
 
     private static ClientCredentialParametersBuilder builder() {
 
@@ -71,9 +50,118 @@ public class ClientCredentialParameters implements IAcquireTokenParameters {
      * @return builder that can be used to construct ClientCredentialParameters
      */
     public static ClientCredentialParametersBuilder builder(Set<String> scopes) {
-
         validateNotNull("scopes", scopes);
 
         return builder().scopes(scopes);
+    }
+
+    public Set<String> scopes() {
+        return this.scopes;
+    }
+
+    public Boolean skipCache() {
+        return this.skipCache;
+    }
+
+    public ClaimsRequest claims() {
+        return this.claims;
+    }
+
+    public Map<String, String> extraHttpHeaders() {
+        return this.extraHttpHeaders;
+    }
+
+    public Map<String, String> extraQueryParameters() {
+        return this.extraQueryParameters;
+    }
+
+    public String tenant() {
+        return this.tenant;
+    }
+
+    public IClientCredential clientCredential() {
+        return this.clientCredential;
+    }
+
+    public static class ClientCredentialParametersBuilder {
+        private Set<String> scopes;
+        private Boolean skipCache = false;
+        private ClaimsRequest claims;
+        private Map<String, String> extraHttpHeaders;
+        private Map<String, String> extraQueryParameters;
+        private String tenant;
+        private IClientCredential clientCredential;
+
+        ClientCredentialParametersBuilder() {
+        }
+
+        /**
+         * Scopes application is requesting access to.
+         * <p>
+         * Cannot be null.
+         */
+        public ClientCredentialParametersBuilder scopes(Set<String> scopes) {
+            validateNotNull("scopes", scopes);
+
+            this.scopes = scopes;
+            return this;
+        }
+
+        /**
+         * Indicates whether the request should skip looking into the token cache. Be default it is
+         * set to false.
+         */
+        public ClientCredentialParametersBuilder skipCache(Boolean skipCache) {
+            this.skipCache = skipCache;
+            return this;
+        }
+
+        /**
+         * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
+         */
+        public ClientCredentialParametersBuilder claims(ClaimsRequest claims) {
+            this.claims = claims;
+            return this;
+        }
+
+        /**
+         * Adds additional headers to the token request
+         */
+        public ClientCredentialParametersBuilder extraHttpHeaders(Map<String, String> extraHttpHeaders) {
+            this.extraHttpHeaders = extraHttpHeaders;
+            return this;
+        }
+
+        /**
+         * Adds additional query parameters to the token request
+         */
+        public ClientCredentialParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
+            this.extraQueryParameters = extraQueryParameters;
+            return this;
+        }
+
+        /**
+         * Overrides the tenant value in the authority URL for this request
+         */
+        public ClientCredentialParametersBuilder tenant(String tenant) {
+            this.tenant = tenant;
+            return this;
+        }
+
+        /**
+         * Overrides the client credentials for this request
+         */
+        public ClientCredentialParametersBuilder clientCredential(IClientCredential clientCredential) {
+            this.clientCredential = clientCredential;
+            return this;
+        }
+
+        public ClientCredentialParameters build() {
+            return new ClientCredentialParameters(this.scopes, this.skipCache, this.claims, this.extraHttpHeaders, this.extraQueryParameters, this.tenant, this.clientCredential);
+        }
+
+        public String toString() {
+            return "ClientCredentialParameters.ClientCredentialParametersBuilder(scopes=" + this.scopes + ", skipCache=" + this.skipCache + ", claims=" + this.claims + ", extraHttpHeaders=" + this.extraHttpHeaders + ", extraQueryParameters=" + this.extraQueryParameters + ", tenant=" + this.tenant + ", clientCredential=" + this.clientCredential + ")";
+        }
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
@@ -3,14 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-
 import java.net.URI;
 import java.util.Map;
 import java.util.Set;
@@ -23,101 +15,55 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
  * <p>
  * For more details, see https://aka.ms/msal4j-interactive-request.
  */
-@Builder
-@Accessors(fluent = true)
-@Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class InteractiveRequestParameters implements IAcquireTokenParameters {
 
-    /**
-     * Redirect URI where MSAL will listen to for the authorization code returned by Azure AD.
-     * Should be a loopback address with a port specified (for example, http://localhost:3671). If no
-     * port is specified, MSAL will find an open port. For more information, see
-     * https://aka.ms/msal4j-interactive-request.
-     */
-    @Setter(AccessLevel.PACKAGE)
-    @NonNull
     private URI redirectUri;
 
-    /**
-     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
-     */
     private ClaimsRequest claims;
 
-    /**
-     * Scopes that the application is requesting access to and the user will consent to.
-     */
     private Set<String> scopes;
 
-    /**
-     * Indicate the type of user interaction that is required.
-     */
     private Prompt prompt;
 
-    /**
-     * Can be used to pre-fill the username/email address field of the sign-in page for the user,
-     * if you know the username/email address ahead of time. Often apps use this parameter during
-     * re-authentication, having already extracted the username from a previous sign-in using the
-     * preferred_username claim.
-     */
     private String loginHint;
 
-    /**
-     * Provides a hint about the tenant or domain that the user should use to sign in. The value
-     * of the domain hint is a registered domain for the tenant.
-     **/
     private String domainHint;
 
-    /**
-     * Sets {@link SystemBrowserOptions} to be used by the PublicClientApplication
-     */
     private SystemBrowserOptions systemBrowserOptions;
 
     private String claimsChallenge;
 
-    /**
-     * Adds additional headers to the token request
-     */
     private Map<String, String> extraHttpHeaders;
 
-    /**
-     * Adds additional query parameters to the token request
-     */
     private Map<String, String> extraQueryParameters;
 
-    /**
-     * Overrides the tenant value in the authority URL for this request
-     */
     private String tenant;
 
-    /**
-     * The amount of time in seconds that the library will wait for an authentication result. 120 seconds is the default timeout,
-     * unless overridden here with some other positive integer
-     *
-     * If this timeout is set to 0 or less it will be ignored, and the library will use a 1 second timeout instead
-     */
-    @Builder.Default
-    private int httpPollingTimeoutInSeconds = 120;
+    private int httpPollingTimeoutInSeconds;
 
-    /**
-     * If set to true, the authorization result will contain the authority for the user's home cloud, and this authority
-     * will be used for the token request instead of the authority set in the application.
-     */
     private boolean instanceAware;
 
-    /**
-     * The parent window handle used to open UI elements with the correct parent
-     *
-     *
-     * For browser scenarios and Windows console applications, this value should not need to be set
-     *
-     * For Windows console applications, MSAL Java will attempt to discover the console's window handle if this parameter is not set
-     *
-     * For scenarios where MSAL Java is responsible for opening UI elements (such as when using MSALRuntime), this parameter is required and an exception will be thrown if not set
-     */
     private long windowHandle;
 
     private PopParameters proofOfPossession;
+
+    private InteractiveRequestParameters(URI redirectUri, ClaimsRequest claims, Set<String> scopes, Prompt prompt, String loginHint, String domainHint, SystemBrowserOptions systemBrowserOptions, String claimsChallenge, Map<String, String> extraHttpHeaders, Map<String, String> extraQueryParameters, String tenant, int httpPollingTimeoutInSeconds, boolean instanceAware, long windowHandle, PopParameters proofOfPossession) {
+        this.redirectUri = redirectUri;
+        this.claims = claims;
+        this.scopes = scopes;
+        this.prompt = prompt;
+        this.loginHint = loginHint;
+        this.domainHint = domainHint;
+        this.systemBrowserOptions = systemBrowserOptions;
+        this.claimsChallenge = claimsChallenge;
+        this.extraHttpHeaders = extraHttpHeaders;
+        this.extraQueryParameters = extraQueryParameters;
+        this.tenant = tenant;
+        this.httpPollingTimeoutInSeconds = httpPollingTimeoutInSeconds;
+        this.instanceAware = instanceAware;
+        this.windowHandle = windowHandle;
+        this.proofOfPossession = proofOfPossession;
+    }
 
     private static InteractiveRequestParametersBuilder builder() {
         return new InteractiveRequestParametersBuilder();
@@ -131,22 +77,244 @@ public class InteractiveRequestParameters implements IAcquireTokenParameters {
                 .redirectUri(redirectUri);
     }
 
-    //This Builder class is used to override Lombok's default setter behavior for any fields defined in it
+    public URI redirectUri() {
+        return this.redirectUri;
+    }
+
+    public ClaimsRequest claims() {
+        return this.claims;
+    }
+
+    public Set<String> scopes() {
+        return this.scopes;
+    }
+
+    public Prompt prompt() {
+        return this.prompt;
+    }
+
+    public String loginHint() {
+        return this.loginHint;
+    }
+
+    public String domainHint() {
+        return this.domainHint;
+    }
+
+    public SystemBrowserOptions systemBrowserOptions() {
+        return this.systemBrowserOptions;
+    }
+
+    public String claimsChallenge() {
+        return this.claimsChallenge;
+    }
+
+    public Map<String, String> extraHttpHeaders() {
+        return this.extraHttpHeaders;
+    }
+
+    public Map<String, String> extraQueryParameters() {
+        return this.extraQueryParameters;
+    }
+
+    public String tenant() {
+        return this.tenant;
+    }
+
+    public int httpPollingTimeoutInSeconds() {
+        return this.httpPollingTimeoutInSeconds;
+    }
+
+    public boolean instanceAware() {
+        return this.instanceAware;
+    }
+
+    public long windowHandle() {
+        return this.windowHandle;
+    }
+
+    public PopParameters proofOfPossession() {
+        return this.proofOfPossession;
+    }
+
+    void redirectUri(URI redirectUri) {
+        this.redirectUri = redirectUri;
+    }
+
     public static class InteractiveRequestParametersBuilder {
+
+        private URI redirectUri;
+        private ClaimsRequest claims;
+        private Set<String> scopes;
+        private Prompt prompt;
+        private String loginHint;
+        private String domainHint;
+        private SystemBrowserOptions systemBrowserOptions;
+        private String claimsChallenge;
+        private Map<String, String> extraHttpHeaders;
+        private Map<String, String> extraQueryParameters;
+        private String tenant;
+        private int httpPollingTimeoutInSeconds = 120;
+        private boolean instanceAware;
+        private long windowHandle;
+        private PopParameters proofOfPossession;
+
+        InteractiveRequestParametersBuilder() {
+        }
 
         /**
          * Sets the PopParameters for this request, allowing the request to retrieve proof-of-possession tokens rather than bearer tokens
-         *
+         * <p>
          * For more information, see {@link PopParameters} and https://aka.ms/msal4j-pop
          *
          * @param httpMethod a valid HTTP method, such as "GET" or "POST"
-         * @param uri the URI on the downstream protected API which the application is trying to access, e.g. https://graph.microsoft.com/beta/me/profile
-         * @param nonce a string obtained by calling the resource (e.g. Microsoft Graph) un-authenticated and parsing the WWW-Authenticate header associated with pop authentication scheme and extracting the nonce parameter, or, on subsequent calls, by parsing the Autheticate-Info header and extracting the nextnonce parameter.
+         * @param uri        the URI on the downstream protected API which the application is trying to access, e.g. https://graph.microsoft.com/beta/me/profile
+         * @param nonce      a string obtained by calling the resource (e.g. Microsoft Graph) un-authenticated and parsing the WWW-Authenticate header associated with pop authentication scheme and extracting the nonce parameter, or, on subsequent calls, by parsing the Autheticate-Info header and extracting the nextnonce parameter.
          */
         public InteractiveRequestParametersBuilder proofOfPossession(HttpMethod httpMethod, URI uri, String nonce) {
             this.proofOfPossession = new PopParameters(httpMethod, uri, nonce);
 
             return this;
+        }
+
+        /**
+         * Redirect URI where MSAL will listen to for the authorization code returned by Azure AD.
+         * Should be a loopback address with a port specified (for example, http://localhost:3671). If no
+         * port is specified, MSAL will find an open port. For more information, see
+         * https://aka.ms/msal4j-interactive-request.
+         * <p>
+         * Cannot be null.
+         */
+        public InteractiveRequestParametersBuilder redirectUri(URI redirectUri) {
+            validateNotNull("redirectUri", redirectUri);
+
+            this.redirectUri = redirectUri;
+            return this;
+        }
+
+        /**
+         * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
+         */
+        public InteractiveRequestParametersBuilder claims(ClaimsRequest claims) {
+            this.claims = claims;
+            return this;
+        }
+
+        /**
+         * Scopes that the application is requesting access to and the user will consent to.
+         */
+        public InteractiveRequestParametersBuilder scopes(Set<String> scopes) {
+            this.scopes = scopes;
+            return this;
+        }
+
+        /**
+         * Indicate the type of user interaction that is required.
+         */
+        public InteractiveRequestParametersBuilder prompt(Prompt prompt) {
+            this.prompt = prompt;
+            return this;
+        }
+
+        /**
+         * Can be used to pre-fill the username/email address field of the sign-in page for the user,
+         * if you know the username/email address ahead of time. Often apps use this parameter during
+         * re-authentication, having already extracted the username from a previous sign-in using the
+         * preferred_username claim.
+         */
+        public InteractiveRequestParametersBuilder loginHint(String loginHint) {
+            this.loginHint = loginHint;
+            return this;
+        }
+
+        /**
+         * Provides a hint about the tenant or domain that the user should use to sign in. The value
+         * of the domain hint is a registered domain for the tenant.
+         */
+        public InteractiveRequestParametersBuilder domainHint(String domainHint) {
+            this.domainHint = domainHint;
+            return this;
+        }
+
+        /**
+         * Sets {@link SystemBrowserOptions} to be used by the PublicClientApplication
+         */
+        public InteractiveRequestParametersBuilder systemBrowserOptions(SystemBrowserOptions systemBrowserOptions) {
+            this.systemBrowserOptions = systemBrowserOptions;
+            return this;
+        }
+
+        /**
+         * Used when a token request fails and the response has a challenge string
+         */
+        public InteractiveRequestParametersBuilder claimsChallenge(String claimsChallenge) {
+            this.claimsChallenge = claimsChallenge;
+            return this;
+        }
+
+        /**
+         * Adds additional headers to the token request
+         */
+        public InteractiveRequestParametersBuilder extraHttpHeaders(Map<String, String> extraHttpHeaders) {
+            this.extraHttpHeaders = extraHttpHeaders;
+            return this;
+        }
+
+        /**
+         * Adds additional query parameters to the token request
+         */
+        public InteractiveRequestParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
+            this.extraQueryParameters = extraQueryParameters;
+            return this;
+        }
+
+        /**
+         * Overrides the tenant value in the authority URL for this request
+         */
+        public InteractiveRequestParametersBuilder tenant(String tenant) {
+            this.tenant = tenant;
+            return this;
+        }
+
+        /**
+         * The amount of time in seconds that the library will wait for an authentication result. 120 seconds is the default timeout.
+         * <p>
+         * If this timeout is set to 0 or less it will be ignored, and the library will use a 1-second timeout instead
+         */
+        public InteractiveRequestParametersBuilder httpPollingTimeoutInSeconds(int httpPollingTimeoutInSeconds) {
+            this.httpPollingTimeoutInSeconds = httpPollingTimeoutInSeconds;
+            return this;
+        }
+
+        /**
+         * If set to true, the authorization result will contain the authority for the user's home cloud, and this authority
+         * will be used for the token request instead of the authority set in the application.
+         */
+        public InteractiveRequestParametersBuilder instanceAware(boolean instanceAware) {
+            this.instanceAware = instanceAware;
+            return this;
+        }
+
+        /**
+         * The parent window handle used to open UI elements with the correct parent
+         * <p>
+         * For browser scenarios and Windows console applications, this value should not need to be set
+         * <p>
+         * For Windows console applications, MSAL Java will attempt to discover the console's window handle if this parameter is not set
+         * <p>
+         * For scenarios where MSAL Java is responsible for opening UI elements (such as when using MSALRuntime), this parameter is required and an exception will be thrown if not set
+         */
+        public InteractiveRequestParametersBuilder windowHandle(long windowHandle) {
+            this.windowHandle = windowHandle;
+            return this;
+        }
+
+        public InteractiveRequestParameters build() {
+            return new InteractiveRequestParameters(this.redirectUri, this.claims, this.scopes, this.prompt, this.loginHint, this.domainHint, this.systemBrowserOptions, this.claimsChallenge, this.extraHttpHeaders, this.extraQueryParameters, this.tenant, this.httpPollingTimeoutInSeconds, this.instanceAware, this.windowHandle, this.proofOfPossession);
+        }
+
+        public String toString() {
+            return "InteractiveRequestParameters.InteractiveRequestParametersBuilder(redirectUri=" + this.redirectUri + ", claims=" + this.claims + ", scopes=" + this.scopes + ", prompt=" + this.prompt + ", loginHint=" + this.loginHint + ", domainHint=" + this.domainHint + ", systemBrowserOptions=" + this.systemBrowserOptions + ", claimsChallenge=" + this.claimsChallenge + ", extraHttpHeaders=" + this.extraHttpHeaders + ", extraQueryParameters=" + this.extraQueryParameters + ", tenant=" + this.tenant + ", httpPollingTimeoutInSeconds=" + this.httpPollingTimeoutInSeconds + ", instanceAware=" + this.instanceAware + ", windowHandle=" + this.windowHandle + ", proofOfPossession=" + this.proofOfPossession + ")";
         }
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/SilentParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/SilentParameters.java
@@ -3,9 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.*;
-import lombok.experimental.Accessors;
-
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Map;
@@ -18,54 +15,37 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
  * {@link PublicClientApplication#acquireTokenSilently(SilentParameters)} or to
  * {@link ConfidentialClientApplication#acquireTokenSilently(SilentParameters)}
  */
-@Builder
-@Accessors(fluent = true)
-@Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class SilentParameters implements IAcquireTokenParameters {
 
-    /**
-     * Scopes application is requesting access to.
-     */
-    @NonNull
     private Set<String> scopes;
 
-    /**
-     * Account for which you are requesting a token for.
-     */
     private IAccount account;
 
-    /**
-     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims.
-     */
     private ClaimsRequest claims;
 
-    /**
-     * Authority for which the application is requesting tokens from.
-     */
     private String authorityUrl;
 
-    /**
-     * Force MSAL to refresh the tokens in the cache, even if there is a valid access token.
-     */
     private boolean forceRefresh;
 
-    /**
-     * Adds additional headers to the token request
-     */
     private Map<String, String> extraHttpHeaders;
 
-    /**
-     * Adds additional query parameters to the token request
-     */
     private Map<String, String> extraQueryParameters;
 
-    /**
-     * Overrides the tenant value in the authority URL for this request
-     */
     private String tenant;
 
     private PopParameters proofOfPossession;
+
+    private SilentParameters(Set<String> scopes, IAccount account, ClaimsRequest claims, String authorityUrl, boolean forceRefresh, Map<String, String> extraHttpHeaders, Map<String, String> extraQueryParameters, String tenant, PopParameters proofOfPossession) {
+        this.scopes = scopes;
+        this.account = account;
+        this.claims = claims;
+        this.authorityUrl = authorityUrl;
+        this.forceRefresh = forceRefresh;
+        this.extraHttpHeaders = extraHttpHeaders;
+        this.extraQueryParameters = extraQueryParameters;
+        this.tenant = tenant;
+        this.proofOfPossession = proofOfPossession;
+    }
 
     private static SilentParametersBuilder builder() {
 
@@ -90,50 +70,172 @@ public class SilentParameters implements IAcquireTokenParameters {
     }
 
     /**
-     * Builder for SilentParameters
+     * Builder for SilentParameters for scenarios which involve no {@link IAccount}, such as some confidential client flows
+     * or broker flows which support using the default OS account.
      *
      * @param scopes scopes application is requesting access to
-     * @return builder object that can be used to construct SilentParameters
-     * @deprecated This method was used for using cached tokens in client credentials or On-behalf-of
-     * flow. Those flows will now by default attempt to use cached the cached tokens, so there is
-     * no need to call acquireTokenSilently. This overload will be removed in the next major version.
+     * @return builder object that can be used to construct SilentParameters flow.
      */
-
     public static SilentParametersBuilder builder(Set<String> scopes) {
         validateNotNull("scopes", scopes);
 
         return builder().scopes(removeEmptyScope(scopes));
     }
 
-    private static Set<String> removeEmptyScope(Set<String> scopes){
+    private static Set<String> removeEmptyScope(Set<String> scopes) {
         // empty string is not a valid scope, but we currently accept it and can't remove support
         // for it yet as its a breaking change. This will be removed eventually (throwing
         // exception if empty scope is passed in).
         Set<String> updatedScopes = new HashSet<>();
-        for(String scope: scopes){
-            if(!scope.equalsIgnoreCase(StringHelper.EMPTY_STRING)){
+        for (String scope : scopes) {
+            if (!scope.equalsIgnoreCase(StringHelper.EMPTY_STRING)) {
                 updatedScopes.add(scope.trim());
             }
         }
         return updatedScopes;
     }
 
+    public Set<String> scopes() {
+        return this.scopes;
+    }
+
+    public IAccount account() {
+        return this.account;
+    }
+
+    public ClaimsRequest claims() {
+        return this.claims;
+    }
+
+    public String authorityUrl() {
+        return this.authorityUrl;
+    }
+
+    public boolean forceRefresh() {
+        return this.forceRefresh;
+    }
+
+    public Map<String, String> extraHttpHeaders() {
+        return this.extraHttpHeaders;
+    }
+
+    public Map<String, String> extraQueryParameters() {
+        return this.extraQueryParameters;
+    }
+
+    public String tenant() {
+        return this.tenant;
+    }
+
+    public PopParameters proofOfPossession() {
+        return this.proofOfPossession;
+    }
+
     //This Builder class is used to override Lombok's default setter behavior for any fields defined in it
     public static class SilentParametersBuilder {
 
+        private Set<String> scopes;
+        private IAccount account;
+        private ClaimsRequest claims;
+        private String authorityUrl;
+        private boolean forceRefresh;
+        private Map<String, String> extraHttpHeaders;
+        private Map<String, String> extraQueryParameters;
+        private String tenant;
+        private PopParameters proofOfPossession;
+
+        SilentParametersBuilder() {
+        }
+
         /**
          * Sets the PopParameters for this request, allowing the request to retrieve proof-of-possession tokens rather than bearer tokens
-         *
+         * <p>
          * For more information, see {@link PopParameters} and https://aka.ms/msal4j-pop
          *
          * @param httpMethod a valid HTTP method, such as "GET" or "POST"
-         * @param uri URI to associate with the token
-         * @param nonce optional nonce value for the token, can be empty or null
+         * @param uri        URI to associate with the token
+         * @param nonce      optional nonce value for the token, can be empty or null
          */
         public SilentParametersBuilder proofOfPossession(HttpMethod httpMethod, URI uri, String nonce) {
             this.proofOfPossession = new PopParameters(httpMethod, uri, nonce);
 
             return this;
+        }
+
+        /**
+         * Scopes application is requesting access to.
+         * <p>
+         * Cannot be null.
+         */
+        public SilentParametersBuilder scopes(Set<String> scopes) {
+            validateNotNull("scopes", scopes);
+
+            this.scopes = scopes;
+            return this;
+        }
+
+        /**
+         * Account for which you are requesting a token for.
+         */
+        public SilentParametersBuilder account(IAccount account) {
+            this.account = account;
+            return this;
+        }
+
+        /**
+         * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims.
+         */
+        public SilentParametersBuilder claims(ClaimsRequest claims) {
+            this.claims = claims;
+            return this;
+        }
+
+        /**
+         * Authority for which the application is requesting tokens from.
+         */
+        public SilentParametersBuilder authorityUrl(String authorityUrl) {
+            this.authorityUrl = authorityUrl;
+            return this;
+        }
+
+        /**
+         * Force MSAL to refresh the tokens in the cache, even if there is a valid access token.
+         */
+        public SilentParametersBuilder forceRefresh(boolean forceRefresh) {
+            this.forceRefresh = forceRefresh;
+            return this;
+        }
+
+        /**
+         * Adds additional headers to the token request
+         */
+        public SilentParametersBuilder extraHttpHeaders(Map<String, String> extraHttpHeaders) {
+            this.extraHttpHeaders = extraHttpHeaders;
+            return this;
+        }
+
+        /**
+         * Adds additional query parameters to the token request
+         */
+        public SilentParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
+            this.extraQueryParameters = extraQueryParameters;
+            return this;
+        }
+
+        /**
+         * Overrides the tenant value in the authority URL for this request
+         */
+        public SilentParametersBuilder tenant(String tenant) {
+            this.tenant = tenant;
+            return this;
+        }
+
+        public SilentParameters build() {
+            return new SilentParameters(this.scopes, this.account, this.claims, this.authorityUrl, this.forceRefresh, this.extraHttpHeaders, this.extraQueryParameters, this.tenant, this.proofOfPossession);
+        }
+
+        public String toString() {
+            return "SilentParameters.SilentParametersBuilder(scopes=" + this.scopes + ", account=" + this.account + ", claims=" + this.claims + ", authorityUrl=" + this.authorityUrl + ", forceRefresh=" + this.forceRefresh + ", extraHttpHeaders=" + this.extraHttpHeaders + ", extraQueryParameters=" + this.extraQueryParameters + ", tenant=" + this.tenant + ", proofOfPossession=" + this.proofOfPossession + ")";
         }
     }
 }


### PR DESCRIPTION
This PR begins the process of removing org.projectlombok.lombok, https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/909

Lombok is used to generate a lot of boilerplate code, such as getters/setters, builders, and constructures. Removing it all at once would produce a large number of changes which would be hard to review, so this first PR keeps it focused by only removing Lombok from a few similar classes as an example of how follow-up PRs will look.

This PR makes the same basic changes to each file:

- Replace `@Getter` and `@Setter` annotations with the actual getter/setters
  - Relatedly, removes the `@Accessors(fluent = true)` annotation, which simply made the generated getter/setters names exactly the same as the fields (as an example, the getter for the `scopes` field was `scopes()` instead of `getScopes()`)
- Replace `@Builder` with an inner builder class
- Replace `@NonNull` with our own `ParameterValidationUtils.validateNotNull()` to ensure certain parameters are not null
- Move Javadoc comments from the private fields to the public builder methods
  - Lombok would copy the Javadocs on private fields to the generated public methods, but in basic Java that doesn't happen
  - Moving them to the builder methods will allow them to still be easily found by developers, such as in tooltip windows in IDEs, and still be clear on automated API doc sites such as https://javadoc.io/doc/com.microsoft.azure/msal4j/latest/index.html

And finally, while removing Lombok we must ensure that no breaking changes are made to any public API. To accomplish that, the RevAPI plugin was used alongside normal testing to ensure the new methods had the same name and the same scope.