### PR TITLE
Remove Lombok

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AADAuthority.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AADAuthority.java
@@ -5,12 +5,6 @@ package com.microsoft.aad.msal4j;
 
 import java.net.URL;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
-@Accessors(fluent = true)
-@Getter(AccessLevel.PACKAGE)
 class AADAuthority extends Authority {
 
     private final static String TENANTLESS_TENANT_NAME = "common";

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryResponse.java
@@ -7,15 +7,10 @@ import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 
 import java.io.IOException;
 import java.util.List;
 
-@Accessors(fluent = true)
-@Getter(AccessLevel.PACKAGE)
 class AadInstanceDiscoveryResponse implements JsonSerializable<AadInstanceDiscoveryResponse> {
 
     private String tenantDiscoveryEndpoint;
@@ -69,5 +64,29 @@ class AadInstanceDiscoveryResponse implements JsonSerializable<AadInstanceDiscov
         jsonWriter.writeStringField("correlation_id", correlationId);
         jsonWriter.writeEndObject();
         return jsonWriter;
+    }
+
+    String tenantDiscoveryEndpoint() {
+        return this.tenantDiscoveryEndpoint;
+    }
+
+    List<InstanceDiscoveryMetadataEntry> metadata() {
+        return this.metadata;
+    }
+
+    String errorDescription() {
+        return this.errorDescription;
+    }
+
+    List<Long> errorCodes() {
+        return this.errorCodes;
+    }
+
+    String error() {
+        return this.error;
+    }
+
+    String correlationId() {
+        return this.correlationId;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractApplicationBase.java
@@ -3,18 +3,13 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 import org.slf4j.Logger;
 
 import javax.net.ssl.SSLSocketFactory;
-import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
@@ -30,63 +25,22 @@ public abstract class AbstractApplicationBase implements IApplicationBase {
 
     protected Logger log;
     protected Authority authenticationAuthority;
-
-    @Accessors(fluent = true)
-    @Getter
     private String correlationId;
-
-    @Accessors(fluent = true)
-    @Getter
     private boolean logPii;
-
-    @Accessors(fluent = true)
-    @Getter
     private Proxy proxy;
-
-    @Accessors(fluent = true)
-    @Getter
     private SSLSocketFactory sslSocketFactory;
-
-    @Accessors(fluent = true)
-    @Getter
     private IHttpClient httpClient;
-
-    @Accessors(fluent = true)
-    @Getter
     private Integer connectTimeoutForDefaultHttpClient;
-
-    @Accessors(fluent = true)
-    @Getter
     private Integer readTimeoutForDefaultHttpClient;
-
-    @Accessors(fluent = true)
-    @Getter(AccessLevel.PACKAGE)
     String tenant;
 
     //The following fields are set in only some applications and/or set internally by the library. To avoid excessive
     // type casting throughout the library they are defined here as package-private, but will not be part of this class's Builder
-    @Accessors(fluent = true)
-    @Getter(AccessLevel.PACKAGE)
     private boolean validateAuthority;
-
-    @Accessors(fluent = true)
-    @Getter(AccessLevel.PACKAGE)
     private String clientId;
-
-    @Accessors(fluent = true)
-    @Getter(AccessLevel.PACKAGE)
     private String authority;
-
-    @Accessors(fluent = true)
-    @Getter(AccessLevel.PACKAGE)
     ServiceBundle serviceBundle;
-
-    @Accessors(fluent = true)
-    @Getter(AccessLevel.PACKAGE)
     Consumer<List<HashMap<String, String>>> telemetryConsumer;
-
-    @Accessors(fluent = true)
-    @Getter(AccessLevel.PACKAGE)
     protected TokenCache tokenCache;
 
     CompletableFuture<IAuthenticationResult> executeRequest(
@@ -166,6 +120,62 @@ public abstract class AbstractApplicationBase implements IApplicationBase {
                     msalRequest, null);
         }
         return supplier;
+    }
+
+    public String correlationId() {
+        return this.correlationId;
+    }
+
+    public boolean logPii() {
+        return this.logPii;
+    }
+
+    public Proxy proxy() {
+        return this.proxy;
+    }
+
+    public SSLSocketFactory sslSocketFactory() {
+        return this.sslSocketFactory;
+    }
+
+    public IHttpClient httpClient() {
+        return this.httpClient;
+    }
+
+    public Integer connectTimeoutForDefaultHttpClient() {
+        return this.connectTimeoutForDefaultHttpClient;
+    }
+
+    public Integer readTimeoutForDefaultHttpClient() {
+        return this.readTimeoutForDefaultHttpClient;
+    }
+
+    String tenant() {
+        return this.tenant;
+    }
+
+    boolean validateAuthority() {
+        return this.validateAuthority;
+    }
+
+    String clientId() {
+        return this.clientId;
+    }
+
+    String authority() {
+        return this.authority;
+    }
+
+    ServiceBundle serviceBundle() {
+        return this.serviceBundle;
+    }
+
+    Consumer<List<HashMap<String, String>>> telemetryConsumer() {
+        return this.telemetryConsumer;
+    }
+
+    TokenCache tokenCache() {
+        return this.tokenCache;
     }
 
     public abstract static class Builder<T extends Builder<T>> {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
@@ -4,8 +4,6 @@
 package com.microsoft.aad.msal4j;
 
 import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 
 import javax.net.ssl.SSLSocketFactory;
 import java.net.MalformedURLException;
@@ -25,46 +23,16 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
  */
 public abstract class AbstractClientApplicationBase extends AbstractApplicationBase implements IClientApplicationBase {
 
-    @Accessors(fluent = true)
-    @Getter
     private String clientId;
-
-    @Accessors(fluent = true)
-    @Getter
     private String authority;
-
-    @Accessors(fluent = true)
-    @Getter
     private boolean validateAuthority;
-
-    @Accessors(fluent = true)
-    @Getter
     private String applicationName;
-
-    @Accessors(fluent = true)
-    @Getter
     private String applicationVersion;
-
-    @Accessors(fluent = true)
-    @Getter
     private AadInstanceDiscoveryResponse aadAadInstanceDiscoveryResponse;
-
     protected abstract ClientAuthentication clientAuthentication();
-
-    @Accessors(fluent = true)
-    @Getter
     private String clientCapabilities;
-
-    @Accessors(fluent = true)
-    @Getter
     private boolean autoDetectRegion;
-
-    @Accessors(fluent = true)
-    @Getter
     protected String azureRegion;
-
-    @Accessors(fluent = true)
-    @Getter
     private boolean instanceDiscovery;
 
     @Override
@@ -187,6 +155,49 @@ public abstract class AbstractClientApplicationBase extends AbstractApplicationB
                 parameters.requestParameters());
     }
 
+    @Override
+    public String clientId() {
+        return this.clientId;
+    }
+
+    @Override
+    public String authority() {
+        return this.authority;
+    }
+
+    @Override
+    public boolean validateAuthority() {
+        return this.validateAuthority;
+    }
+
+    public String applicationName() {
+        return this.applicationName;
+    }
+
+    public String applicationVersion() {
+        return this.applicationVersion;
+    }
+
+    public AadInstanceDiscoveryResponse aadAadInstanceDiscoveryResponse() {
+        return this.aadAadInstanceDiscoveryResponse;
+    }
+
+    public String clientCapabilities() {
+        return this.clientCapabilities;
+    }
+
+    public boolean autoDetectRegion() {
+        return this.autoDetectRegion;
+    }
+
+    public String azureRegion() {
+        return this.azureRegion;
+    }
+
+    public boolean instanceDiscovery() {
+        return this.instanceDiscovery;
+    }
+
     public abstract static class Builder<T extends Builder<T>> extends AbstractApplicationBase.Builder<T> {
         // Required parameters
         private String clientId;
@@ -253,11 +264,11 @@ public abstract class AbstractClientApplicationBase extends AbstractApplicationB
 
         /**
          * Set URL of the authenticating B2C authority from which MSAL will acquire tokens
-         *
+         * <p>
          * Valid B2C authorities should look like: https://&lt;something.b2clogin.com/&lt;tenant&gt;/&lt;policy&gt;
-         *
+         * <p>
          * MSAL Java also supports a legacy B2C authority format, which looks like: https://&lt;host&gt;/tfp/&lt;tenant&gt;/&lt;policy&gt;
-         *
+         * <p>
          * However, MSAL Java will eventually stop supporting the legacy format. See here for information on how to migrate to the new format: https://aka.ms/msal4j-b2c
          *
          * @param val a boolean value for validateAuthority
@@ -393,10 +404,10 @@ public abstract class AbstractClientApplicationBase extends AbstractApplicationB
          * Indicates that the library should attempt to discover the Azure region the application is running in when
          * fetching the instance discovery metadata. Regions can only be detected when running in an Azure environment,
          * such as an Azure VM or other service, or if the environment has environment variable named REGION_NAME configured.
-         *
+         * <p>
          * Although you can enable both autodetection here and a specific region with {@link AbstractClientApplicationBase#azureRegion} at the same time,
          * the region set with {@link AbstractClientApplicationBase#azureRegion} will take priority if there is a mismatch.
-         *
+         * <p>
          * See here for more information about supported scenarios: https://aka.ms/msal4j-azure-regions
          *
          * @param val boolean (default is false)
@@ -410,13 +421,13 @@ public abstract class AbstractClientApplicationBase extends AbstractApplicationB
         /**
          * Set the region that the library will use to format authorities in token requests. If given a valid Azure region,
          * the library will attempt to make token requests at a regional ESTS-R endpoint rather than the global ESTS endpoint.
-         *
+         * <p>
          * Regions must be valid Azure regions and their short names should be used, such as 'westus' for the West US Azure region,
          * 'centralus' for the Central US Azure region, etc.
-         *
+         * <p>
          * Although you can set a specific region here and enable autodetection with {@link AbstractClientApplicationBase#autoDetectRegion} at the same time
          * the specific region set here will take priority over the autodetected region if there is a mismatch.
-         *
+         * <p>
          * See here for more information about supported scenarios: https://aka.ms/msal4j-azure-regions
          *
          * @param val String region name
@@ -427,13 +438,15 @@ public abstract class AbstractClientApplicationBase extends AbstractApplicationB
             return self();
         }
 
-        /** Historically, MSAL would connect to a central endpoint located at
-            ``https://login.microsoftonline.com`` to acquire some metadata, especially when using an unfamiliar authority.
-        This behavior is known as Instance Discovery.
-        This parameter defaults to true, which enables the Instance Discovery.
-        If you do not know some authorities beforehand,
-        yet still want MSAL to accept any authority that you will provide,
-        you can use a ``False`` to unconditionally disable Instance Discovery. */
+        /**
+         * Historically, MSAL would connect to a central endpoint located at
+         * ``https://login.microsoftonline.com`` to acquire some metadata, especially when using an unfamiliar authority.
+         * This behavior is known as Instance Discovery.
+         * This parameter defaults to true, which enables the Instance Discovery.
+         * If you do not know some authorities beforehand,
+         * yet still want MSAL to accept any authority that you will provide,
+         * you can use a ``False`` to unconditionally disable Instance Discovery.
+         */
         public T instanceDiscovery(boolean val) {
             isInstanceDiscoveryEnabled = val;
             return self();

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractManagedIdentitySource.java
@@ -3,8 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,16 +22,10 @@ abstract class AbstractManagedIdentitySource {
     ManagedIdentityIdType idType;
     String userAssignedId;
 
-    @Getter
-    @Setter
     private boolean isUserAssignedManagedIdentity;
 
-    @Getter
-    @Setter
     private String managedIdentityUserAssignedClientId;
 
-    @Getter
-    @Setter
     private String managedIdentityUserAssignedResourceId;
 
     public AbstractManagedIdentitySource(MsalRequest msalRequest, ServiceBundle serviceBundle,
@@ -132,5 +124,29 @@ abstract class AbstractManagedIdentitySource {
     protected static IEnvironmentVariables getEnvironmentVariables() {
         return ManagedIdentityApplication.environmentVariables == null ?
                 new EnvironmentVariables() : ManagedIdentityApplication.environmentVariables;
+    }
+
+    public boolean isUserAssignedManagedIdentity() {
+        return this.isUserAssignedManagedIdentity;
+    }
+
+    public String getManagedIdentityUserAssignedClientId() {
+        return this.managedIdentityUserAssignedClientId;
+    }
+
+    public String getManagedIdentityUserAssignedResourceId() {
+        return this.managedIdentityUserAssignedResourceId;
+    }
+
+    public void setUserAssignedManagedIdentity(boolean isUserAssignedManagedIdentity) {
+        this.isUserAssignedManagedIdentity = isUserAssignedManagedIdentity;
+    }
+
+    public void setManagedIdentityUserAssignedClientId(String managedIdentityUserAssignedClientId) {
+        this.managedIdentityUserAssignedClientId = managedIdentityUserAssignedClientId;
+    }
+
+    public void setManagedIdentityUserAssignedResourceId(String managedIdentityUserAssignedResourceId) {
+        this.managedIdentityUserAssignedResourceId = managedIdentityUserAssignedResourceId;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AccessTokenCacheEntity.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AccessTokenCacheEntity.java
@@ -4,16 +4,10 @@
 package com.microsoft.aad.msal4j;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@Accessors(fluent = true)
-@Getter
-@Setter
 class AccessTokenCacheEntity extends Credential {
 
     @JsonProperty("credential_type")
@@ -48,5 +42,61 @@ class AccessTokenCacheEntity extends Credential {
         keyParts.add(target);
 
         return String.join(Constants.CACHE_KEY_SEPARATOR, keyParts).toLowerCase();
+    }
+
+    String credentialType() {
+        return this.credentialType;
+    }
+
+    String realm() {
+        return this.realm;
+    }
+
+    String target() {
+        return this.target;
+    }
+
+    String cachedAt() {
+        return this.cachedAt;
+    }
+
+    String expiresOn() {
+        return this.expiresOn;
+    }
+
+    String extExpiresOn() {
+        return this.extExpiresOn;
+    }
+
+    String refreshOn() {
+        return this.refreshOn;
+    }
+
+    void credentialType(String credentialType) {
+        this.credentialType = credentialType;
+    }
+
+    void realm(String realm) {
+        this.realm = realm;
+    }
+
+    void target(String target) {
+        this.target = target;
+    }
+
+    void cachedAt(String cachedAt) {
+        this.cachedAt = cachedAt;
+    }
+
+    void expiresOn(String expiresOn) {
+        this.expiresOn = expiresOn;
+    }
+
+    void extExpiresOn(String extExpiresOn) {
+        this.extExpiresOn = extExpiresOn;
+    }
+
+    void refreshOn(String refreshOn) {
+        this.refreshOn = refreshOn;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
@@ -3,15 +3,15 @@
 
 package com.microsoft.aad.msal4j;
 
-
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URL;
 import java.util.Date;
 
-@Slf4j
 class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
 
+    private static final Logger log = LoggerFactory.getLogger(AcquireTokenSilentSupplier.class);
     private SilentRequest silentRequest;
     protected static final int ACCESS_TOKEN_EXPIRE_BUFFER_IN_SEC = 5 * 60;
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AppMetadataCacheEntity.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AppMetadataCacheEntity.java
@@ -4,16 +4,9 @@
 package com.microsoft.aad.msal4j;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-
 import java.util.ArrayList;
 import java.util.List;
 
-@Accessors(fluent = true)
-@Getter
-@Setter
 class AppMetadataCacheEntity {
 
     public static final String APP_METADATA_CACHE_ENTITY_ID = "appmetadata";
@@ -35,5 +28,29 @@ class AppMetadataCacheEntity {
         keyParts.add(clientId);
 
         return String.join(Constants.CACHE_KEY_SEPARATOR, keyParts).toLowerCase();
+    }
+
+    String clientId() {
+        return this.clientId;
+    }
+
+    String environment() {
+        return this.environment;
+    }
+
+    String familyId() {
+        return this.familyId;
+    }
+
+    void clientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    void environment(String environment) {
+        this.environment = environment;
+    }
+
+    void familyId(String familyId) {
+        this.familyId = familyId;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultMetadata.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationResultMetadata.java
@@ -3,21 +3,11 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-
 import java.io.Serializable;
 
 /**
  * Contains metadata and additional context for the contents of an AuthenticationResult
  */
-@Accessors(fluent = true)
-@Getter
-@Setter(AccessLevel.PACKAGE)
-@Builder
 public class AuthenticationResultMetadata implements Serializable {
 
     /**
@@ -33,6 +23,71 @@ public class AuthenticationResultMetadata implements Serializable {
     /**
      * Specifies the reason for refreshing the access token, see {@link CacheRefreshReason} for possible values. Will be {@link CacheRefreshReason#NOT_APPLICABLE} if the token was returned from the cache or if the API used to fetch the token does not attempt to read the cache.
      */
-    @Builder.Default
     private CacheRefreshReason cacheRefreshReason = CacheRefreshReason.NOT_APPLICABLE;
+
+    AuthenticationResultMetadata(TokenSource tokenSource, Long refreshOn, CacheRefreshReason cacheRefreshReason) {
+        this.tokenSource = tokenSource;
+        this.refreshOn = refreshOn;
+        this.cacheRefreshReason = cacheRefreshReason == null ? CacheRefreshReason.NOT_APPLICABLE : cacheRefreshReason;
+    }
+
+    public static AuthenticationResultMetadataBuilder builder() {
+        return new AuthenticationResultMetadataBuilder();
+    }
+
+    public TokenSource tokenSource() {
+        return this.tokenSource;
+    }
+
+    public Long refreshOn() {
+        return this.refreshOn;
+    }
+
+    public CacheRefreshReason cacheRefreshReason() {
+        return this.cacheRefreshReason;
+    }
+
+    void tokenSource(TokenSource tokenSource) {
+        this.tokenSource = tokenSource;
+    }
+
+    void refreshOn(Long refreshOn) {
+        this.refreshOn = refreshOn;
+    }
+
+    void cacheRefreshReason(CacheRefreshReason cacheRefreshReason) {
+        this.cacheRefreshReason = cacheRefreshReason;
+    }
+
+    public static class AuthenticationResultMetadataBuilder {
+        private TokenSource tokenSource;
+        private Long refreshOn;
+        private CacheRefreshReason cacheRefreshReason;
+
+        AuthenticationResultMetadataBuilder() {
+        }
+
+        public AuthenticationResultMetadataBuilder tokenSource(TokenSource tokenSource) {
+            this.tokenSource = tokenSource;
+            return this;
+        }
+
+        public AuthenticationResultMetadataBuilder refreshOn(Long refreshOn) {
+            this.refreshOn = refreshOn;
+            return this;
+        }
+
+        public AuthenticationResultMetadataBuilder cacheRefreshReason(CacheRefreshReason cacheRefreshReason) {
+            this.cacheRefreshReason = cacheRefreshReason;
+            return this;
+        }
+
+        public AuthenticationResultMetadata build() {
+            return new AuthenticationResultMetadata(this.tokenSource, this.refreshOn, cacheRefreshReason);
+        }
+
+        public String toString() {
+            return "AuthenticationResultMetadata.AuthenticationResultMetadataBuilder(tokenSource=" + this.tokenSource + ", refreshOn=" + this.refreshOn + ", cacheRefreshReason$value=" + this.cacheRefreshReason + ")";
+        }
+    }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Authority.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Authority.java
@@ -3,18 +3,12 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 
 /**
  * Represents Authentication Authority responsible for issuing access tokens.
  */
-@Accessors(fluent = true)
-@Getter(AccessLevel.PACKAGE)
 abstract class Authority {
 
     private static final String ADFS_PATH_SEGMENT = "adfs";
@@ -176,5 +170,41 @@ abstract class Authority {
             authority += "/";
         }
         return authority;
+    }
+
+    String authority() {
+        return this.authority;
+    }
+
+    URL canonicalAuthorityUrl() {
+        return this.canonicalAuthorityUrl;
+    }
+
+    AuthorityType authorityType() {
+        return this.authorityType;
+    }
+
+    String selfSignedJwtAudience() {
+        return this.selfSignedJwtAudience;
+    }
+
+    String host() {
+        return this.host;
+    }
+
+    String tenant() {
+        return this.tenant;
+    }
+
+    boolean isTenantless() {
+        return this.isTenantless;
+    }
+
+    String authorizationEndpoint() {
+        return this.authorizationEndpoint;
+    }
+
+    String tokenEndpoint() {
+        return this.tokenEndpoint;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
@@ -4,9 +4,6 @@
 package com.microsoft.aad.msal4j;
 
 import com.nimbusds.oauth2.sdk.util.URLUtils;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.experimental.Accessors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,16 +11,14 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
 
+import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
+
 /**
  * Parameters for {@link AbstractClientApplicationBase#getAuthorizationRequestUrl(AuthorizationRequestUrlParameters)}
  */
-@Accessors(fluent = true)
-@Getter
 public class AuthorizationRequestUrlParameters {
 
-    @NonNull
     private String redirectUri;
-    @NonNull
     private Set<String> scopes;
     private String codeChallenge;
     private String codeChallengeMethod;
@@ -194,6 +189,66 @@ public class AuthorizationRequestUrlParameters {
         return authorizationRequestUrl;
     }
 
+    public String redirectUri() {
+        return this.redirectUri;
+    }
+
+    public Set<String> scopes() {
+        return this.scopes;
+    }
+
+    public String codeChallenge() {
+        return this.codeChallenge;
+    }
+
+    public String codeChallengeMethod() {
+        return this.codeChallengeMethod;
+    }
+
+    public String state() {
+        return this.state;
+    }
+
+    public String nonce() {
+        return this.nonce;
+    }
+
+    public ResponseMode responseMode() {
+        return this.responseMode;
+    }
+
+    public String loginHint() {
+        return this.loginHint;
+    }
+
+    public String domainHint() {
+        return this.domainHint;
+    }
+
+    public Prompt prompt() {
+        return this.prompt;
+    }
+
+    public String correlationId() {
+        return this.correlationId;
+    }
+
+    public boolean instanceAware() {
+        return this.instanceAware;
+    }
+
+    public Map<String, String> extraQueryParameters() {
+        return this.extraQueryParameters;
+    }
+
+    public Map<String, List<String>> requestParameters() {
+        return this.requestParameters;
+    }
+
+    public Logger log() {
+        return this.log;
+    }
+
     public static class Builder {
 
         private String redirectUri;
@@ -227,6 +282,8 @@ public class AuthorizationRequestUrlParameters {
          * must exactly match one of the redirect URIs registered in the Azure portal.
          */
         public Builder redirectUri(String val) {
+            validateNotNull("redirectUri", val);
+
             this.redirectUri = val;
             return self();
         }
@@ -235,6 +292,8 @@ public class AuthorizationRequestUrlParameters {
          * Scopes which the application is requesting access to and the user will consent to.
          */
         public Builder scopes(Set<String> val) {
+            validateNotNull("scopes", val);
+
             this.scopes = val;
             return self();
         }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
@@ -6,8 +6,6 @@ package com.microsoft.aad.msal4j;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,8 +16,6 @@ import java.io.OutputStream;
 import java.util.concurrent.BlockingQueue;
 import java.util.stream.Collectors;
 
-@Getter
-@Accessors(fluent = true)
 class AuthorizationResponseHandler implements HttpHandler {
 
     private final static Logger LOG = LoggerFactory.getLogger(AuthorizationResponseHandler.class);
@@ -120,5 +116,13 @@ class AuthorizationResponseHandler implements HttpHandler {
             return DEFAULT_FAILURE_MESSAGE;
         }
         return systemBrowserOptions().htmlMessageError();
+    }
+
+    BlockingQueue<AuthorizationResult> authorizationResultQueue() {
+        return this.authorizationResultQueue;
+    }
+
+    SystemBrowserOptions systemBrowserOptions() {
+        return this.systemBrowserOptions;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationResult.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationResult.java
@@ -3,17 +3,10 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-
 import java.net.URLDecoder;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@Getter
-@Setter
-@Accessors(fluent = true)
 class AuthorizationResult {
 
     private String code;
@@ -22,6 +15,54 @@ class AuthorizationResult {
     private String error;
     private String errorDescription;
     private String environment;
+
+    String code() {
+        return this.code;
+    }
+
+    String state() {
+        return this.state;
+    }
+
+    AuthorizationStatus status() {
+        return this.status;
+    }
+
+    String error() {
+        return this.error;
+    }
+
+    String errorDescription() {
+        return this.errorDescription;
+    }
+
+    String environment() {
+        return this.environment;
+    }
+
+    void code(String code) {
+        this.code = code;
+    }
+
+    void state(String state) {
+        this.state = state;
+    }
+
+    void status(AuthorizationStatus status) {
+        this.status = status;
+    }
+
+    void error(String error) {
+        this.error = error;
+    }
+
+    void errorDescription(String errorDescription) {
+        this.errorDescription = errorDescription;
+    }
+
+    void environment(String environment) {
+        this.environment = environment;
+    }
 
     enum AuthorizationStatus {
         Success,

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/B2CAuthority.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/B2CAuthority.java
@@ -3,14 +3,8 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
 import java.net.URL;
 
-@Accessors(fluent = true)
-@Getter(AccessLevel.PACKAGE)
 class B2CAuthority extends Authority {
 
     private final static String AUTHORIZATION_ENDPOINT = "/oauth2/v2.0/authorize";
@@ -66,5 +60,9 @@ class B2CAuthority extends Authority {
         this.authorizationEndpoint = String.format(B2C_AUTHORIZATION_ENDPOINT_FORMAT, host, tenant, policy);
         this.tokenEndpoint = String.format(B2C_TOKEN_ENDPOINT_FORMAT, host, tenant, policy);
         this.selfSignedJwtAudience = this.tokenEndpoint;
+    }
+
+    String policy() {
+        return this.policy;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClaimsRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClaimsRequest.java
@@ -9,12 +9,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import lombok.Getter;
-import lombok.Setter;
 
-import java.util.Iterator;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -24,10 +22,7 @@ import java.util.List;
  */
 public class ClaimsRequest {
 
-    @Getter
-    @Setter
     List<RequestedClaim> idTokenRequestedClaims = new ArrayList<>();
-
     List<RequestedClaim> userInfoRequestedClaims = new ArrayList<>();
     List<RequestedClaim> accessTokenRequestedClaims = new ArrayList<>();
 
@@ -146,5 +141,13 @@ public class ClaimsRequest {
                 if (group.equals("access_token")) cr.requestClaimInAccessToken(claim, claimInfo);
             }
         }
+    }
+
+    public List<RequestedClaim> getIdTokenRequestedClaims() {
+        return this.idTokenRequestedClaims;
+    }
+
+    public void setIdTokenRequestedClaims(List<RequestedClaim> idTokenRequestedClaims) {
+        this.idTokenRequestedClaims = idTokenRequestedClaims;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
@@ -3,34 +3,19 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.PrivateKey;
-import java.security.UnrecoverableKeyException;
+import java.security.*;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Enumeration;
-import java.util.List;
+import java.util.*;
 
 final class ClientCertificate implements IClientCertificate {
 
     public static final String DEFAULT_PKCS12_PASSWORD = "";
 
-    @Accessors(fluent = true)
-    @Getter
     private final PrivateKey privateKey;
 
     private final List<X509Certificate> publicKeyCertificateChain;
@@ -134,5 +119,9 @@ final class ClientCertificate implements IClientCertificate {
         final MessageDigest md = MessageDigest.getInstance("SHA-256");
         md.update(inputBytes);
         return md.digest();
+    }
+
+    public PrivateKey privateKey() {
+        return this.privateKey;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientInfo.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientInfo.java
@@ -5,14 +5,11 @@ package com.microsoft.aad.msal4j;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.nimbusds.jose.util.StandardCharset;
-import lombok.AccessLevel;
-import lombok.Getter;
 
 import java.util.Base64;
 
 import static com.microsoft.aad.msal4j.Constants.POINT_DELIMITER;
 
-@Getter(AccessLevel.PACKAGE)
 class ClientInfo {
 
     @JsonProperty("uid")
@@ -33,5 +30,13 @@ class ClientInfo {
 
     String toAccountIdentifier() {
         return uniqueIdentifier + POINT_DELIMITER + uniqueTenantIdentifier;
+    }
+
+    String getUniqueIdentifier() {
+        return this.uniqueIdentifier;
+    }
+
+    String getUniqueTenantIdentifier() {
+        return this.uniqueTenantIdentifier;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ConfidentialClientApplication.java
@@ -6,15 +6,9 @@ package com.microsoft.aad.msal4j;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.auth.*;
 import com.nimbusds.oauth2.sdk.id.ClientID;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -39,8 +33,6 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
      useful to applications in general because the token provider must implement all authentication logic. */
     public Function<AppTokenProviderParameters, CompletableFuture<TokenProviderResult>> appTokenProvider;
 
-    @Accessors(fluent = true)
-    @Getter
     private boolean sendX5c;
 
     @Override
@@ -168,6 +160,10 @@ public class ConfidentialClientApplication extends AbstractClientApplicationBase
     public static Builder builder(String clientId, IClientCredential clientCredential) {
 
         return new Builder(clientId, clientCredential);
+    }
+
+    public boolean sendX5c() {
+        return this.sendX5c;
     }
 
     public static class Builder extends AbstractClientApplicationBase.Builder<Builder> {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Credential.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Credential.java
@@ -4,13 +4,7 @@
 package com.microsoft.aad.msal4j;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 
-@Accessors(fluent = true)
-@Getter
-@Setter
 class Credential {
 
     @JsonProperty("home_account_id")
@@ -27,4 +21,44 @@ class Credential {
 
     @JsonProperty("user_assertion_hash")
     protected String userAssertionHash;
+
+    String homeAccountId() {
+        return this.homeAccountId;
+    }
+
+    String environment() {
+        return this.environment;
+    }
+
+    String clientId() {
+        return this.clientId;
+    }
+
+    String secret() {
+        return this.secret;
+    }
+
+    String userAssertionHash() {
+        return this.userAssertionHash;
+    }
+
+    void homeAccountId(String homeAccountId) {
+        this.homeAccountId = homeAccountId;
+    }
+
+    void environment(String environment) {
+        this.environment = environment;
+    }
+
+    void clientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    void secret(String secret) {
+        this.secret = secret;
+    }
+
+    void userAssertionHash(String userAssertionHash) {
+        this.userAssertionHash = userAssertionHash;
+    }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CredentialTypeEnum.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CredentialTypeEnum.java
@@ -3,14 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
-@Accessors(fluent = true)
-@Getter
-@AllArgsConstructor
 enum CredentialTypeEnum {
 
     ACCESS_TOKEN("AccessToken"),
@@ -18,4 +10,12 @@ enum CredentialTypeEnum {
     ID_TOKEN("IdToken");
 
     private final String value;
+
+    CredentialTypeEnum(String value) {
+        this.value = value;
+    }
+
+    String value() {
+        return this.value;
+    }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CurrentRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CurrentRequest.java
@@ -3,29 +3,51 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-
-@Getter
-@Accessors(fluent = true)
 class CurrentRequest {
 
     private final PublicApi publicApi;
-
-    @Setter
     private CacheRefreshReason cacheInfo = CacheRefreshReason.NOT_APPLICABLE;
-
-    @Setter
     private String regionUsed = StringHelper.EMPTY_STRING;
-
-    @Setter
     private int regionSource = 0;
-
-    @Setter
     private int regionOutcome = 0;
 
     CurrentRequest(PublicApi publicApi) {
         this.publicApi = publicApi;
+    }
+
+    PublicApi publicApi() {
+        return this.publicApi;
+    }
+
+    CacheRefreshReason cacheInfo() {
+        return this.cacheInfo;
+    }
+
+    String regionUsed() {
+        return this.regionUsed;
+    }
+
+    int regionSource() {
+        return this.regionSource;
+    }
+
+    int regionOutcome() {
+        return this.regionOutcome;
+    }
+
+    void cacheInfo(CacheRefreshReason cacheInfo) {
+        this.cacheInfo = cacheInfo;
+    }
+
+    void regionUsed(String regionUsed) {
+        this.regionUsed = regionUsed;
+    }
+
+    void regionSource(int regionSource) {
+        this.regionSource = regionSource;
+    }
+
+    void regionOutcome(int regionOutcome) {
+        this.regionOutcome = regionOutcome;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCode.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCode.java
@@ -4,64 +4,101 @@
 package com.microsoft.aad.msal4j;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 
 /**
  * Response returned from the STS device code endpoint containing information necessary for
  * device code flow
  */
-@Accessors(fluent = true)
-@Getter
 public final class DeviceCode {
+
+    @JsonProperty("user_code")
+    private String userCode;
+
+    @JsonProperty("device_code")
+    private String deviceCode;
+
+    @JsonProperty("verification_uri")
+    private String verificationUri;
+
+    @JsonProperty("expires_in")
+    private long expiresIn;
+
+    @JsonProperty("interval")
+    private long interval;
+
+    @JsonProperty("message")
+    private String message;
+
+    private transient String correlationId = null;
+    private transient String clientId = null;
+    private transient String scopes = null;
 
     /**
      * code which user needs to provide when authenticating at the verification URI
      */
-    @JsonProperty("user_code")
-    private String userCode;
+    public String userCode() {
+        return this.userCode;
+    }
 
     /**
      * code which should be included in the request for the access token
      */
-    @JsonProperty("device_code")
-    private String deviceCode;
+    public String deviceCode() {
+        return this.deviceCode;
+    }
 
     /**
      * URI where user can authenticate
      */
-    @JsonProperty("verification_uri")
-    private String verificationUri;
+    public String verificationUri() {
+        return this.verificationUri;
+    }
 
     /**
      * expiration time of device code in seconds.
      */
-    @JsonProperty("expires_in")
-    private long expiresIn;
+    public long expiresIn() {
+        return this.expiresIn;
+    }
 
     /**
      * interval at which the STS should be polled at
      */
-    @JsonProperty("interval")
-    private long interval;
+    public long interval() {
+        return this.interval;
+    }
 
     /**
      * message which should be displayed to the user.
      */
-    @JsonProperty("message")
-    private String message;
+    public String message() {
+        return this.message;
+    }
 
-    @Getter(AccessLevel.PROTECTED)
-    @Setter(AccessLevel.PROTECTED)
-    private transient String correlationId = null;
+    protected String correlationId() {
+        return this.correlationId;
+    }
 
-    @Getter(AccessLevel.PROTECTED)
-    @Setter(AccessLevel.PROTECTED)
-    private transient String clientId = null;
+    protected String clientId() {
+        return this.clientId;
+    }
 
-    @Getter(AccessLevel.PROTECTED)
-    @Setter(AccessLevel.PROTECTED)
-    private transient String scopes = null;
+    protected String scopes() {
+        return this.scopes;
+    }
+
+    protected DeviceCode correlationId(String correlationId) {
+        this.correlationId = correlationId;
+        return this;
+    }
+
+    protected DeviceCode clientId(String clientId) {
+        this.clientId = clientId;
+        return this;
+    }
+
+    protected DeviceCode scopes(String scopes) {
+        this.scopes = scopes;
+        return this;
+    }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowParameters.java
@@ -3,9 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.*;
-import lombok.experimental.Accessors;
-
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -17,47 +14,23 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
  * {@link PublicClientApplication#acquireToken(DeviceCodeFlowParameters)}. For more details,
  * see https://aka.ms/msal4j-device-code
  */
-@Builder
-@Accessors(fluent = true)
-@Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class DeviceCodeFlowParameters implements IAcquireTokenParameters {
 
-    /**
-     * Scopes to which the application is requesting access to.
-     */
-    @NonNull
     private Set<String> scopes;
-
-    /**
-     * Receives the device code returned from the first step of Oauth2.0 device code flow. The
-     * {@link DeviceCode#verificationUri} and the {@link DeviceCode#userCode} should be shown
-     * to the end user.
-     * <p>
-     * For more details, see https://aka.ms/msal4j-device-code
-     */
-    @NonNull
     private Consumer<DeviceCode> deviceCodeConsumer;
-
-    /**
-     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
-     */
     private ClaimsRequest claims;
-
-    /**
-     * Adds additional headers to the token request
-     */
     private Map<String, String> extraHttpHeaders;
-
-    /**
-     * Adds additional query parameters to the token request
-     */
     private Map<String, String> extraQueryParameters;
-
-    /**
-     * Overrides the tenant value in the authority URL for this request
-     */
     private String tenant;
+
+    private DeviceCodeFlowParameters(Set<String> scopes, Consumer<DeviceCode> deviceCodeConsumer, ClaimsRequest claims, Map<String, String> extraHttpHeaders, Map<String, String> extraQueryParameters, String tenant) {
+        this.scopes = scopes;
+        this.deviceCodeConsumer = deviceCodeConsumer;
+        this.claims = claims;
+        this.extraHttpHeaders = extraHttpHeaders;
+        this.extraQueryParameters = extraQueryParameters;
+        this.tenant = tenant;
+    }
 
     private static DeviceCodeFlowParametersBuilder builder() {
 
@@ -79,5 +52,109 @@ public class DeviceCodeFlowParameters implements IAcquireTokenParameters {
         return builder()
                 .scopes(scopes)
                 .deviceCodeConsumer(deviceCodeConsumer);
+    }
+
+    public Set<String> scopes() {
+        return this.scopes;
+    }
+
+    public Consumer<DeviceCode> deviceCodeConsumer() {
+        return this.deviceCodeConsumer;
+    }
+
+    public ClaimsRequest claims() {
+        return this.claims;
+    }
+
+    public Map<String, String> extraHttpHeaders() {
+        return this.extraHttpHeaders;
+    }
+
+    public Map<String, String> extraQueryParameters() {
+        return this.extraQueryParameters;
+    }
+
+    public String tenant() {
+        return this.tenant;
+    }
+
+    public static class DeviceCodeFlowParametersBuilder {
+        private Set<String> scopes;
+        private Consumer<DeviceCode> deviceCodeConsumer;
+        private ClaimsRequest claims;
+        private Map<String, String> extraHttpHeaders;
+        private Map<String, String> extraQueryParameters;
+        private String tenant;
+
+        DeviceCodeFlowParametersBuilder() {
+        }
+
+        /**
+         * Scopes to which the application is requesting access to.
+         * <p>
+         * Cannot be null.
+         */
+        public DeviceCodeFlowParametersBuilder scopes(Set<String> scopes) {
+            validateNotNull("scopes", scopes);
+
+            this.scopes = scopes;
+            return this;
+        }
+
+        /**
+         * Receives the device code returned from the first step of Oauth2.0 device code flow. The
+         * {@link DeviceCode#verificationUri} and the {@link DeviceCode#userCode} should be shown
+         * to the end user.
+         * <p>
+         * For more details, see https://aka.ms/msal4j-device-code
+         * <p>
+         * Cannot be null.
+         */
+        public DeviceCodeFlowParametersBuilder deviceCodeConsumer(Consumer<DeviceCode> deviceCodeConsumer) {
+            validateNotNull("deviceCodeConsumer", scopes);
+
+            this.deviceCodeConsumer = deviceCodeConsumer;
+            return this;
+        }
+
+        /**
+         * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
+         */
+        public DeviceCodeFlowParametersBuilder claims(ClaimsRequest claims) {
+            this.claims = claims;
+            return this;
+        }
+
+        /**
+         * Adds additional headers to the token request
+         */
+        public DeviceCodeFlowParametersBuilder extraHttpHeaders(Map<String, String> extraHttpHeaders) {
+            this.extraHttpHeaders = extraHttpHeaders;
+            return this;
+        }
+
+        /**
+         * Adds additional query parameters to the token request
+         */
+        public DeviceCodeFlowParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
+            this.extraQueryParameters = extraQueryParameters;
+            return this;
+        }
+
+        /**
+         * Overrides the tenant value in the authority URL for this request
+         */
+        public DeviceCodeFlowParametersBuilder tenant(String tenant) {
+            this.tenant = tenant;
+            return this;
+        }
+
+        public DeviceCodeFlowParameters build() {
+            return new DeviceCodeFlowParameters(this.scopes, this.deviceCodeConsumer, this.claims, this.extraHttpHeaders, this.extraQueryParameters, this.tenant);
+        }
+
+        public String toString() {
+            return "DeviceCodeFlowParameters.DeviceCodeFlowParametersBuilder(scopes=" + this.scopes + ", deviceCodeConsumer=" + this.deviceCodeConsumer + ", claims=" + this.claims + ", extraHttpHeaders=" + this.extraHttpHeaders + ", extraQueryParameters=" + this.extraQueryParameters + ", tenant=" + this.tenant + ")";
+        }
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowRequest.java
@@ -4,9 +4,6 @@
 package com.microsoft.aad.msal4j;
 
 import com.nimbusds.oauth2.sdk.util.URLUtils;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -15,8 +12,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
-@Accessors(fluent = true)
-@Getter(AccessLevel.PACKAGE)
 class DeviceCodeFlowRequest extends MsalRequest {
 
     private AtomicReference<CompletableFuture<IAuthenticationResult>> futureReference;
@@ -98,5 +93,17 @@ class DeviceCodeFlowRequest extends MsalRequest {
         result.scopes(scopesStr);
 
         return result;
+    }
+
+    AtomicReference<CompletableFuture<IAuthenticationResult>> futureReference() {
+        return this.futureReference;
+    }
+
+    DeviceCodeFlowParameters parameters() {
+        return this.parameters;
+    }
+
+    String scopesStr() {
+        return this.scopesStr;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ErrorResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ErrorResponse.java
@@ -4,13 +4,7 @@
 package com.microsoft.aad.msal4j;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 
-@Accessors(fluent = true)
-@Getter
-@Setter
 class ErrorResponse {
 
     private Integer statusCode;
@@ -39,4 +33,84 @@ class ErrorResponse {
 
     @JsonProperty("claims")
     private String claims;
+
+    Integer statusCode() {
+        return this.statusCode;
+    }
+
+    String statusMessage() {
+        return this.statusMessage;
+    }
+
+    String error() {
+        return this.error;
+    }
+
+    String errorDescription() {
+        return this.errorDescription;
+    }
+
+    long[] errorCodes() {
+        return this.errorCodes;
+    }
+
+    String subError() {
+        return this.subError;
+    }
+
+    String traceId() {
+        return this.traceId;
+    }
+
+    String timestamp() {
+        return this.timestamp;
+    }
+
+    String correlation_id() {
+        return this.correlation_id;
+    }
+
+    String claims() {
+        return this.claims;
+    }
+
+    void statusCode(Integer statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    void statusMessage(String statusMessage) {
+        this.statusMessage = statusMessage;
+    }
+
+    void error(String error) {
+        this.error = error;
+    }
+
+    void errorDescription(String errorDescription) {
+        this.errorDescription = errorDescription;
+    }
+
+    void errorCodes(long[] errorCodes) {
+        this.errorCodes = errorCodes;
+    }
+
+    void subError(String subError) {
+        this.subError = subError;
+    }
+
+    void traceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+    void timestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    void correlation_id(String correlation_id) {
+        this.correlation_id = correlation_id;
+    }
+
+    void claims(String claims) {
+        this.claims = claims;
+    }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpListener.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpListener.java
@@ -5,23 +5,18 @@ package com.microsoft.aad.msal4j;
 
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
-@Accessors(fluent = true)
 class HttpListener {
 
     private final static Logger LOG = LoggerFactory.getLogger(HttpListener.class);
 
     private HttpServer server;
 
-    @Getter(AccessLevel.PACKAGE)
     private int port;
 
     void startListener(int port, HttpHandler httpHandler) {
@@ -46,5 +41,9 @@ class HttpListener {
             LOG.debug("Http listener stopped");
 
         }
+    }
+
+    int port() {
+        return this.port;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpResponse.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -15,14 +11,11 @@ import java.util.Map;
 /**
  * HTTP response
  */
-@Accessors(fluent = true)
-@Getter
 public class HttpResponse implements IHttpResponse {
 
     /**
      * HTTP response status code
      */
-    @Setter
     private int statusCode;
 
     /**
@@ -33,7 +26,6 @@ public class HttpResponse implements IHttpResponse {
     /**
      * HTTP response body
      */
-    @Setter
     private String body;
 
     /**
@@ -60,5 +52,27 @@ public class HttpResponse implements IHttpResponse {
         } else {
             headers.remove(name);
         }
+    }
+
+    public int statusCode() {
+        return this.statusCode;
+    }
+
+    public Map<String, List<String>> headers() {
+        return this.headers;
+    }
+
+    public String body() {
+        return this.body;
+    }
+
+    public HttpResponse statusCode(int statusCode) {
+        this.statusCode = statusCode;
+        return this;
+    }
+
+    public HttpResponse body(String body) {
+        this.body = body;
+        return this;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IdTokenCacheEntity.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IdTokenCacheEntity.java
@@ -4,16 +4,10 @@
 package com.microsoft.aad.msal4j;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@Accessors(fluent = true)
-@Getter
-@Setter
 class IdTokenCacheEntity extends Credential {
 
     @JsonProperty("credential_type")
@@ -35,5 +29,21 @@ class IdTokenCacheEntity extends Credential {
         keyParts.add("");
 
         return String.join(Constants.CACHE_KEY_SEPARATOR, keyParts).toLowerCase();
+    }
+
+    String credentialType() {
+        return this.credentialType;
+    }
+
+    String realm() {
+        return this.realm;
+    }
+
+    void credentialType(String credentialType) {
+        this.credentialType = credentialType;
+    }
+
+    void realm(String realm) {
+        this.realm = realm;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/InstanceDiscoveryMetadataEntry.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/InstanceDiscoveryMetadataEntry.java
@@ -7,22 +7,25 @@ import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
-import lombok.*;
-import lombok.experimental.Accessors;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.Set;
 
-@Accessors(fluent = true)
-@Getter(AccessLevel.PACKAGE)
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 class InstanceDiscoveryMetadataEntry implements JsonSerializable<InstanceDiscoveryMetadataEntry> {
 
     String preferredNetwork;
     String preferredCache;
     Set<String> aliases;
+
+    public InstanceDiscoveryMetadataEntry(String preferredNetwork, String preferredCache, Set<String> aliases) {
+        this.preferredNetwork = preferredNetwork;
+        this.preferredCache = preferredCache;
+        this.aliases = aliases;
+    }
+
+    public InstanceDiscoveryMetadataEntry() {
+    }
 
     public static InstanceDiscoveryMetadataEntry fromJson(JsonReader jsonReader) throws IOException {
         InstanceDiscoveryMetadataEntry entry = new InstanceDiscoveryMetadataEntry();
@@ -56,5 +59,17 @@ class InstanceDiscoveryMetadataEntry implements JsonSerializable<InstanceDiscove
         jsonWriter.writeArrayField("aliases", aliases, JsonWriter::writeString);
         jsonWriter.writeEndObject();
         return jsonWriter;
+    }
+
+    String preferredNetwork() {
+        return this.preferredNetwork;
+    }
+
+    String preferredCache() {
+        return this.preferredCache;
+    }
+
+    Set<String> aliases() {
+        return this.aliases;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthenticationParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthenticationParameters.java
@@ -3,9 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.*;
-import lombok.experimental.Accessors;
-
 import java.util.Map;
 import java.util.Set;
 
@@ -18,43 +15,23 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
  * <p>
  * For more details, see https://aka.ms/msal4j-iwa
  */
-@Builder
-@Accessors(fluent = true)
-@Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class IntegratedWindowsAuthenticationParameters implements IAcquireTokenParameters {
 
-    /**
-     * Scopes that the application is requesting access to
-     */
-    @NonNull
     private Set<String> scopes;
-
-    /**
-     * Identifier of user account for which to acquire tokens for
-     */
-    @NonNull
     private String username;
-
-    /**
-     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
-     */
     private ClaimsRequest claims;
-
-    /**
-     * Adds additional headers to the token request
-     */
     private Map<String, String> extraHttpHeaders;
-
-    /**
-     * Adds additional parameters to the token request
-     */
     private Map<String, String> extraQueryParameters;
-
-    /**
-     * Overrides the tenant value in the authority URL for this request
-     */
     private String tenant;
+
+    private IntegratedWindowsAuthenticationParameters(Set<String> scopes, String username, ClaimsRequest claims, Map<String, String> extraHttpHeaders, Map<String, String> extraQueryParameters, String tenant) {
+        this.scopes = scopes;
+        this.username = username;
+        this.claims = claims;
+        this.extraHttpHeaders = extraHttpHeaders;
+        this.extraQueryParameters = extraQueryParameters;
+        this.tenant = tenant;
+    }
 
     private static IntegratedWindowsAuthenticationParametersBuilder builder() {
 
@@ -77,5 +54,101 @@ public class IntegratedWindowsAuthenticationParameters implements IAcquireTokenP
         return builder()
                 .scopes(scopes)
                 .username(username);
+    }
+
+    public Set<String> scopes() {
+        return this.scopes;
+    }
+
+    public String username() {
+        return this.username;
+    }
+
+    public ClaimsRequest claims() {
+        return this.claims;
+    }
+
+    public Map<String, String> extraHttpHeaders() {
+        return this.extraHttpHeaders;
+    }
+
+    public Map<String, String> extraQueryParameters() {
+        return this.extraQueryParameters;
+    }
+
+    public String tenant() {
+        return this.tenant;
+    }
+
+    public static class IntegratedWindowsAuthenticationParametersBuilder {
+        private Set<String> scopes;
+        private String username;
+        private ClaimsRequest claims;
+        private Map<String, String> extraHttpHeaders;
+        private Map<String, String> extraQueryParameters;
+        private String tenant;
+
+        IntegratedWindowsAuthenticationParametersBuilder() {
+        }
+
+        /**
+         * Scopes that the application is requesting access to
+         */
+        public IntegratedWindowsAuthenticationParametersBuilder scopes(Set<String> scopes) {
+            validateNotNull("scopes", scopes);
+
+            this.scopes = scopes;
+            return this;
+        }
+
+        /**
+         * Identifier of user account for which to acquire tokens for
+         */
+        public IntegratedWindowsAuthenticationParametersBuilder username(String username) {
+            validateNotNull("username", username);
+
+            this.username = username;
+            return this;
+        }
+
+        /**
+         * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
+         */
+        public IntegratedWindowsAuthenticationParametersBuilder claims(ClaimsRequest claims) {
+            this.claims = claims;
+            return this;
+        }
+
+        /**
+         * Adds additional headers to the token request
+         */
+        public IntegratedWindowsAuthenticationParametersBuilder extraHttpHeaders(Map<String, String> extraHttpHeaders) {
+            this.extraHttpHeaders = extraHttpHeaders;
+            return this;
+        }
+
+        /**
+         * Adds additional parameters to the token request
+         */
+        public IntegratedWindowsAuthenticationParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
+            this.extraQueryParameters = extraQueryParameters;
+            return this;
+        }
+
+        /**
+         * Overrides the tenant value in the authority URL for this request
+         */
+        public IntegratedWindowsAuthenticationParametersBuilder tenant(String tenant) {
+            this.tenant = tenant;
+            return this;
+        }
+
+        public IntegratedWindowsAuthenticationParameters build() {
+            return new IntegratedWindowsAuthenticationParameters(this.scopes, this.username, this.claims, this.extraHttpHeaders, this.extraQueryParameters, this.tenant);
+        }
+
+        public String toString() {
+            return "IntegratedWindowsAuthenticationParameters.IntegratedWindowsAuthenticationParametersBuilder(scopes=" + this.scopes + ", username=" + this.username + ", claims=" + this.claims + ", extraHttpHeaders=" + this.extraHttpHeaders + ", extraQueryParameters=" + this.extraQueryParameters + ", tenant=" + this.tenant + ")";
+        }
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/InteractiveRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/InteractiveRequest.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
@@ -17,19 +13,14 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
-@Accessors(fluent = true)
 class InteractiveRequest extends MsalRequest {
 
-    @Getter(AccessLevel.PACKAGE)
     private AtomicReference<CompletableFuture<IAuthenticationResult>> futureReference;
 
-    @Getter(AccessLevel.PACKAGE)
     private InteractiveRequestParameters interactiveRequestParameters;
 
-    @Getter(AccessLevel.PACKAGE)
     private String verifier;
 
-    @Getter(AccessLevel.PACKAGE)
     private String state;
 
     private PublicClientApplication publicClientApplication;
@@ -119,5 +110,21 @@ class InteractiveRequest extends MsalRequest {
         builder.codeChallenge(StringHelper.createBase64EncodedSha256Hash(verifier))
                 .codeChallengeMethod("S256")
                 .state(state);
+    }
+
+    AtomicReference<CompletableFuture<IAuthenticationResult>> futureReference() {
+        return this.futureReference;
+    }
+
+    InteractiveRequestParameters interactiveRequestParameters() {
+        return this.interactiveRequestParameters;
+    }
+
+    String verifier() {
+        return this.verifier;
+    }
+
+    String state() {
+        return this.state;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
@@ -3,8 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AccessLevel;
-import lombok.Getter;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
@@ -17,17 +15,13 @@ import java.util.concurrent.CompletableFuture;
  */
 public class ManagedIdentityApplication extends AbstractApplicationBase implements IManagedIdentityApplication {
 
-    @Getter
     private final ManagedIdentityId managedIdentityId;
-
-    @Getter
     static TokenCache sharedTokenCache = new TokenCache();
 
     //Deprecated the field in favor of the static getManagedIdentitySource method
     @Deprecated
     ManagedIdentitySourceType managedIdentitySource = ManagedIdentityClient.getManagedIdentitySource();
 
-    @Getter(value = AccessLevel.PACKAGE)
     static IEnvironmentVariables environmentVariables;
 
     static void setEnvironmentVariables(IEnvironmentVariables environmentVariables) {
@@ -51,6 +45,17 @@ public class ManagedIdentityApplication extends AbstractApplicationBase implemen
         this.tenant = Constants.MANAGED_IDENTITY_DEFAULT_TENTANT;
     }
 
+    public static TokenCache getSharedTokenCache() {
+        return ManagedIdentityApplication.sharedTokenCache;
+    }
+
+    static IEnvironmentVariables getEnvironmentVariables() {
+        return ManagedIdentityApplication.environmentVariables;
+    }
+
+    public ManagedIdentityId getManagedIdentityId() {
+        return this.managedIdentityId;
+    }
     @Override
     public CompletableFuture<IAuthenticationResult> acquireTokenForManagedIdentity(ManagedIdentityParameters managedIdentityParameters)
             throws Exception {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityErrorResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityErrorResponse.java
@@ -4,9 +4,7 @@
 package com.microsoft.aad.msal4j;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
 
-@Getter
 public class ManagedIdentityErrorResponse {
 
     @JsonProperty("message")
@@ -29,12 +27,35 @@ public class ManagedIdentityErrorResponse {
     @JsonProperty("error_description")
     private String errorDescription;
 
-    @Getter
+    public String getMessage() {
+        return this.message;
+    }
+
+    public String getCorrelationId() {
+        return this.correlationId;
+    }
+
+    public String getError() {
+        return this.error;
+    }
+
+    public String getErrorDescription() {
+        return this.errorDescription;
+    }
+
     private static class ErrorField {
         @JsonProperty("code")
         private String code;
 
         @JsonProperty("message")
         private String message;
+
+       String getCode() {
+            return this.code;
+        }
+
+        String getMessage() {
+            return this.message;
+        }
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityId.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityId.java
@@ -3,9 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.Getter;
-
-@Getter
 public class ManagedIdentityId {
 
     private String userAssignedId;
@@ -77,5 +74,13 @@ public class ManagedIdentityId {
         }
 
         return new ManagedIdentityId(ManagedIdentityIdType.OBJECT_ID, objectId);
+    }
+
+    public String getUserAssignedId() {
+        return this.userAssignedId;
+    }
+
+    public ManagedIdentityIdType getIdType() {
+        return this.idType;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityParameters.java
@@ -3,12 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
 import java.util.Map;
 import java.util.Set;
 
@@ -16,16 +10,15 @@ import java.util.Set;
  * Object containing parameters for managed identity flow. Can be used as parameter to
  * {@link ManagedIdentityApplication#acquireTokenForManagedIdentity(ManagedIdentityParameters)}
  */
-@Builder
-@Accessors(fluent = true)
-@Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ManagedIdentityParameters implements IAcquireTokenParameters {
 
-    @Getter
     String resource;
-    
     boolean forceRefresh;
+
+    private ManagedIdentityParameters(String resource, boolean forceRefresh) {
+        this.resource = resource;
+        this.forceRefresh = forceRefresh;
+    }
 
     @Override
     public Set<String> scopes() {
@@ -63,5 +56,39 @@ public class ManagedIdentityParameters implements IAcquireTokenParameters {
      */
     public static ManagedIdentityParametersBuilder builder(String resource) {
         return builder().resource(resource);
+    }
+
+    public boolean forceRefresh() {
+        return this.forceRefresh;
+    }
+
+    public String resource() {
+        return this.resource;
+    }
+
+    public static class ManagedIdentityParametersBuilder {
+        private String resource;
+        private boolean forceRefresh;
+
+        ManagedIdentityParametersBuilder() {
+        }
+
+        public ManagedIdentityParametersBuilder resource(String resource) {
+            this.resource = resource;
+            return this;
+        }
+
+        public ManagedIdentityParametersBuilder forceRefresh(boolean forceRefresh) {
+            this.forceRefresh = forceRefresh;
+            return this;
+        }
+
+        public ManagedIdentityParameters build() {
+            return new ManagedIdentityParameters(this.resource, this.forceRefresh);
+        }
+
+        public String toString() {
+            return "ManagedIdentityParameters.ManagedIdentityParametersBuilder(resource=" + this.resource + ", forceRefresh=" + this.forceRefresh + ")";
+        }
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityResponse.java
@@ -7,13 +7,11 @@ import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
-import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-@Getter
 class ManagedIdentityResponse implements JsonSerializable<ManagedIdentityResponse> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ManagedIdentityResponse.class);
@@ -65,5 +63,25 @@ class ManagedIdentityResponse implements JsonSerializable<ManagedIdentityRespons
         jsonWriter.writeStringField("client_id", clientId);
         jsonWriter.writeEndObject();
         return jsonWriter;
+    }
+
+    public String getTokenType() {
+        return this.tokenType;
+    }
+
+    public String getAccessToken() {
+        return this.accessToken;
+    }
+
+    public String getExpiresOn() {
+        return this.expiresOn;
+    }
+
+    public String getResource() {
+        return this.resource;
+    }
+
+    public String getClientId() {
+        return this.clientId;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalException.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalException.java
@@ -3,9 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
 /**
  * Base exception type thrown when an error occurs during token acquisition.
  */
@@ -16,8 +13,6 @@ public class MsalException extends RuntimeException {
     /**
      * Authentication error code
      */
-    @Accessors(fluent = true)
-    @Getter
     private String errorCode;
 
     /**
@@ -37,5 +32,9 @@ public class MsalException extends RuntimeException {
     public MsalException(final String message, String errorCode) {
         super(message);
         this.errorCode = errorCode;
+    }
+
+    public String errorCode() {
+        return this.errorCode;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalInteractionRequiredException.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalInteractionRequiredException.java
@@ -3,9 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
 import java.util.List;
 import java.util.Map;
 
@@ -19,8 +16,6 @@ public class MsalInteractionRequiredException extends MsalServiceException {
      * Reason for the MsalInteractionRequiredException, enabling you to do more actions or inform the
      * user depending on your scenario.
      */
-    @Accessors(fluent = true)
-    @Getter
     private final InteractionRequiredExceptionReason reason;
 
     /**
@@ -35,5 +30,9 @@ public class MsalInteractionRequiredException extends MsalServiceException {
         super(errorResponse, headerMap);
 
         reason = InteractionRequiredExceptionReason.fromSubErrorString(errorResponse.subError);
+    }
+
+    public InteractionRequiredExceptionReason reason() {
+        return this.reason;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalRequest.java
@@ -3,29 +3,18 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
-@Accessors(fluent = true)
-@Getter(AccessLevel.PACKAGE)
-@AllArgsConstructor
 abstract class MsalRequest {
 
     AbstractMsalAuthorizationGrant msalAuthorizationGrant;
-
     private final AbstractApplicationBase application;
-
     private final RequestContext requestContext;
-
-    @Getter(value = AccessLevel.PACKAGE, lazy = true)
-    private final HttpHeaders headers = new HttpHeaders(requestContext);
+    private final HttpHeaders headers;
 
     MsalRequest(AbstractApplicationBase clientApplicationBase, AbstractMsalAuthorizationGrant abstractMsalAuthorizationGrant, RequestContext requestContext) {
         this.application = clientApplicationBase;
         this.msalAuthorizationGrant = abstractMsalAuthorizationGrant;
         this.requestContext = requestContext;
+        this.headers = new HttpHeaders(requestContext);
 
         CurrentRequest currentRequest = new CurrentRequest(requestContext.publicApi());
         application.serviceBundle().getServerSideTelemetry().setCurrentRequest(currentRequest);
@@ -34,13 +23,25 @@ abstract class MsalRequest {
     MsalRequest(AbstractApplicationBase clientApplicationBase, RequestContext requestContext) {
         this.application = clientApplicationBase;
         this.requestContext = requestContext;
+        this.headers = new HttpHeaders(requestContext);
 
         CurrentRequest currentRequest = new CurrentRequest(requestContext.publicApi());
         application.serviceBundle().getServerSideTelemetry().setCurrentRequest(currentRequest);
     }
 
-    MsalRequest() {
-        this.application = null;
-        this.requestContext = null;
+    AbstractMsalAuthorizationGrant msalAuthorizationGrant() {
+        return this.msalAuthorizationGrant;
+    }
+
+    AbstractApplicationBase application() {
+        return this.application;
+    }
+
+    RequestContext requestContext() {
+        return this.requestContext;
+    }
+
+    HttpHeaders headers() {
+        return this.headers;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalServiceException.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalServiceException.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -14,41 +10,14 @@ import java.util.Map;
 /**
  * Exception type thrown when service returns an error response or other networking errors occur.
  */
-@Accessors(fluent = true)
-@Getter
 public class MsalServiceException extends MsalException {
 
-    /**
-     * Status code returned from http layer
-     */
     private Integer statusCode;
-
-    /**
-     * Status message returned from the http layer
-     */
     private String statusMessage;
-
-    /**
-     * An ID that can be used to piece up a single authentication flow.
-     */
     private String correlationId;
-
-    /**
-     * Claims included in the claims challenge
-     */
     private String claims;
-
-    /**
-     * Contains the http headers from the server response that indicated an error.
-     * When the server returns a 429 Too Many Requests error, a Retry-After should be set.
-     * It is important to read and respect the time specified in the Retry-After header
-     */
     private Map<String, List<String>> headers;
-
     private String managedIdentitySource;
-
-    @Accessors(fluent = true)
-    @Getter(AccessLevel.PACKAGE)
     private String subError;
 
     /**
@@ -104,5 +73,50 @@ public class MsalServiceException extends MsalException {
         super(discoveryResponse.errorDescription(), discoveryResponse.error());
 
         this.correlationId = discoveryResponse.correlationId();
+    }
+
+    /**
+     * Status code returned from http layer
+     */
+    public Integer statusCode() {
+        return this.statusCode;
+    }
+
+    /**
+     * Status message returned from the http layer
+     */
+    public String statusMessage() {
+        return this.statusMessage;
+    }
+
+    /**
+     * An ID that can be used to piece up a single authentication flow.
+     */
+    public String correlationId() {
+        return this.correlationId;
+    }
+
+    /**
+     * Claims included in the claims challenge
+     */
+    public String claims() {
+        return this.claims;
+    }
+
+    /**
+     * Contains the http headers from the server response that indicated an error.
+     * When the server returns a 429 Too Many Requests error, a Retry-After should be set.
+     * It is important to read and respect the time specified in the Retry-After header
+     */
+    public Map<String, List<String>> headers() {
+        return this.headers;
+    }
+
+    public String managedIdentitySource() {
+        return this.managedIdentitySource;
+    }
+
+    String subError() {
+        return this.subError;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalThrottlingException.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalThrottlingException.java
@@ -1,19 +1,11 @@
 package com.microsoft.aad.msal4j;
 
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
 /**
  * Exception type thrown when service returns throttling instruction:
  * Retry-After header, 429 or 5xx statuses.
  */
-@Accessors(fluent = true)
-@Getter
 public class MsalThrottlingException extends MsalServiceException {
 
-    /**
-     * how long to wait before repeating request
-     */
     private long retryInMs;
 
     /**
@@ -26,5 +18,12 @@ public class MsalThrottlingException extends MsalServiceException {
                 AuthenticationErrorCode.THROTTLED_REQUEST);
 
         this.retryInMs = retryInMs;
+    }
+
+    /**
+     * how long to wait before repeating request
+     */
+    public long retryInMs() {
+        return this.retryInMs;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OAuthHttpRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OAuthHttpRequest.java
@@ -6,8 +6,6 @@ package com.microsoft.aad.msal4j;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
-import lombok.AccessLevel;
-import lombok.Getter;
 
 import java.io.IOException;
 import java.net.URI;
@@ -19,7 +17,6 @@ import java.util.Map;
 
 class OAuthHttpRequest extends HTTPRequest {
 
-    @Getter(AccessLevel.PACKAGE)
     private final Map<String, String> extraHeaderParams;
     private final ServiceBundle serviceBundle;
     private final RequestContext requestContext;
@@ -110,5 +107,9 @@ class OAuthHttpRequest extends HTTPRequest {
             response.setContent(httpResponse.body());
         }
         return response;
+    }
+
+    Map<String, String> getExtraHeaderParams() {
+        return this.extraHeaderParams;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OidcDiscoveryResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OidcDiscoveryResponse.java
@@ -7,14 +7,9 @@ import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 
 import java.io.IOException;
 
-@Accessors(fluent = true)
-@Getter(AccessLevel.PACKAGE)
 class OidcDiscoveryResponse implements JsonSerializable<OidcDiscoveryResponse> {
 
     private String authorizationEndpoint;
@@ -53,5 +48,17 @@ class OidcDiscoveryResponse implements JsonSerializable<OidcDiscoveryResponse> {
         jsonWriter.writeStringField("device_authorization_endpoint", deviceCodeEndpoint);
         jsonWriter.writeEndObject();
         return jsonWriter;
+    }
+
+    String authorizationEndpoint() {
+        return this.authorizationEndpoint;
+    }
+
+    String tokenEndpoint() {
+        return this.tokenEndpoint;
+    }
+
+    String deviceCodeEndpoint() {
+        return this.deviceCodeEndpoint;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfParameters.java
@@ -3,9 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.*;
-import lombok.experimental.Accessors;
-
 import java.util.Map;
 import java.util.Set;
 
@@ -17,44 +14,26 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
  * <p>
  * For more details, see https://aka.ms/msal4j-on-behalf-of
  */
-@Builder
-@Accessors(fluent = true)
-@Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class OnBehalfOfParameters implements IAcquireTokenParameters {
 
-    @NonNull
     private Set<String> scopes;
-
-    /**
-     * Indicates whether the request should skip looking into the token cache. Be default it is
-     * set to false.
-     */
-    @Builder.Default
-    private Boolean skipCache = false;
-
-    @NonNull
+    private boolean skipCache;
     private IUserAssertion userAssertion;
-
-    /**
-     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
-     */
     private ClaimsRequest claims;
-
-    /**
-     * Adds additional headers to the token request
-     */
     private Map<String, String> extraHttpHeaders;
-
-    /**
-     * Adds additional parameters to the token request
-     */
     private Map<String, String> extraQueryParameters;
-
-    /**
-     * Overrides the tenant value in the authority URL for this request
-     */
     private String tenant;
+
+    private OnBehalfOfParameters(Set<String> scopes, Boolean skipCache, IUserAssertion userAssertion, ClaimsRequest claims, Map<String, String> extraHttpHeaders, Map<String, String> extraQueryParameters, String tenant) {
+        this.scopes = scopes;
+        //Legacy code that made the public parameter take the Boolean class instead of the primitive, so we need a null check
+        this.skipCache = skipCache != null && skipCache;
+        this.userAssertion = userAssertion;
+        this.claims = claims;
+        this.extraHttpHeaders = extraHttpHeaders;
+        this.extraQueryParameters = extraQueryParameters;
+        this.tenant = tenant;
+    }
 
     private static OnBehalfOfParametersBuilder builder() {
 
@@ -75,5 +54,108 @@ public class OnBehalfOfParameters implements IAcquireTokenParameters {
         return builder()
                 .scopes(scopes)
                 .userAssertion(userAssertion);
+    }
+
+    public Set<String> scopes() {
+        return this.scopes;
+    }
+
+    public Boolean skipCache() {
+        return this.skipCache;
+    }
+
+    public IUserAssertion userAssertion() {
+        return this.userAssertion;
+    }
+
+    public ClaimsRequest claims() {
+        return this.claims;
+    }
+
+    public Map<String, String> extraHttpHeaders() {
+        return this.extraHttpHeaders;
+    }
+
+    public Map<String, String> extraQueryParameters() {
+        return this.extraQueryParameters;
+    }
+
+    public String tenant() {
+        return this.tenant;
+    }
+
+    public static class OnBehalfOfParametersBuilder {
+        private Set<String> scopes;
+        private Boolean skipCache;
+        private IUserAssertion userAssertion;
+        private ClaimsRequest claims;
+        private Map<String, String> extraHttpHeaders;
+        private Map<String, String> extraQueryParameters;
+        private String tenant;
+
+        OnBehalfOfParametersBuilder() {
+        }
+
+        public OnBehalfOfParametersBuilder scopes(Set<String> scopes) {
+            validateNotNull("scopes", scopes);
+
+            this.scopes = scopes;
+            return this;
+        }
+
+        /**
+         * Indicates whether the request should skip looking into the token cache. Be default it is set to false.
+         */
+        public OnBehalfOfParametersBuilder skipCache(Boolean skipCache) {
+            this.skipCache = skipCache;
+            return this;
+        }
+
+        public OnBehalfOfParametersBuilder userAssertion(IUserAssertion userAssertion) {
+            validateNotNull("userAssertion", userAssertion);
+
+            this.userAssertion = userAssertion;
+            return this;
+        }
+
+        /**
+         * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
+         */
+        public OnBehalfOfParametersBuilder claims(ClaimsRequest claims) {
+            this.claims = claims;
+            return this;
+        }
+
+        /**
+         * Adds additional headers to the token request
+         */
+        public OnBehalfOfParametersBuilder extraHttpHeaders(Map<String, String> extraHttpHeaders) {
+            this.extraHttpHeaders = extraHttpHeaders;
+            return this;
+        }
+
+        /**
+         * Adds additional parameters to the token request
+         */
+        public OnBehalfOfParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
+            this.extraQueryParameters = extraQueryParameters;
+            return this;
+        }
+
+        /**
+         * Overrides the tenant value in the authority URL for this request
+         */
+        public OnBehalfOfParametersBuilder tenant(String tenant) {
+            this.tenant = tenant;
+            return this;
+        }
+
+        public OnBehalfOfParameters build() {
+            return new OnBehalfOfParameters(this.scopes, this.skipCache, this.userAssertion, this.claims, this.extraHttpHeaders, this.extraQueryParameters, this.tenant);
+        }
+
+        public String toString() {
+            return "OnBehalfOfParameters.OnBehalfOfParametersBuilder(scopes=" + this.scopes + ", skipCache$value=" + this.skipCache + ", userAssertion=" + this.userAssertion + ", claims=" + this.claims + ", extraHttpHeaders=" + this.extraHttpHeaders + ", extraQueryParameters=" + this.extraQueryParameters + ", tenant=" + this.tenant + ")";
+        }
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfRequest.java
@@ -6,8 +6,6 @@ package com.microsoft.aad.msal4j;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationGrant;
 import com.nimbusds.oauth2.sdk.JWTBearerGrant;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -16,8 +14,6 @@ import java.util.Map;
 
 import static com.microsoft.aad.msal4j.AbstractMsalAuthorizationGrant.SCOPES_DELIMITER;
 
-@Accessors(fluent = true)
-@Getter
 class OnBehalfOfRequest extends MsalRequest {
 
     OnBehalfOfParameters parameters;
@@ -45,5 +41,9 @@ class OnBehalfOfRequest extends MsalRequest {
         }
 
         return new OAuthAuthorizationGrant(jWTBearerGrant, String.join(SCOPES_DELIMITER, parameters.scopes()), params);
+    }
+
+    OnBehalfOfParameters parameters() {
+        return this.parameters;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RefreshTokenCacheEntity.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RefreshTokenCacheEntity.java
@@ -4,16 +4,10 @@
 package com.microsoft.aad.msal4j;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@Accessors(fluent = true)
-@Getter
-@Setter
 class RefreshTokenCacheEntity extends Credential {
 
     @JsonProperty("credential_type")
@@ -45,5 +39,21 @@ class RefreshTokenCacheEntity extends Credential {
         keyParts.add("");
 
         return String.join(Constants.CACHE_KEY_SEPARATOR, keyParts).toLowerCase();
+    }
+
+    String credentialType() {
+        return this.credentialType;
+    }
+
+    String family_id() {
+        return this.family_id;
+    }
+
+    void credentialType(String credentialType) {
+        this.credentialType = credentialType;
+    }
+
+    void family_id(String family_id) {
+        this.family_id = family_id;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RefreshTokenParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RefreshTokenParameters.java
@@ -3,9 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.*;
-import lombok.experimental.Accessors;
-
 import java.util.Map;
 import java.util.Set;
 
@@ -20,43 +17,23 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
  * RefreshTokenParameters should only be used for migration scenarios (when moving from ADAL to
  * MSAL). To acquire tokens silently, use {@link AbstractClientApplicationBase#acquireTokenSilently(SilentParameters)}
  */
-@Builder
-@Accessors(fluent = true)
-@Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class RefreshTokenParameters implements IAcquireTokenParameters {
 
-    /**
-     * Scopes the application is requesting access to
-     */
-    @NonNull
     private Set<String> scopes;
-
-    /**
-     * Refresh token received from the STS
-     */
-    @NonNull
     private String refreshToken;
-
-    /**
-     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
-     */
     private ClaimsRequest claims;
-
-    /**
-     * Adds additional headers to the token request
-     */
     private Map<String, String> extraHttpHeaders;
-
-    /**
-     * Adds additional parameters to the token request
-     */
     private Map<String, String> extraQueryParameters;
-
-    /**
-     * Overrides the tenant value in the authority URL for this request
-     */
     private String tenant;
+
+    private RefreshTokenParameters(Set<String> scopes, String refreshToken, ClaimsRequest claims, Map<String, String> extraHttpHeaders, Map<String, String> extraQueryParameters, String tenant) {
+        this.scopes = scopes;
+        this.refreshToken = refreshToken;
+        this.claims = claims;
+        this.extraHttpHeaders = extraHttpHeaders;
+        this.extraQueryParameters = extraQueryParameters;
+        this.tenant = tenant;
+    }
 
     private static RefreshTokenParametersBuilder builder() {
 
@@ -77,5 +54,105 @@ public class RefreshTokenParameters implements IAcquireTokenParameters {
         return builder()
                 .scopes(scopes)
                 .refreshToken(refreshToken);
+    }
+
+    public Set<String> scopes() {
+        return this.scopes;
+    }
+
+    public String refreshToken() {
+        return this.refreshToken;
+    }
+
+    public ClaimsRequest claims() {
+        return this.claims;
+    }
+
+    public Map<String, String> extraHttpHeaders() {
+        return this.extraHttpHeaders;
+    }
+
+    public Map<String, String> extraQueryParameters() {
+        return this.extraQueryParameters;
+    }
+
+    public String tenant() {
+        return this.tenant;
+    }
+
+    public static class RefreshTokenParametersBuilder {
+        private Set<String> scopes;
+        private String refreshToken;
+        private ClaimsRequest claims;
+        private Map<String, String> extraHttpHeaders;
+        private Map<String, String> extraQueryParameters;
+        private String tenant;
+
+        RefreshTokenParametersBuilder() {
+        }
+
+        /**
+         * Scopes the application is requesting access to
+         * <p>
+         * Cannot be null.
+         */
+        public RefreshTokenParametersBuilder scopes(Set<String> scopes) {
+            validateNotNull("scopes", scopes);
+
+            this.scopes = scopes;
+            return this;
+        }
+
+        /**
+         * Refresh token received from the STS
+         * <p>
+         * Cannot be null.
+         */
+        public RefreshTokenParametersBuilder refreshToken(String refreshToken) {
+            validateNotNull("refreshToken", scopes);
+
+            this.refreshToken = refreshToken;
+            return this;
+        }
+
+        /**
+         * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
+         */
+        public RefreshTokenParametersBuilder claims(ClaimsRequest claims) {
+            this.claims = claims;
+            return this;
+        }
+
+        /**
+         * Adds additional headers to the token request
+         */
+        public RefreshTokenParametersBuilder extraHttpHeaders(Map<String, String> extraHttpHeaders) {
+            this.extraHttpHeaders = extraHttpHeaders;
+            return this;
+        }
+
+        /**
+         * Adds additional parameters to the token request
+         */
+        public RefreshTokenParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
+            this.extraQueryParameters = extraQueryParameters;
+            return this;
+        }
+
+        /**
+         * Overrides the tenant value in the authority URL for this request
+         */
+        public RefreshTokenParametersBuilder tenant(String tenant) {
+            this.tenant = tenant;
+            return this;
+        }
+
+        public RefreshTokenParameters build() {
+            return new RefreshTokenParameters(this.scopes, this.refreshToken, this.claims, this.extraHttpHeaders, this.extraQueryParameters, this.tenant);
+        }
+
+        public String toString() {
+            return "RefreshTokenParameters.RefreshTokenParametersBuilder(scopes=" + this.scopes + ", refreshToken=" + this.refreshToken + ", claims=" + this.claims + ", extraHttpHeaders=" + this.extraHttpHeaders + ", extraQueryParameters=" + this.extraQueryParameters + ", tenant=" + this.tenant + ")";
+        }
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RequestContext.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RequestContext.java
@@ -3,18 +3,10 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-
 import java.util.UUID;
 
-@Accessors(fluent = true)
-@Getter(AccessLevel.PACKAGE)
 class RequestContext {
 
-    @Setter(AccessLevel.PACKAGE)
     private String telemetryRequestId;
     private String clientId;
     private String correlationId;
@@ -57,5 +49,50 @@ class RequestContext {
 
     private static String generateNewCorrelationId() {
         return UUID.randomUUID().toString();
+    }
+
+    String telemetryRequestId() {
+        return this.telemetryRequestId;
+    }
+
+    String clientId() {
+        return this.clientId;
+    }
+
+    String correlationId() {
+        return this.correlationId;
+    }
+
+    PublicApi publicApi() {
+        return this.publicApi;
+    }
+
+    String applicationName() {
+        return this.applicationName;
+    }
+
+    String applicationVersion() {
+        return this.applicationVersion;
+    }
+
+    String authority() {
+        return this.authority;
+    }
+
+    IAcquireTokenParameters apiParameters() {
+        return this.apiParameters;
+    }
+
+    IApplicationBase clientApplication() {
+        return this.clientApplication;
+    }
+
+    UserIdentifier userIdentifier() {
+        return this.userIdentifier;
+    }
+
+    RequestContext telemetryRequestId(String telemetryRequestId) {
+        this.telemetryRequestId = telemetryRequestId;
+        return this;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RequestedClaim.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RequestedClaim.java
@@ -6,7 +6,6 @@ package com.microsoft.aad.msal4j;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.AllArgsConstructor;
 
 import java.util.Collections;
 import java.util.Map;
@@ -16,7 +15,6 @@ import java.util.Map;
  *
  * @see <a href="https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter">https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter</a>
  */
-@AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RequestedClaim {
 
@@ -24,6 +22,11 @@ public class RequestedClaim {
     public String name;
 
     RequestedClaimAdditionalInfo requestedClaimAdditionalInfo;
+
+    public RequestedClaim(String name, RequestedClaimAdditionalInfo requestedClaimAdditionalInfo) {
+        this.name = name;
+        this.requestedClaimAdditionalInfo = requestedClaimAdditionalInfo;
+    }
 
     @JsonAnyGetter
     protected Map<String, Object> any() {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RequestedClaimAdditionalInfo.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RequestedClaimAdditionalInfo.java
@@ -3,11 +3,8 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
@@ -16,9 +13,6 @@ import java.util.List;
  *
  * @see <a href="https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter">https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter</a>
  */
-@Getter
-@Setter
-@AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RequestedClaimAdditionalInfo {
 
@@ -31,4 +25,34 @@ public class RequestedClaimAdditionalInfo {
 
     @JsonProperty("values")
     List<String> values;
+
+    public RequestedClaimAdditionalInfo(boolean essential, String value, List<String> values) {
+        this.essential = essential;
+        this.value = value;
+        this.values = values;
+    }
+
+    public boolean isEssential() {
+        return this.essential;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public List<String> getValues() {
+        return this.values;
+    }
+
+    public void setEssential(boolean essential) {
+        this.essential = essential;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/SilentParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/SilentParameters.java
@@ -131,7 +131,6 @@ public class SilentParameters implements IAcquireTokenParameters {
         return this.proofOfPossession;
     }
 
-    //This Builder class is used to override Lombok's default setter behavior for any fields defined in it
     public static class SilentParametersBuilder {
 
         private Set<String> scopes;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/SilentRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/SilentRequest.java
@@ -3,14 +3,9 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 
-@Accessors(fluent = true)
-@Getter
 class SilentRequest extends MsalRequest {
 
     private SilentParameters parameters;
@@ -34,5 +29,17 @@ class SilentRequest extends MsalRequest {
             application.serviceBundle().getServerSideTelemetry().getCurrentRequest().cacheInfo(
                     CacheRefreshReason.FORCE_REFRESH);
         }
+    }
+
+    SilentParameters parameters() {
+        return this.parameters;
+    }
+
+    IUserAssertion assertion() {
+        return this.assertion;
+    }
+
+    Authority requestAuthority() {
+        return this.requestAuthority;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/SystemBrowserOptions.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/SystemBrowserOptions.java
@@ -3,12 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
 import java.net.URI;
 
 /**
@@ -17,48 +11,112 @@ import java.net.URI;
  * It can however response with a HTTP 200 OK message or a 302 Redirect, which can be configured here.
  * For more details, see https://aka.ms/msal4j-interactive-request
  */
-@Builder
-@Accessors(fluent = true)
-@Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class SystemBrowserOptions {
 
-    /**
-     * When the user finishes authenticating, MSAL will respond with a Http 200 OK message, which the
-     * browser will show to the user
-     */
     private String htmlMessageSuccess;
-
-    /**
-     * WHen the user finishes authenticating, but an error occurred, MSAL will respond with a
-     * Http 200 Ok message, which the browser will show to the user.
-     */
     private String htmlMessageError;
-
-    /**
-     * When the user finishes authenticating, MSAL will redirect the browser to the given URI.
-     * Takes precedence over htmlMessageSuccess
-     */
     private URI browserRedirectSuccess;
-
-    /**
-     * When the the user finishes authenticating, but an error occurred, MSAL will redirect the
-     * browser to the given URI.
-     * Takes precedence over htmlMessageError
-     */
     private URI browserRedirectError;
-
-    /**
-     * Allows developers to implement their own logic for starting a browser and navigating to a
-     * specific Uri. Msal will use this when opening the browser. If not set, the user configured
-     * browser will be used.
-     */
     private OpenBrowserAction openBrowserAction;
+
+    private SystemBrowserOptions(String htmlMessageSuccess, String htmlMessageError, URI browserRedirectSuccess, URI browserRedirectError, OpenBrowserAction openBrowserAction) {
+        this.htmlMessageSuccess = htmlMessageSuccess;
+        this.htmlMessageError = htmlMessageError;
+        this.browserRedirectSuccess = browserRedirectSuccess;
+        this.browserRedirectError = browserRedirectError;
+        this.openBrowserAction = openBrowserAction;
+    }
 
     /**
      * Builder for {@link SystemBrowserOptions}
      */
     public static SystemBrowserOptionsBuilder builder() {
         return new SystemBrowserOptionsBuilder();
+    }
+
+    public String htmlMessageSuccess() {
+        return this.htmlMessageSuccess;
+    }
+
+    public String htmlMessageError() {
+        return this.htmlMessageError;
+    }
+
+    public URI browserRedirectSuccess() {
+        return this.browserRedirectSuccess;
+    }
+
+    public URI browserRedirectError() {
+        return this.browserRedirectError;
+    }
+
+    public OpenBrowserAction openBrowserAction() {
+        return this.openBrowserAction;
+    }
+
+    public static class SystemBrowserOptionsBuilder {
+        private String htmlMessageSuccess;
+        private String htmlMessageError;
+        private URI browserRedirectSuccess;
+        private URI browserRedirectError;
+        private OpenBrowserAction openBrowserAction;
+
+        SystemBrowserOptionsBuilder() {
+        }
+
+        /**
+         * When the user finishes authenticating, MSAL will respond with a Http 200 OK message, which the
+         * browser will show to the user
+         */
+        public SystemBrowserOptionsBuilder htmlMessageSuccess(String htmlMessageSuccess) {
+            this.htmlMessageSuccess = htmlMessageSuccess;
+            return this;
+        }
+
+        /**
+         * WHen the user finishes authenticating, but an error occurred, MSAL will respond with a
+         * Http 200 Ok message, which the browser will show to the user.
+         */
+        public SystemBrowserOptionsBuilder htmlMessageError(String htmlMessageError) {
+            this.htmlMessageError = htmlMessageError;
+            return this;
+        }
+
+        /**
+         * When the user finishes authenticating, MSAL will redirect the browser to the given URI.
+         * Takes precedence over htmlMessageSuccess
+         */
+        public SystemBrowserOptionsBuilder browserRedirectSuccess(URI browserRedirectSuccess) {
+            this.browserRedirectSuccess = browserRedirectSuccess;
+            return this;
+        }
+
+        /**
+         * When the the user finishes authenticating, but an error occurred, MSAL will redirect the
+         * browser to the given URI.
+         * Takes precedence over htmlMessageError
+         */
+        public SystemBrowserOptionsBuilder browserRedirectError(URI browserRedirectError) {
+            this.browserRedirectError = browserRedirectError;
+            return this;
+        }
+
+        /**
+         * Allows developers to implement their own logic for starting a browser and navigating to a
+         * specific Uri. Msal will use this when opening the browser. If not set, the user configured
+         * browser will be used.
+         */
+        public SystemBrowserOptionsBuilder openBrowserAction(OpenBrowserAction openBrowserAction) {
+            this.openBrowserAction = openBrowserAction;
+            return this;
+        }
+
+        public SystemBrowserOptions build() {
+            return new SystemBrowserOptions(this.htmlMessageSuccess, this.htmlMessageError, this.browserRedirectSuccess, this.browserRedirectError, this.openBrowserAction);
+        }
+
+        public String toString() {
+            return "SystemBrowserOptions.SystemBrowserOptionsBuilder(htmlMessageSuccess=" + this.htmlMessageSuccess + ", htmlMessageError=" + this.htmlMessageError + ", browserRedirectSuccess=" + this.browserRedirectSuccess + ", browserRedirectError=" + this.browserRedirectError + ", openBrowserAction=" + this.openBrowserAction + ")";
+        }
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TenantProfile.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TenantProfile.java
@@ -3,27 +3,41 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-
 import java.util.Map;
 
 /**
  * Representation of a single tenant profile
  */
-@Accessors(fluent = true)
-@Getter
-@Setter
-@AllArgsConstructor
 class TenantProfile implements ITenantProfile {
 
     Map<String, ?> idTokenClaims;
 
     String environment;
 
+    public TenantProfile(Map<String, ?> idTokenClaims, String environment) {
+        this.idTokenClaims = idTokenClaims;
+        this.environment = environment;
+    }
+
     public Map<String, ?> getClaims() {
         return idTokenClaims;
+    }
+
+    public Map<String, ?> idTokenClaims() {
+        return this.idTokenClaims;
+    }
+
+    public String environment() {
+        return this.environment;
+    }
+
+    public TenantProfile idTokenClaims(Map<String, ?> idTokenClaims) {
+        this.idTokenClaims = idTokenClaims;
+        return this;
+    }
+
+    public TenantProfile environment(String environment) {
+        this.environment = environment;
+        return this;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenCacheAccessContext.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenCacheAccessContext.java
@@ -3,25 +3,80 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
 /**
- * Context in which the the token cache is accessed
+ * Context in which the token cache is accessed
  * <p>
  * For more details, see https://aka.ms/msal4j-token-cache
  */
-@Builder
-@Accessors(fluent = true)
-@Getter
 public class TokenCacheAccessContext implements ITokenCacheAccessContext {
 
     private ITokenCache tokenCache;
-
     private String clientId;
-
     private IAccount account;
-
     private boolean hasCacheChanged;
+
+    TokenCacheAccessContext(ITokenCache tokenCache, String clientId, IAccount account, boolean hasCacheChanged) {
+        this.tokenCache = tokenCache;
+        this.clientId = clientId;
+        this.account = account;
+        this.hasCacheChanged = hasCacheChanged;
+    }
+
+    public static TokenCacheAccessContextBuilder builder() {
+        return new TokenCacheAccessContextBuilder();
+    }
+
+    public ITokenCache tokenCache() {
+        return this.tokenCache;
+    }
+
+    public String clientId() {
+        return this.clientId;
+    }
+
+    public IAccount account() {
+        return this.account;
+    }
+
+    public boolean hasCacheChanged() {
+        return this.hasCacheChanged;
+    }
+
+    public static class TokenCacheAccessContextBuilder {
+        private ITokenCache tokenCache;
+        private String clientId;
+        private IAccount account;
+        private boolean hasCacheChanged;
+
+        TokenCacheAccessContextBuilder() {
+        }
+
+        public TokenCacheAccessContextBuilder tokenCache(ITokenCache tokenCache) {
+            this.tokenCache = tokenCache;
+            return this;
+        }
+
+        public TokenCacheAccessContextBuilder clientId(String clientId) {
+            this.clientId = clientId;
+            return this;
+        }
+
+        public TokenCacheAccessContextBuilder account(IAccount account) {
+            this.account = account;
+            return this;
+        }
+
+        public TokenCacheAccessContextBuilder hasCacheChanged(boolean hasCacheChanged) {
+            this.hasCacheChanged = hasCacheChanged;
+            return this;
+        }
+
+        public TokenCacheAccessContext build() {
+            return new TokenCacheAccessContext(this.tokenCache, this.clientId, this.account, this.hasCacheChanged);
+        }
+
+        public String toString() {
+            return "TokenCacheAccessContext.TokenCacheAccessContextBuilder(tokenCache=" + this.tokenCache + ", clientId=" + this.clientId + ", account=" + this.account + ", hasCacheChanged=" + this.hasCacheChanged + ")";
+        }
+    }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenProviderResult.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenProviderResult.java
@@ -3,11 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.Getter;
-import lombok.Setter;
-
-@Getter
-@Setter
 /// Token result from external token provider
 public class TokenProviderResult {
 
@@ -20,4 +15,35 @@ public class TokenProviderResult {
     //When the token be refreshed proactively (optional)
     private long refreshInSeconds;
 
+    public String getAccessToken() {
+        return this.accessToken;
+    }
+
+    public String getTenantId() {
+        return this.tenantId;
+    }
+
+    public long getExpiresInSeconds() {
+        return this.expiresInSeconds;
+    }
+
+    public long getRefreshInSeconds() {
+        return this.refreshInSeconds;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public void setTenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public void setExpiresInSeconds(long expiresInSeconds) {
+        this.expiresInSeconds = expiresInSeconds;
+    }
+
+    public void setRefreshInSeconds(long refreshInSeconds) {
+        this.refreshInSeconds = refreshInSeconds;
+    }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -9,8 +9,6 @@ import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
 import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
-import lombok.AccessLevel;
-import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,7 +17,6 @@ import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-@Getter(AccessLevel.PACKAGE)
 class TokenRequestExecutor {
     Logger log = LoggerFactory.getLogger(TokenRequestExecutor.class);
 
@@ -178,5 +175,25 @@ class TokenRequestExecutor {
             throw MsalServiceExceptionFactory.fromHttpResponse(oauthHttpResponse);
         }
         return result;
+    }
+
+    Logger getLog() {
+        return this.log;
+    }
+
+    Authority getRequestAuthority() {
+        return this.requestAuthority;
+    }
+
+    String getTenant() {
+        return this.tenant;
+    }
+
+    MsalRequest getMsalRequest() {
+        return this.msalRequest;
+    }
+
+    ServiceBundle getServiceBundle() {
+        return this.serviceBundle;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenResponse.java
@@ -10,11 +10,8 @@ import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.oauth2.sdk.util.JSONObjectUtils;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
-import lombok.AccessLevel;
-import lombok.Getter;
 import net.minidev.json.JSONObject;
 
-@Getter(AccessLevel.PACKAGE)
 class TokenResponse extends OIDCTokenResponse {
 
     private String scope;
@@ -107,5 +104,29 @@ class TokenResponse extends OIDCTokenResponse {
         } catch (Exception e) {
             throw new MsalClientException(e);
         }
+    }
+
+    String getScope() {
+        return this.scope;
+    }
+
+    String getClientInfo() {
+        return this.clientInfo;
+    }
+
+    long getExpiresIn() {
+        return this.expiresIn;
+    }
+
+    long getExtExpiresIn() {
+        return this.extExpiresIn;
+    }
+
+    String getFoci() {
+        return this.foci;
+    }
+
+    long getRefreshIn() {
+        return this.refreshIn;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserDiscoveryResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserDiscoveryResponse.java
@@ -7,14 +7,9 @@ import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 
 import java.io.IOException;
 
-@Accessors(fluent = true)
-@Getter(AccessLevel.PACKAGE)
 class UserDiscoveryResponse implements JsonSerializable<UserDiscoveryResponse> {
 
     private float version;
@@ -78,5 +73,29 @@ class UserDiscoveryResponse implements JsonSerializable<UserDiscoveryResponse> {
         jsonWriter.writeStringField("cloud_audience_urn", cloudAudienceUrn);
         jsonWriter.writeEndObject();
         return jsonWriter;
+    }
+
+    float version() {
+        return this.version;
+    }
+
+    String accountType() {
+        return this.accountType;
+    }
+
+    String federationMetadataUrl() {
+        return this.federationMetadataUrl;
+    }
+
+    String federationProtocol() {
+        return this.federationProtocol;
+    }
+
+    String federationActiveAuthUrl() {
+        return this.federationActiveAuthUrl;
+    }
+
+    String cloudAudienceUrn() {
+        return this.cloudAudienceUrn;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserIdentifier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserIdentifier.java
@@ -3,16 +3,10 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
 /**
  * Used for populating the X-AnchorMailbox header, which is used in the cached credential service
  * (CCS) routing
  */
-@Getter(AccessLevel.PACKAGE)
-@Accessors(fluent = true)
 public class UserIdentifier {
 
     // Format is "userObjectId@userTenantId"
@@ -44,5 +38,13 @@ public class UserIdentifier {
 
         userIdentifier.oid = String.format(OID_HEADER_FORMAT, homeAccountIdParts[0], homeAccountIdParts[1]);
         return userIdentifier;
+    }
+
+    String upn() {
+        return this.upn;
+    }
+
+    String oid() {
+        return this.oid;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordParameters.java
@@ -3,16 +3,11 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.*;
-import lombok.experimental.Accessors;
-
 import java.net.URI;
 import java.util.Map;
 import java.util.Set;
 
-import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotBlank;
-import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotEmpty;
-import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
+import static com.microsoft.aad.msal4j.ParameterValidationUtils.*;
 
 /**
  * Object containing parameters for Username/Password flow. Can be used as parameter to
@@ -20,51 +15,27 @@ import static com.microsoft.aad.msal4j.ParameterValidationUtils.validateNotNull;
  * <p>
  * For more details, see https://aka.ms/msal4j-username-password
  */
-@Builder
-@Accessors(fluent = true)
-@Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserNamePasswordParameters implements IAcquireTokenParameters {
 
-    /**
-     * Scopes application is requesting access to
-     */
-    @NonNull
     private Set<String> scopes;
-
-    /**
-     * Username of the account
-     */
-    @NonNull
     private String username;
-
-    /**
-     * Char array containing credentials for the username
-     */
-    @NonNull
     private char[] password;
-
-    /**
-     * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
-     */
     private ClaimsRequest claims;
-
-    /**
-     * Adds additional headers to the token request
-     */
     private Map<String, String> extraHttpHeaders;
-
-    /**
-     * Adds additional query parameters to the token request
-     */
     private Map<String, String> extraQueryParameters;
-
-    /**
-     * Overrides the tenant value in the authority URL for this request
-     */
     private String tenant;
-
     private PopParameters proofOfPossession;
+
+    private UserNamePasswordParameters(Set<String> scopes, String username, char[] password, ClaimsRequest claims, Map<String, String> extraHttpHeaders, Map<String, String> extraQueryParameters, String tenant, PopParameters proofOfPossession) {
+        this.scopes = scopes;
+        this.username = username;
+        this.password = password;
+        this.claims = claims;
+        this.extraHttpHeaders = extraHttpHeaders;
+        this.extraQueryParameters = extraQueryParameters;
+        this.tenant = tenant;
+        this.proofOfPossession = proofOfPossession;
+    }
 
     public char[] password() {
         return password.clone();
@@ -96,8 +67,53 @@ public class UserNamePasswordParameters implements IAcquireTokenParameters {
                 .password(password);
     }
 
+    public Set<String> scopes() {
+        return this.scopes;
+    }
+
+    public String username() {
+        return this.username;
+    }
+
+    public ClaimsRequest claims() {
+        return this.claims;
+    }
+
+    public Map<String, String> extraHttpHeaders() {
+        return this.extraHttpHeaders;
+    }
+
+    public Map<String, String> extraQueryParameters() {
+        return this.extraQueryParameters;
+    }
+
+    public String tenant() {
+        return this.tenant;
+    }
+
+    public PopParameters proofOfPossession() {
+        return this.proofOfPossession;
+    }
+
     public static class UserNamePasswordParametersBuilder {
+        private Set<String> scopes;
+        private String username;
+        private char[] password;
+        private ClaimsRequest claims;
+        private Map<String, String> extraHttpHeaders;
+        private Map<String, String> extraQueryParameters;
+        private String tenant;
+        private PopParameters proofOfPossession;
+
+        UserNamePasswordParametersBuilder() {
+        }
+
+        /**
+         * Char array containing credentials for the username
+         */
         public UserNamePasswordParametersBuilder password(char[] password) {
+            validateNotNull("password", password);
+
             this.password = password.clone();
             return this;
         }
@@ -115,6 +131,70 @@ public class UserNamePasswordParameters implements IAcquireTokenParameters {
             this.proofOfPossession = new PopParameters(httpMethod, uri, nonce);
 
             return this;
+        }
+
+        /**
+         * Scopes application is requesting access to
+         * <p>
+         * Cannot be null.
+         */
+        public UserNamePasswordParametersBuilder scopes(Set<String> scopes) {
+            validateNotNull("scopes", scopes);
+
+            this.scopes = scopes;
+            return this;
+        }
+
+        /**
+         * Username of the account
+         * <p>
+         * Cannot be null.
+         */
+        public UserNamePasswordParametersBuilder username(String username) {
+            validateNotNull("username", username);
+
+            this.username = username;
+            return this;
+        }
+
+        /**
+         * Claims to be requested through the OIDC claims request parameter, allowing requests for standard and custom claims
+         */
+        public UserNamePasswordParametersBuilder claims(ClaimsRequest claims) {
+            this.claims = claims;
+            return this;
+        }
+
+        /**
+         * Adds additional headers to the token request
+         */
+        public UserNamePasswordParametersBuilder extraHttpHeaders(Map<String, String> extraHttpHeaders) {
+            this.extraHttpHeaders = extraHttpHeaders;
+            return this;
+        }
+
+        /**
+         * Adds additional query parameters to the token request
+         */
+        public UserNamePasswordParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
+            this.extraQueryParameters = extraQueryParameters;
+            return this;
+        }
+
+        /**
+         * Overrides the tenant value in the authority URL for this request
+         */
+        public UserNamePasswordParametersBuilder tenant(String tenant) {
+            this.tenant = tenant;
+            return this;
+        }
+
+        public UserNamePasswordParameters build() {
+            return new UserNamePasswordParameters(this.scopes, this.username, this.password, this.claims, this.extraHttpHeaders, this.extraQueryParameters, this.tenant, this.proofOfPossession);
+        }
+
+        public String toString() {
+            return "UserNamePasswordParameters.UserNamePasswordParametersBuilder(scopes=" + this.scopes + ", username=" + this.username + ", password=" + java.util.Arrays.toString(this.password) + ", claims=" + this.claims + ", extraHttpHeaders=" + this.extraHttpHeaders + ", extraQueryParameters=" + this.extraQueryParameters + ", tenant=" + this.tenant + ", proofOfPossession=" + this.proofOfPossession + ")";
         }
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/WSTrustVersion.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/WSTrustVersion.java
@@ -3,12 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.experimental.Accessors;
-
-@Accessors(fluent = true)
-@Getter(AccessLevel.PACKAGE)
 enum WSTrustVersion {
 
     WSTRUST13(
@@ -22,5 +16,13 @@ enum WSTrustVersion {
     WSTrustVersion(String tokenType, String responseSecurityToken) {
         this.responseTokenTypePath = tokenType;
         this.responseSecurityTokenPath = responseSecurityToken;
+    }
+
+    String responseTokenTypePath() {
+        return this.responseTokenTypePath;
+    }
+
+    String responseSecurityTokenPath() {
+        return this.responseSecurityTokenPath;
     }
 }


### PR DESCRIPTION
Finishes the work started in https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/919 to remove Lombok code generation.

This PR affects a lot more files, but makes the same changes as the previous PR to remove Lombok's annotations:
- Replace `@Getter` and `@Setter` annotations with actual getter/setters
- Replace `@Builder` with an inner builder class
- Replace `@NonNull` with our own `ParameterValidationUtils.validateNotNull()`
- Move Javadoc comments from the private fields to the public builder methods

The RevAPI plugin was used alongside normal testing to help ensure there are no breaking changes.