### PR TITLE
Resolve minor CodeQL issues

### DIFF
--- a/msal4j-sdk/src/samples/msal-b2c-web-sample/src/main/java/com/microsoft/azure/msalwebsample/CookieHelper.java
+++ b/msal4j-sdk/src/samples/msal-b2c-web-sample/src/main/java/com/microsoft/azure/msalwebsample/CookieHelper.java
@@ -32,11 +32,11 @@ public class CookieHelper {
         Cookie stateCookie = new Cookie(MSAL_WEB_APP_STATE_COOKIE, "");
         stateCookie.setMaxAge(0);
 
-        // CodeQL [SM00710]: CodeQL flagged this as the 'secure' flag was not set on this cookie, however this is just a sample to help with manual testing.
         httpResponse.addCookie(stateCookie);
 
         Cookie nonceCookie = new Cookie(MSAL_WEB_APP_NONCE_COOKIE, "");
         nonceCookie.setMaxAge(0);
+        nonceCookie.setSecure(true);
 
         httpResponse.addCookie(nonceCookie);
     }

--- a/msal4j-sdk/src/samples/msal-web-sample/src/main/java/com/microsoft/azure/msalwebsample/CookieHelper.java
+++ b/msal4j-sdk/src/samples/msal-web-sample/src/main/java/com/microsoft/azure/msalwebsample/CookieHelper.java
@@ -32,11 +32,11 @@ public class CookieHelper {
         Cookie stateCookie = new Cookie(MSAL_WEB_APP_STATE_COOKIE, "");
         stateCookie.setMaxAge(0);
 
-        // CodeQL [java/insecure-cookie]: Suppressing CodeQL warning since this is just a sample
         httpResponse.addCookie(stateCookie);
 
         Cookie nonceCookie = new Cookie(MSAL_WEB_APP_NONCE_COOKIE, "");
         nonceCookie.setMaxAge(0);
+        nonceCookie.setSecure(true);
 
         httpResponse.addCookie(nonceCookie);
     }


### PR DESCRIPTION
CodeQL flagged insecure cookies used in some non-production code (sample meant to help manual dev testing). This PR sets the `secure` flag on the cookies to address that issue, and removes the suppression comments.