### PR TITLE
Remove usage of com.nimbusds.oauth2's Token classes

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpResponse.java
@@ -63,12 +63,7 @@ public class HttpResponse implements IHttpResponse {
     }
 
     Map<String, String> getBodyAsMap() {
-        try (JsonReader reader = JsonProviders.createReader(this.body)) {
-            reader.nextToken();
-            return reader.readMap(JsonReader::getString);
-        } catch (IOException e) {
-            throw new MsalClientException("Could not parse JSON from HttpResponse body: " + e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
-        }
+        return JsonHelper.convertJsonToMap(this.body);
     }
 
     public int statusCode() {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpResponse.java
@@ -3,10 +3,10 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.nimbusds.oauth2.sdk.util.JSONObjectUtils;
-import net.minidev.json.JSONObject;
-import com.nimbusds.oauth2.sdk.ParseException;
+import com.azure.json.JsonProviders;
+import com.azure.json.JsonReader;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -62,11 +62,12 @@ public class HttpResponse implements IHttpResponse {
         return headers.get(key);
     }
 
-    JSONObject getBodyAsJson() {
-        try {
-            return JSONObjectUtils.parse(this.body());
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
+    Map<String, String> getBodyAsMap() {
+        try (JsonReader reader = JsonProviders.createReader(this.body)) {
+            reader.nextToken();
+            return reader.readMap(JsonReader::getString);
+        } catch (IOException e) {
+            throw new MsalClientException("Could not parse JSON from HttpResponse body: " + e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
         }
     }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 class JsonHelper {
@@ -48,6 +49,16 @@ class JsonHelper {
             throw new MsalClientException(e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
         } catch (Exception e) {
             throw new MsalClientException("Error parsing JSON response: " + e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
+        }
+    }
+
+    //Converts a JSON string to a Map<String, String>
+    static Map<String, String> convertJsonToMap(String jsonString) {
+        try (JsonReader reader = JsonProviders.createReader(jsonString)) {
+            reader.nextToken();
+            return reader.readMap(JsonReader::getString);
+        } catch (IOException e) {
+            throw new MsalClientException("Could not parse JSON from HttpResponse body: " + e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
         }
     }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -6,7 +6,6 @@ package com.microsoft.aad.msal4j;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.SerializeException;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
-import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,17 +120,11 @@ class TokenRequestExecutor {
         if (oauthHttpResponse.statusCode() == HttpHelper.HTTP_STATUS_200) {
             final TokenResponse response = TokenResponse.parseHttpResponse(oauthHttpResponse);
 
-            OIDCTokens tokens = response.getOIDCTokens();
-            String refreshToken = null;
-            if (tokens.getRefreshToken() != null) {
-                refreshToken = tokens.getRefreshToken().getValue();
-            }
-
             AccountCacheEntity accountCacheEntity = null;
-            if (!StringHelper.isNullOrBlank(tokens.getIDTokenString())) {
+            if (!StringHelper.isNullOrBlank(response.idToken())) {
                 String idTokenJson;
                 try {
-                    idTokenJson = new String(Base64.getDecoder().decode(tokens.getIDTokenString().split("\\.")[1]), StandardCharsets.UTF_8);
+                    idTokenJson = new String(Base64.getDecoder().decode(response.idToken().split("\\.")[1]), StandardCharsets.UTF_8);
                 } catch (ArrayIndexOutOfBoundsException e) {
                     throw new MsalServiceException("Error parsing ID token, missing payload section. Ensure that the ID token is following the JWT format.",
                             AuthenticationErrorCode.INVALID_JWT);
@@ -161,10 +154,10 @@ class TokenRequestExecutor {
             long currTimestampSec = new Date().getTime() / 1000;
 
             result = AuthenticationResult.builder().
-                    accessToken(tokens.getAccessToken().getValue()).
-                    refreshToken(refreshToken).
+                    accessToken(response.accessToken()).
+                    refreshToken(response.refreshToken()).
                     familyId(response.getFoci()).
-                    idToken(tokens.getIDTokenString()).
+                    idToken(response.idToken()).
                     environment(requestAuthority.host()).
                     expiresOn(currTimestampSec + response.getExpiresIn()).
                     extExpiresOn(response.getExtExpiresIn() > 0 ? currTimestampSec + response.getExtExpiresIn() : 0).

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenResponse.java
@@ -3,15 +3,9 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.token.AccessToken;
-import com.nimbusds.oauth2.sdk.token.RefreshToken;
-import com.nimbusds.oauth2.sdk.util.JSONObjectUtils;
-import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
-import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
-import net.minidev.json.JSONObject;
+import java.util.Map;
 
-class TokenResponse extends OIDCTokenResponse {
+class TokenResponse {
 
     private String scope;
     private String clientInfo;
@@ -19,92 +13,29 @@ class TokenResponse extends OIDCTokenResponse {
     private long extExpiresIn;
     private String foci;
     private long refreshIn;
+    private String accessToken;
+    private String idToken;
+    private String refreshToken;
 
-    TokenResponse(final AccessToken accessToken, final RefreshToken refreshToken, final String idToken,
-                  final String scope, String clientInfo, long expiresIn, long extExpiresIn, String foci,
-                  long refreshIn) {
-        super(new OIDCTokens(idToken, accessToken, refreshToken));
-        this.scope = scope;
-        this.clientInfo = clientInfo;
-        this.expiresIn = expiresIn;
-        this.extExpiresIn = extExpiresIn;
-        this.refreshIn = refreshIn;
-        this.foci = foci;
+    TokenResponse(Map<String, String> jsonMap) {
+        this.accessToken = jsonMap.get("access_token");
+        this.idToken = jsonMap.get("id_token");
+        this.refreshToken = jsonMap.get("refresh_token");
+        this.scope = jsonMap.get("scope");
+        this.clientInfo = jsonMap.get("client_info");
+        this.expiresIn = StringHelper.isNullOrBlank(jsonMap.get("expires_in")) ? 0 : Long.parseLong(jsonMap.get("expires_in"));
+        this.extExpiresIn = StringHelper.isNullOrBlank(jsonMap.get("ext_expires_in")) ? 0 : Long.parseLong(jsonMap.get("ext_expires_in"));
+        this.refreshIn = StringHelper.isNullOrBlank(jsonMap.get("refresh_in")) ? 0: Long.parseLong(jsonMap.get("refresh_in"));
+        this.foci = jsonMap.get("foci");
     }
 
-    static TokenResponse parseHttpResponse(final HttpResponse httpResponse) throws ParseException {
+    static TokenResponse parseHttpResponse(final HttpResponse httpResponse) {
 
         if (httpResponse.statusCode() != HttpHelper.HTTP_STATUS_200) {
             throw MsalServiceExceptionFactory.fromHttpResponse(httpResponse);
         }
 
-        final JSONObject jsonObject = httpResponse.getBodyAsJson();
-
-        return parseJsonObject(jsonObject);
-    }
-
-    static Long getLongValue(JSONObject jsonObject, String key) throws ParseException {
-        Object value = jsonObject.get(key);
-
-        if (value instanceof Long) {
-            return JSONObjectUtils.getLong(jsonObject, key);
-        } else {
-            return Long.parseLong(JSONObjectUtils.getString(jsonObject, key));
-        }
-    }
-
-    static TokenResponse parseJsonObject(final JSONObject jsonObject)
-            throws ParseException {
-
-        // In same cases such as client credentials there isn't an id token. Instead of a null value
-        // use an empty string in order to avoid an IllegalArgumentException from OIDCTokens.
-        String idTokenValue = "";
-        if (jsonObject.containsKey("id_token")) {
-            idTokenValue = JSONObjectUtils.getString(jsonObject, "id_token");
-        }
-
-        // Parse value
-        String scopeValue = null;
-        if (jsonObject.containsKey("scope")) {
-            scopeValue = JSONObjectUtils.getString(jsonObject, "scope");
-        }
-
-        String clientInfo = null;
-        if (jsonObject.containsKey("client_info")) {
-            clientInfo = JSONObjectUtils.getString(jsonObject, "client_info");
-        }
-
-        long expiresIn = 0;
-        if (jsonObject.containsKey("expires_in")) {
-            expiresIn = getLongValue(jsonObject, "expires_in");
-        }
-
-        long ext_expires_in = 0;
-        if (jsonObject.containsKey("ext_expires_in")) {
-            ext_expires_in = getLongValue(jsonObject, "ext_expires_in");
-        }
-
-        String foci = null;
-        if (jsonObject.containsKey("foci")) {
-            foci = JSONObjectUtils.getString(jsonObject, "foci");
-        }
-
-        long refreshIn = 0;
-        if (jsonObject.containsKey("refresh_in")) {
-            refreshIn = getLongValue(jsonObject, "refresh_in");
-        }
-
-        try {
-            final AccessToken accessToken = AccessToken.parse(jsonObject);
-            final RefreshToken refreshToken = RefreshToken.parse(jsonObject);
-            return new TokenResponse(accessToken, refreshToken, idTokenValue, scopeValue, clientInfo,
-                    expiresIn, ext_expires_in, foci, refreshIn);
-        } catch (ParseException e) {
-            throw new MsalClientException("Invalid or missing token, could not parse. If using B2C, information on a potential B2C issue and workaround can be found here: https://aka.ms/msal4j-b2c-known-issues",
-                    AuthenticationErrorCode.INVALID_JSON);
-        } catch (Exception e) {
-            throw new MsalClientException(e);
-        }
+        return new TokenResponse(httpResponse.getBodyAsMap());
     }
 
     String getScope() {
@@ -129,5 +60,17 @@ class TokenResponse extends OIDCTokenResponse {
 
     long getRefreshIn() {
         return this.refreshIn;
+    }
+
+    public String accessToken() {
+        return accessToken;
+    }
+
+    public String idToken() {
+        return idToken;
+    }
+
+    public String refreshToken() {
+        return refreshToken;
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
@@ -158,7 +158,7 @@ class CacheFormatTests {
         doReturn(msalOAuthHttpRequest).when(request).createOauthHttpRequest();
         doReturn(httpResponse).when(msalOAuthHttpRequest).send();
         doReturn(200).when(httpResponse).statusCode();
-        doReturn(JSONObjectUtils.parse(tokenResponse)).when(httpResponse).getBodyAsJson();
+        doReturn(TestHelper.convertJsonToMap((tokenResponse))).when(httpResponse).getBodyAsMap();
 
         final AuthenticationResult result = request.executeTokenRequest();
 
@@ -186,12 +186,22 @@ class CacheFormatTests {
         String valueExpected = readResource(folder + AT_CACHE_ENTITY);
 
         JSONObject tokenResponseJsonObj = JSONObjectUtils.parse(tokenResponse);
-        long expireIn = TokenResponse.getLongValue(tokenResponseJsonObj, "expires_in");
+        long expireIn = getLongValue(tokenResponseJsonObj, "expires_in");
 
-        long extExpireIn = TokenResponse.getLongValue(tokenResponseJsonObj, "ext_expires_in");
+        long extExpireIn = getLongValue(tokenResponseJsonObj, "ext_expires_in");
 
         JSONAssert.assertEquals(valueExpected, valueActual,
                 new DynamicTimestampsComparator(JSONCompareMode.STRICT, expireIn, extExpireIn));
+    }
+
+    static Long getLongValue(JSONObject jsonObject, String key) throws ParseException {
+        Object value = jsonObject.get(key);
+
+        if (value instanceof Long) {
+            return JSONObjectUtils.getLong(jsonObject, key);
+        } else {
+            return Long.parseLong(JSONObjectUtils.getString(jsonObject, key));
+        }
     }
 
     private void validateRefreshTokenCacheEntity(String folder, TokenCache tokenCache)

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
@@ -158,7 +158,7 @@ class CacheFormatTests {
         doReturn(msalOAuthHttpRequest).when(request).createOauthHttpRequest();
         doReturn(httpResponse).when(msalOAuthHttpRequest).send();
         doReturn(200).when(httpResponse).statusCode();
-        doReturn(TestHelper.convertJsonToMap((tokenResponse))).when(httpResponse).getBodyAsMap();
+        doReturn(JsonHelper.convertJsonToMap((tokenResponse))).when(httpResponse).getBodyAsMap();
 
         final AuthenticationResult result = request.executeTokenRequest();
 

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/RequestThrottlingTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/RequestThrottlingTest.java
@@ -98,7 +98,7 @@ class RequestThrottlingTest {
         switch (responseType) {
             case RETRY_AFTER_HEADER:
                 httpResponse.statusCode(HTTPResponse.SC_OK);
-                httpResponse.body(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE);
+                httpResponse.body(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE_ID_AND_ACCESS);
 
                 headers.put("Retry-After", Arrays.asList(THROTTLE_IN_SEC.toString()));
                 break;

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestConfiguration.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestConfiguration.java
@@ -43,7 +43,7 @@ public final class TestConfiguration {
 
     public final static String AAD_PREFERRED_NETWORK_ENV_ALIAS = "login.microsoftonline.com";
 
-    public final static String TOKEN_ENDPOINT_OK_RESPONSE = "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6I"
+    public final static String TOKEN_ENDPOINT_OK_RESPONSE_ID_AND_ACCESS = "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6I"
             + "k5HVEZ2ZEstZnl0aEV1THdqcHdBSk9NOW4tQSJ9.eyJhdWQiOiJiN2E2NzFkOC1hNDA4LTQyZmYtODZlMC1hYWY0NDdmZDE3YzQiLCJpc3MiOiJod"
             + "HRwczovL3N0cy53aW5kb3dzLm5ldC8zMGJhYTY2Ni04ZGY4LTQ4ZTctOTdlNi03N2NmZDA5OTU5NjMvIiwiaWF0IjoxMzkzODQ0NTA0LCJuYmYiOj"
             + "EzOTM4NDQ1MDQsImV4cCI6MTM5Mzg0ODQwNCwidmVyIjoiMS4wIiwidGlkIjoiMzBiYWE2NjYtOGRmOC00OGU3LTk3ZTYtNzdjZmQwOTk1OTYzIiwi"
@@ -64,6 +64,21 @@ public final class TestConfiguration {
             "VAxNEJSUFdybjQiLA0KICAidGlkIjogImY2NDVhZDkyLWUzOGQtNGQxYS1iNTEwLWQxYjA5YTc0YThjYSIsDQogICJ1dGkiOiAiNm5jaVgwMlNNa2k5azc" +
             "zLUYxc1pBQSIsDQogICJ2ZXIiOiAiMi4wIg0KfQ==.e30=\", \"client_info\": \"eyJ1a" +
             "WQiOiI5ZjQ4ODBkOC04MGJhLTRjNDAtOTdiYy1mN2EyM2M3MDMwODQiLCJ1dGlkIjoiZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhIn0\"" +
+            "}";
+
+    public final static String TOKEN_ENDPOINT_OK_RESPONSE_ACCESS_ONLY = "{\"token_type\":\"Bearer\",\"expires_in\":3600," +
+            "\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik5HVEZ2ZEstZnl0aEV1THdqcHdBSk9NOW4tQSJ9" +
+            ".eyJhdWQiOiJiN2E2NzFkOC1hNDA4LTQyZmYtODZlMC1hYWY0NDdmZDE3YzQiLCJpc3MiOiJodRwczovL3N0cy53aW5kb3dzLm5ldC8" +
+            "zMGJhYTY2Ni04ZGY4LTQ4ZTctOTdlNi03N2NmZDA5OTU5NjMvIiwiaWF0IjoxMzkzODQ0NTA0LCJuYmYiOjEzOTM4NDQ1MDQsImV4cC" +
+            "I6MTM5Mzg0ODQwNCwidmVyIjoiMS4wIiwidGlkIjoiMzBiYWE2NjYtOGRmOC00OGU3LTk3ZTYtNzdjZmQwOTk1OTYzIiwib2lkIjoiN" +
+            "GY4NTk5ODktYTJmZi00MTFlLTkwNDgtYzMyMjI0N2FjNjJjIiwidXBuIjoiYWRtaW5AYWFsdGVzdHMub25taWNyb3NvZnQuY29tIiwi" +
+            "dW5pcXVlX25hbWUiOiJhZG1pbkBhYWx0ZXN0cy5vbm1pY3Jvc29mdC5jb20iLCJzdWIiOiJqQ0ttUENWWEFzblN1MVBQUzRWblo4c2V" +
+            "ONTR3U3F0cW1RkpGbW14SEF3IiwiZmFtaWx5X25hbWUiOiJBZG1pbiIsImdpdmVuX25hbWUiOiJBREFMVGVzdHMiLCJhcHBpZCI6Ijk" +
+            "wODNjY2I4LThhNDYtNDNlNy04NDM5LTFkNjk2ZGY5ODRhZSIsImFwcGlkYWNyIjoiMSIsInNjcCI6InVzZXJfaW1wZXJzb25hdGlvbi" +
+            "IsImFjciI6IjEifQ.lUfDlkLdNGuAGUukgTnS_uWeSFXljbhId1l9PDrr7AwOSbOzogLvO14TaU294T6HeOQ8e0dUAvxEAMvsK_800A" +
+            "-AGNvbHK363xDjgmu464ye3CQvwq73GoHkzuxILCJKo0DUj0_XsCpQ4TdkPepuhzaGc-zYsfMU1POuIOB87pzW7e_VDpCdxcN1fuk-7" +
+            "CECPQb8nrO0L8Du8y-TZDdTSe-i_A0Alv48Zll-6tDY9cxfAR0UyYKl_Kf45kuHAphCWwPsjUxv4rGHhgXZPRlKFq7bkXP2Es4ixCQz" +
+            "b3bVLLrtQaZjkQ1yn37ngJro8NR63EbHHjHTA9lRmf8KIQ\"" +
             "}";
 
     public final static String HTTP_ERROR_RESPONSE = "{\"error\":\"invalid_request\",\"error_description\":\"AADSTS90011: Request "

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestHelper.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestHelper.java
@@ -190,13 +190,4 @@ class TestHelper {
 
         return privateKey;
     }
-
-    static Map<String, String> convertJsonToMap(String jsonString) {
-        try (JsonReader reader = JsonProviders.createReader(jsonString)) {
-            reader.nextToken();
-            return reader.readMap(JsonReader::getString);
-        } catch (IOException e) {
-            throw new MsalClientException("Could not parse JSON from HttpResponse body: " + e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
-        }
-    }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestHelper.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestHelper.java
@@ -3,6 +3,8 @@
 
 package com.microsoft.aad.msal4j;
 
+import com.azure.json.JsonProviders;
+import com.azure.json.JsonReader;
 import com.nimbusds.jose.*;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.RSAKey;
@@ -187,5 +189,14 @@ class TestHelper {
         }
 
         return privateKey;
+    }
+
+    static Map<String, String> convertJsonToMap(String jsonString) {
+        try (JsonReader reader = JsonProviders.createReader(jsonString)) {
+            reader.nextToken();
+            return reader.readMap(JsonReader::getString);
+        } catch (IOException e) {
+            throw new MsalClientException("Could not parse JSON from HttpResponse body: " + e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
+        }
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
@@ -234,7 +234,7 @@ class TokenRequestExecutorTest {
 
         doReturn(msalOAuthHttpRequest).when(request).createOauthHttpRequest();
         doReturn(httpResponse).when(msalOAuthHttpRequest).send();
-        doReturn(TestHelper.convertJsonToMap(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE)).when(httpResponse).getBodyAsMap();
+        doReturn(JsonHelper.convertJsonToMap(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE_ID_AND_ACCESS)).when(httpResponse).getBodyAsMap();
 
         doReturn(200).when(httpResponse).statusCode();
 

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
@@ -5,7 +5,6 @@ package com.microsoft.aad.msal4j;
 
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.SerializeException;
-import com.nimbusds.oauth2.sdk.util.JSONObjectUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -235,7 +234,7 @@ class TokenRequestExecutorTest {
 
         doReturn(msalOAuthHttpRequest).when(request).createOauthHttpRequest();
         doReturn(httpResponse).when(msalOAuthHttpRequest).send();
-        doReturn(JSONObjectUtils.parse(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE)).when(httpResponse).getBodyAsJson();
+        doReturn(TestHelper.convertJsonToMap(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE)).when(httpResponse).getBodyAsMap();
 
         doReturn(200).when(httpResponse).statusCode();
 

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenResponseTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenResponseTest.java
@@ -3,77 +3,26 @@
 
 package com.microsoft.aad.msal4j;
 
-import java.text.ParseException;
-
-import com.nimbusds.jwt.JWT;
-import com.nimbusds.oauth2.sdk.token.AccessToken;
-import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
-import com.nimbusds.oauth2.sdk.token.RefreshToken;
-import com.nimbusds.oauth2.sdk.util.JSONObjectUtils;
-import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TokenResponseTest {
 
-    private final String idToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik5HVEZ2ZEstZnl0aEV1THdqcHdBSk9NOW4tQSJ9."
-            + "eyJhdWQiOiIyMTZlZjgxZC1mM2IyLTQ3ZDQtYWQyMS1hNGRmNDliNTZkZWUiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5l"
-            + "dC9kM2VhYjEzMi1iM2Y3LTRkNzktOTM5Yy0zMDIyN2FlYjhjMjYvIiwiaWF0IjoxMzkzNDk2MDM3LCJuYmYiOjEzOTM0OTYwMzcsI"
-            + "mV4cCI6MTM5MzQ5OTkzNywidmVyIjoiMS4wIiwidGlkIjoiZDNlYWIxMzItYjNmNy00ZDc5LTkzOWMtMzAyMjdhZWI4YzI2Iiwib2l"
-            + "kIjoiMzZiNjE4MTMtM2EyYi00NTA4LWFlOGQtZmM3NTQyMDE3NTlhIiwidXBuIjoibWVAa2FuaXNoa3BhbndhcmhvdG1haWwub25ta"
-            + "WNyb3NvZnQuY29tIiwidW5pcXVlX25hbWUiOiJtZUBrYW5pc2hrcGFud2FyaG90bWFpbC5vbm1pY3Jvc29mdC5jb20iLCJzdWIiOiJ"
-            + "mZU40RU4wTW1vQ3ZubFZoRk1KeWozMzRSd0NaTGxrdTFfMVQ1VlNSN0xrIiwiZmFtaWx5X25hbWUiOiJQYW53YXIiLCJnaXZlbl9uYW"
-            + "1lIjoiS2FuaXNoayIsIm5vbmNlIjoiYTM1OWY0MGItNDJhOC00YTRjLTk2YWMtMTE0MjRhZDk2N2U5IiwiY19oYXNoIjoib05kOXE1e"
-            + "m1fWTZQaUNpYTg1MDZUQSJ9.iyGfoL0aKai-rZVGFwaCYm73h2Dk93M80CRAOoIwlxAKfGrQ2YDbvAPIvlQUrNQacqzenmkJvVEMqXT"
-            + "OYO5teyweUkxruod_iMgmhC6RZZZ603vMoqItUVu8c-4Y3KIEweRi17BYjdR2_tEowPlcEteRY52nwCmiNJRQnkqnQ2aZP89Jzhb9qw"
-            + "_G3CeYsOmV4f7jUp7anDT9hae7eGuvdUAf4LTDD6hFTBJP8MsyuMD6DkgBytlSxaXXJBKBJ5r5XPHdtStCTNF7edktlSufA2owTWVGw"
-            + "gWpKmnue_2Mgl3jBozTSJJ34r-R6lnWWeN6lqZ2Svw7saI5pmPtC8OZbw";
-
-    private final long expiresIn = 12345678910L;
-    private final long extExpiresIn = 12345678910L;
-    private final long refreshIn = 0;
-
     @Test
-    public void testConstructor() throws ParseException {
-        final TokenResponse response = new TokenResponse(
-                new BearerAccessToken("access_token"), new RefreshToken(
-                "refresh_token"), idToken, null, null, expiresIn, extExpiresIn, null, refreshIn);
+    void testConstructor() {
+        final Map<String, String> jsonMap = TestHelper.convertJsonToMap(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE);
+        final TokenResponse response = new TokenResponse(TestHelper.convertJsonToMap(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE));
         assertNotNull(response);
-        OIDCTokens tokens = response.getOIDCTokens();
-        assertNotNull(tokens);
-        final JWT jwt = tokens.getIDToken();
-        assertTrue(jwt.getJWTClaimsSet().getClaims().size() >= 0);
-    }
-
-    @Test
-    public void testParseJsonObject()
-            throws com.nimbusds.oauth2.sdk.ParseException {
-        final TokenResponse response = TokenResponse
-                .parseJsonObject(JSONObjectUtils
-                        .parse(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE));
-        assertNotNull(response);
-        OIDCTokens tokens = response.getOIDCTokens();
-        assertNotNull(tokens);
-        assertNotNull(tokens.getIDToken());
-        assertFalse(StringHelper.isBlank(tokens.getIDTokenString()));
-        assertFalse(StringHelper.isBlank(response.getScope()));
-    }
-
-    @Test
-    public void testEmptyIdToken() {
-        final TokenResponse response = new TokenResponse(
-                new BearerAccessToken(idToken),
-                new RefreshToken("refresh_token"),
-                "", null, null, expiresIn, extExpiresIn, null, refreshIn);
-
-        assertNotNull(response);
-        OIDCTokens tokens = response.getOIDCTokens();
-        assertNotNull(tokens);
-        final AccessToken accessToken = tokens.getAccessToken();
-        assertNotNull(accessToken);
+        assertEquals(jsonMap.get("access_token"), response.accessToken());
+        assertEquals(jsonMap.get("id_token"), response.idToken());
+        assertEquals(jsonMap.get("client_info"), response.getClientInfo());
+        assertEquals(jsonMap.get("scope"), response.getScope());
+        assertEquals(jsonMap.get("expires_in"), Long.toString(response.getExpiresIn()));
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenResponseTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenResponseTest.java
@@ -10,19 +10,31 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TokenResponseTest {
 
     @Test
-    void testConstructor() {
-        final Map<String, String> jsonMap = TestHelper.convertJsonToMap(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE);
-        final TokenResponse response = new TokenResponse(TestHelper.convertJsonToMap(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE));
+    void testConstructor_PublicResponse() {
+        final Map<String, String> jsonMap = JsonHelper.convertJsonToMap(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE_ID_AND_ACCESS);
+        final TokenResponse response = new TokenResponse(JsonHelper.convertJsonToMap(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE_ID_AND_ACCESS));
         assertNotNull(response);
         assertEquals(jsonMap.get("access_token"), response.accessToken());
         assertEquals(jsonMap.get("id_token"), response.idToken());
         assertEquals(jsonMap.get("client_info"), response.getClientInfo());
         assertEquals(jsonMap.get("scope"), response.getScope());
+        assertEquals(jsonMap.get("expires_in"), Long.toString(response.getExpiresIn()));
+    }
+
+    @Test
+    void testConstructor_CLientCredentialResponse() {
+        final Map<String, String> jsonMap = JsonHelper.convertJsonToMap(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE_ACCESS_ONLY);
+        final TokenResponse response = new TokenResponse(JsonHelper.convertJsonToMap(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE_ACCESS_ONLY));
+        assertNotNull(response);
+        assertEquals(jsonMap.get("access_token"), response.accessToken());
+        assertNull(response.idToken());
+        assertNull(response.getClientInfo());
         assertEquals(jsonMap.get("expires_in"), Long.toString(response.getExpiresIn()));
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/UIRequiredCacheTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/UIRequiredCacheTest.java
@@ -89,7 +89,7 @@ class UIRequiredCacheTest {
         IHttpClient httpClientMock = mock(IHttpClient.class);
 
         HttpResponse httpResponse =
-                getHttpResponse(HTTPResponse.SC_OK, TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE);
+                getHttpResponse(HTTPResponse.SC_OK, TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE_ID_AND_ACCESS);
         lenient().doReturn(httpResponse).when(httpClientMock).send(any());
 
         httpResponse = getHttpResponse(HTTPResponse.SC_UNAUTHORIZED,


### PR DESCRIPTION
This PR removes usage of several com.nimbusds.oauth2 classes, as per https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/909

com.nimbusds.oauth2's OIDCTokens, OIDCTokenResponse, AccessToken, and RefreshToken were removed, as well as various smaller util classes that were used with them.

To replace them, this PR does the following:
- Refactor MSAL Java's existing `HttpResponse` class to cover the behavior of Nimbus's `HTTPResponse`, and refactor it to use com.azure.json for JSON instead of com.nimbusds.oauth2
- Refactor `TokenResponse` to deal with tokens as simple Strings, rather than use Nimbus's various token-related classes
- Refactor `TokenRequestExecutor` to use MSAL Java's `HttpResponse` instead of Nimbus's `HTTPResponse`
- Adjust unit test's HTTP mocking to handle the above changes

Note: this PR builds off the changes made in https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/927, so that must be merged in first