### PR TITLE
Add APIs to add client capabilities and claims

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByManagedIdentitySupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByManagedIdentitySupplier.java
@@ -52,6 +52,7 @@ class AcquireTokenByManagedIdentitySupplier extends AuthenticationResultSupplier
             SilentParameters parameters = SilentParameters
                     .builder(scopes)
                     .tenant(managedIdentityParameters.tenant())
+                    .claims(managedIdentityParameters.claims())
                     .build();
 
             RequestContext context = new RequestContext(

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
@@ -103,15 +103,16 @@ public class ManagedIdentityApplication extends AbstractApplicationBase implemen
         }
 
         /**
-         * Sets client capabilities for the application.
+         * Informs the token issuer that the application is able to perform complex authentication actions.
+         * For example, "cp1" means that the application is able to perform conditional access evaluation,
+         * because the application has been setup to parse WWW-Authenticate headers associated with a 401 response from the protected APIs,
+         * and to retry the request with claims API.
          * 
-         * @param clientCapabilities List of client capabilities to be requested
-         * @return instance of Builder of ManagedIdentityApplication
+         * @param clientCapabilities a list of capabilities (e.g., ["cp1"]) recognized by the token service.
+         * @return instance of Builder of ManagedIdentityApplication.
          */
         public Builder clientCapabilities(List<String> clientCapabilities) {
-            if (clientCapabilities != null) {
-                this.clientCapabilities = clientCapabilities;
-            }
+            this.clientCapabilities = clientCapabilities;
             return self();
         }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
@@ -5,6 +5,9 @@ package com.microsoft.aad.msal4j;
 
 import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -56,6 +59,7 @@ public class ManagedIdentityApplication extends AbstractApplicationBase implemen
     public ManagedIdentityId getManagedIdentityId() {
         return this.managedIdentityId;
     }
+    
     @Override
     public CompletableFuture<IAuthenticationResult> acquireTokenForManagedIdentity(ManagedIdentityParameters managedIdentityParameters)
             throws Exception {
@@ -86,6 +90,7 @@ public class ManagedIdentityApplication extends AbstractApplicationBase implemen
 
         private String resource;
         private ManagedIdentityId managedIdentityId;
+        private List<String> clientCapabilities;
 
         private Builder(ManagedIdentityId managedIdentityId) {
             super(managedIdentityId.getIdType() == ManagedIdentityIdType.SYSTEM_ASSIGNED ?
@@ -99,9 +104,21 @@ public class ManagedIdentityApplication extends AbstractApplicationBase implemen
             return self();
         }
 
+        /**
+         * Sets client capabilities for the application.
+         * 
+         * @param clientCapabilities List of client capabilities to be requested
+         * @return instance of Builder of ManagedIdentityApplication
+         */
+        public Builder clientCapabilities(List<String> clientCapabilities) {
+            if (clientCapabilities != null) {
+                this.clientCapabilities = clientCapabilities;
+            }
+            return self();
+        }
+
         @Override
         public ManagedIdentityApplication build() {
-
             return new ManagedIdentityApplication(this);
         }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
@@ -5,9 +5,7 @@ package com.microsoft.aad.msal4j;
 
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityParameters.java
@@ -3,7 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
-import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityParameters.java
@@ -4,7 +4,6 @@
 package com.microsoft.aad.msal4j;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -30,7 +29,7 @@ public class ManagedIdentityParameters implements IAcquireTokenParameters {
 
     @Override
     public ClaimsRequest claims() {
-        return (claims != null) ? ClaimsRequest.fromJsonString(claims) : null;
+        return (claims != null) ? ClaimsRequest.formatAsClaimsRequest(claims) : null;
     }
 
     @Override

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityParameters.java
@@ -30,8 +30,7 @@ public class ManagedIdentityParameters implements IAcquireTokenParameters {
     @Override
     public ClaimsRequest claims() {
         if (claims == null || claims.isEmpty()) {
-            throw new MsalClientException("Claims cannot be null or empty",
-                                         AuthenticationErrorCode.INVALID_JSON);
+            return null;
         }
 
         try {
@@ -108,6 +107,8 @@ public class ManagedIdentityParameters implements IAcquireTokenParameters {
          * @return this builder instance
          */
         public ManagedIdentityParametersBuilder claims(String claims) {
+            ParameterValidationUtils.validateNotBlank("claims", claims);
+
             this.claims = claims;
             return this;
         }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityParameters.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -14,10 +15,12 @@ public class ManagedIdentityParameters implements IAcquireTokenParameters {
 
     String resource;
     boolean forceRefresh;
+    String claims;
 
-    private ManagedIdentityParameters(String resource, boolean forceRefresh) {
+    private ManagedIdentityParameters(String resource, boolean forceRefresh, String claims) {
         this.resource = resource;
         this.forceRefresh = forceRefresh;
+        this.claims = claims;
     }
 
     @Override
@@ -27,7 +30,7 @@ public class ManagedIdentityParameters implements IAcquireTokenParameters {
 
     @Override
     public ClaimsRequest claims() {
-        return null;
+        return (claims != null) ? ClaimsRequest.fromJsonString(claims) : null;
     }
 
     @Override
@@ -69,6 +72,7 @@ public class ManagedIdentityParameters implements IAcquireTokenParameters {
     public static class ManagedIdentityParametersBuilder {
         private String resource;
         private boolean forceRefresh;
+        private String claims;
 
         ManagedIdentityParametersBuilder() {
         }
@@ -83,8 +87,13 @@ public class ManagedIdentityParameters implements IAcquireTokenParameters {
             return this;
         }
 
+        public ManagedIdentityParametersBuilder claims(String claims) {
+            this.claims = claims;
+            return this;
+        }
+
         public ManagedIdentityParameters build() {
-            return new ManagedIdentityParameters(this.resource, this.forceRefresh);
+            return new ManagedIdentityParameters(this.resource, this.forceRefresh, this.claims);
         }
 
         public String toString() {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityParameters.java
@@ -29,7 +29,18 @@ public class ManagedIdentityParameters implements IAcquireTokenParameters {
 
     @Override
     public ClaimsRequest claims() {
-        return (claims != null) ? ClaimsRequest.formatAsClaimsRequest(claims) : null;
+        if (claims == null || claims.isEmpty()) {
+            throw new MsalClientException("Claims cannot be null or empty",
+                                         AuthenticationErrorCode.INVALID_JSON);
+        }
+
+        try {
+            return ClaimsRequest.formatAsClaimsRequest(claims);
+        } catch (Exception ex) {
+            // Log the exception if the claims JSON is invalid
+            throw new MsalClientException("Failed to parse claims JSON: " + ex.getMessage(),
+                                         AuthenticationErrorCode.INVALID_JSON);
+        }
     }
 
     @Override
@@ -86,6 +97,16 @@ public class ManagedIdentityParameters implements IAcquireTokenParameters {
             return this;
         }
 
+        /**
+         * Instructs the SDK to bypass any token caches and to request new tokens with an additional claims challenge.
+         * The claims challenge string is opaque to applications and should not be parsed.
+         * The claims challenge string is issued either by the STS as part of an error response or by the resource,
+         * as part of an HTTP 401 response, in the WWW-Authenticate header.
+         * For more details see https://learn.microsoft.com/entra/identity-platform/app-resilience-continuous-access-evaluation?tabs=dotnet
+         *
+         * @param claims a valid JSON string representing additional claims
+         * @return this builder instance
+         */
         public ManagedIdentityParametersBuilder claims(String claims) {
             this.claims = claims;
             return this;

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTestDataProvider.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTestDataProvider.java
@@ -114,4 +114,12 @@ class ManagedIdentityTestDataProvider {
                 Arguments.of(ManagedIdentitySourceType.IMDS, "", ManagedIdentitySourceType.DEFAULT_TO_IMDS),
                 Arguments.of(ManagedIdentitySourceType.SERVICE_FABRIC, ManagedIdentityTests.serviceFabricEndpoint, ManagedIdentitySourceType.SERVICE_FABRIC));
     }
+
+    public static Stream<Arguments> createInvalidClaimsData() {
+        return Stream.of(
+                Arguments.of("invalid json format"),
+                Arguments.of("{\"access_token\": }"),
+                Arguments.of("")
+        );
+    }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTestDataProvider.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTestDataProvider.java
@@ -118,8 +118,7 @@ class ManagedIdentityTestDataProvider {
     public static Stream<Arguments> createInvalidClaimsData() {
         return Stream.of(
                 Arguments.of("invalid json format"),
-                Arguments.of("{\"access_token\": }"),
-                Arguments.of("")
+                Arguments.of("{\"access_token\": }")
         );
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -738,8 +738,42 @@ class ManagedIdentityTests {
 
         ExecutionException ex = assertThrows(ExecutionException.class, future::get);
         assertInstanceOf(MsalClientException.class, ex.getCause());
+
         MsalClientException msalException = (MsalClientException) ex.getCause();
         assertEquals(AuthenticationErrorCode.INVALID_JSON, msalException.errorCode());
+
+        // Verify no HTTP requests were made for invalid claims
+        verify(httpClientMock, never()).send(any());
+    }
+
+    @Test
+    void managedIdentityTest_WithEmptyClaims() throws Exception {
+        IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(APP_SERVICE, appServiceEndpoint);
+        ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
+        DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+
+        miApp = ManagedIdentityApplication
+                .builder(ManagedIdentityId.systemAssigned())
+                .httpClient(httpClientMock)
+                .build();
+
+        try {
+            miApp.acquireTokenForManagedIdentity(
+                    ManagedIdentityParameters.builder(resource)
+                            .claims("")
+                            .build());
+        } catch (Exception exception) {
+            assert(exception instanceof IllegalArgumentException);
+        }
+
+        try {
+            miApp.acquireTokenForManagedIdentity(
+                    ManagedIdentityParameters.builder(resource)
+                            .claims(null)
+                            .build());
+        } catch (Exception exception) {
+            assert(exception instanceof IllegalArgumentException);
+        }
 
         // Verify no HTTP requests were made for invalid claims
         verify(httpClientMock, never()).send(any());

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -233,39 +233,6 @@ class ManagedIdentityTests {
     }
 
     @Test
-    void managedIdentityTest_TokenRevocation() throws Exception {
-        IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(ManagedIdentitySourceType.APP_SERVICE, appServiceEndpoint);
-        ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
-        DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
-
-        when(httpClientMock.send(expectedRequest(ManagedIdentitySourceType.APP_SERVICE, resource))).thenReturn(expectedResponse(200, getSuccessfulResponse(resource)));
-
-        miApp = ManagedIdentityApplication
-                .builder(ManagedIdentityId.systemAssigned())
-                .httpClient(httpClientMock)
-                .build();
-
-        // Clear caching to avoid cross test pollution.
-        miApp.tokenCache().accessTokens.clear();
-
-        IAuthenticationResult result = miApp.acquireTokenForManagedIdentity(
-                ManagedIdentityParameters.builder(resource)
-                        .build()).get();
-
-        assertNotNull(result.accessToken());
-
-        // Simulate token revocation by clearing the cache
-        miApp.tokenCache().accessTokens.clear();
-
-        result = miApp.acquireTokenForManagedIdentity(
-                ManagedIdentityParameters.builder(resource)
-                        .build()).get();
-
-        assertNotNull(result.accessToken());
-        verify(httpClientMock, times(2)).send(any());
-    }
-
-    @Test
     void managedIdentityTest_RefreshOnHalfOfExpiresOn() throws Exception {
         //All managed identity flows use the same AcquireTokenByManagedIdentitySupplier where refreshOn is set,
         //  so any of the MI options should let us verify that it's being set correctly

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -4,6 +4,7 @@
 package com.microsoft.aad.msal4j;
 
 import com.nimbusds.oauth2.sdk.util.URLUtils;
+import labapi.App;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -11,11 +12,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.SocketException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,56 +81,51 @@ class ManagedIdentityTests {
         Map<String, List<String>> queryParameters = new HashMap<>();
 
         switch (source) {
-            case APP_SERVICE: {
+            case APP_SERVICE:
                 endpoint = appServiceEndpoint;
-
-                queryParameters.put("api-version", singletonList("2019-08-01"));
-                queryParameters.put("resource", singletonList(resource));
-
+                queryParameters.put("api-version", Collections.singletonList("2019-08-01"));
+                queryParameters.put("resource", Collections.singletonList(resource));
                 headers.put("X-IDENTITY-HEADER", "secret");
                 break;
-            }
-            case CLOUD_SHELL: {
+            case CLOUD_SHELL:
                 endpoint = cloudShellEndpoint;
-
                 headers.put("ContentType", "application/x-www-form-urlencoded");
                 headers.put("Metadata", "true");
-
-                queryParameters.put("resource", singletonList(resource));
+                queryParameters.put("resource", Collections.singletonList(resource));
                 break;
-            }
-            case IMDS: {
+            case IMDS:
                 endpoint = IMDS_ENDPOINT;
-                queryParameters.put("api-version", singletonList("2018-02-01"));
-                queryParameters.put("resource", singletonList(resource));
+                queryParameters.put("api-version", Collections.singletonList("2018-02-01"));
+                queryParameters.put("resource", Collections.singletonList(resource));
                 headers.put("Metadata", "true");
                 break;
-            }
-            case AZURE_ARC: {
+            case AZURE_ARC:
                 endpoint = azureArcEndpoint;
-
-                queryParameters.put("api-version", singletonList("2019-11-01"));
-                queryParameters.put("resource", singletonList(resource));
-
+                queryParameters.put("api-version", Collections.singletonList("2019-11-01"));
+                queryParameters.put("resource", Collections.singletonList(resource));
                 headers.put("Metadata", "true");
                 break;
-            }
-            case SERVICE_FABRIC: {
+            case SERVICE_FABRIC:
                 endpoint = serviceFabricEndpoint;
-                queryParameters.put("api-version", singletonList("2019-07-01-preview"));
-                queryParameters.put("resource", singletonList(resource));
-
+                queryParameters.put("api-version", Collections.singletonList("2019-07-01-preview"));
+                queryParameters.put("resource", Collections.singletonList(resource));
                 headers.put("secret", "secret");
                 break;
-            }
+            case NONE:
+            case DEFAULT_TO_IMDS:
+                endpoint = IMDS_ENDPOINT;
+                queryParameters.put("api-version", Collections.singletonList("2018-02-01"));
+                queryParameters.put("resource", Collections.singletonList(resource));
+                headers.put("Metadata", "true");
+                break;
         }
 
         switch (id.getIdType()) {
             case CLIENT_ID:
-                queryParameters.put("client_id", singletonList(id.getUserAssignedId()));
+                queryParameters.put("client_id", Collections.singletonList(id.getUserAssignedId()));
                 break;
             case RESOURCE_ID:
-                queryParameters.put("mi_res_id", singletonList(id.getUserAssignedId()));
+                queryParameters.put("mi_res_id", Collections.singletonList(id.getUserAssignedId()));
                 break;
             case OBJECT_ID:
                 queryParameters.put("object_id", singletonList(id.getUserAssignedId()));
@@ -314,9 +312,10 @@ class ManagedIdentityTests {
         miApp.tokenCache().accessTokens.clear();
 
         try {
-            IAuthenticationResult result = miApp.acquireTokenForManagedIdentity(
+            miApp.acquireTokenForManagedIdentity(
                     ManagedIdentityParameters.builder(resource)
                             .build()).get();
+            fail("MsalServiceException is expected but not thrown.");
         } catch (Exception e) {
             assertNotNull(e);
             assertNotNull(e.getCause());
@@ -325,10 +324,7 @@ class ManagedIdentityTests {
             MsalServiceException msalMsiException = (MsalServiceException) e.getCause();
             assertEquals(source.name(), msalMsiException.managedIdentitySource());
             assertEquals(MsalError.USER_ASSIGNED_MANAGED_IDENTITY_NOT_SUPPORTED, msalMsiException.errorCode());
-            return;
         }
-
-        fail("MsalServiceException is expected but not thrown.");
     }
 
     @ParameterizedTest
@@ -637,6 +633,56 @@ class ManagedIdentityTests {
 
         miApp = ManagedIdentityApplication
                 .builder(ManagedIdentityId.systemAssigned())
+                .httpClient(httpClientMock)
+                .build();
+
+        // Clear caching to avoid cross test pollution.
+        miApp.tokenCache().accessTokens.clear();
+
+        String claimsJson = "{\"default\":\"claim\"}";
+
+        // First call, get the token from the identity provider.
+        IAuthenticationResult result = miApp.acquireTokenForManagedIdentity(
+            ManagedIdentityParameters.builder(resource)
+                .build()).get();
+
+        assertNotNull(result.accessToken());
+        assertEquals(TokenSource.IDENTITY_PROVIDER, result.metadata().tokenSource());
+
+        // Second call, get the token from the cache without passing the claims.
+        result = miApp.acquireTokenForManagedIdentity(
+                ManagedIdentityParameters.builder(resource)
+                        .build()).get();
+
+        assertNotNull(result.accessToken());
+        assertEquals(TokenSource.CACHE, result.metadata().tokenSource());
+
+        // Third call, when claims are passed bypass the cache.
+        result = miApp.acquireTokenForManagedIdentity(
+                ManagedIdentityParameters.builder(resource)
+                        .claims(claimsJson)
+                        .build()).get();
+
+        assertNotNull(result.accessToken());
+        assertEquals(TokenSource.IDENTITY_PROVIDER, result.metadata().tokenSource());
+
+        verify(httpClientMock, times(2)).send(any());
+    }
+
+    @ParameterizedTest
+    @MethodSource("com.microsoft.aad.msal4j.ManagedIdentityTestDataProvider#createDataError")
+    void managedIdentity_ClaimsAndCapabilities(ManagedIdentitySourceType source, String endpoint) throws Exception {
+        IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(source, endpoint);
+        ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
+        DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+        if (source == SERVICE_FABRIC) {
+            ServiceFabricManagedIdentitySource.setHttpClient(httpClientMock);
+        }
+
+        when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(200, getSuccessfulResponse(resource)));
+
+        miApp = ManagedIdentityApplication
+                .builder(ManagedIdentityId.systemAssigned())
                 .clientCapabilities(singletonList("cp1"))
                 .httpClient(httpClientMock)
                 .build();
@@ -645,13 +691,58 @@ class ManagedIdentityTests {
         miApp.tokenCache().accessTokens.clear();
 
         String claimsJson = "{\"default\":\"claim\"}";
+        // First call, get the token from the identity provider.
         IAuthenticationResult result = miApp.acquireTokenForManagedIdentity(
-            ManagedIdentityParameters.builder(resource)
-                .claims(claimsJson)
-                .build()).get();
+                ManagedIdentityParameters.builder(resource)
+                        .build()).get();
 
         assertNotNull(result.accessToken());
-        verify(httpClientMock, times(1)).send(any());
+        assertEquals(TokenSource.IDENTITY_PROVIDER, result.metadata().tokenSource());
+
+        // Second call, get the token from the cache without passing the claims.
+        result = miApp.acquireTokenForManagedIdentity(
+                ManagedIdentityParameters.builder(resource)
+                        .build()).get();
+
+        assertNotNull(result.accessToken());
+        assertEquals(TokenSource.CACHE, result.metadata().tokenSource());
+
+        // Third call, when claims are passed bypass the cache.
+        result = miApp.acquireTokenForManagedIdentity(
+                ManagedIdentityParameters.builder(resource)
+                        .claims(claimsJson)
+                        .build()).get();
+
+        assertNotNull(result.accessToken());
+        assertEquals(TokenSource.IDENTITY_PROVIDER, result.metadata().tokenSource());
+
+        verify(httpClientMock, times(2)).send(any());
+    }
+
+    @ParameterizedTest
+    @MethodSource("com.microsoft.aad.msal4j.ManagedIdentityTestDataProvider#createInvalidClaimsData")
+    void managedIdentity_InvalidClaims(String claimsJson) throws Exception {
+        IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(APP_SERVICE, appServiceEndpoint);
+        ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
+        DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+
+        miApp = ManagedIdentityApplication
+                .builder(ManagedIdentityId.systemAssigned())
+                .httpClient(httpClientMock)
+                .build();
+
+        CompletableFuture<IAuthenticationResult> future = miApp.acquireTokenForManagedIdentity(
+                ManagedIdentityParameters.builder(resource)
+                        .claims(claimsJson)
+                        .build());
+
+        ExecutionException ex = assertThrows(ExecutionException.class, future::get);
+        assertInstanceOf(MsalClientException.class, ex.getCause());
+        MsalClientException msalException = (MsalClientException) ex.getCause();
+        assertEquals(AuthenticationErrorCode.INVALID_JSON, msalException.errorCode());
+
+        // Verify no HTTP requests were made for invalid claims
+        verify(httpClientMock, never()).send(any());
     }
 
     @Nested

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -28,6 +28,7 @@ import static com.microsoft.aad.msal4j.MsalErrorMessage.*;
 import static java.util.Collections.*;
 import static org.apache.http.HttpStatus.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -229,6 +230,39 @@ class ManagedIdentityTests {
 
         assertNotNull(result.accessToken());
         verify(httpClientMock, times(1)).send(any());
+    }
+
+    @Test
+    void managedIdentityTest_TokenRevocation() throws Exception {
+        IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(ManagedIdentitySourceType.APP_SERVICE, appServiceEndpoint);
+        ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
+        DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+
+        when(httpClientMock.send(expectedRequest(ManagedIdentitySourceType.APP_SERVICE, resource))).thenReturn(expectedResponse(200, getSuccessfulResponse(resource)));
+
+        miApp = ManagedIdentityApplication
+                .builder(ManagedIdentityId.systemAssigned())
+                .httpClient(httpClientMock)
+                .build();
+
+        // Clear caching to avoid cross test pollution.
+        miApp.tokenCache().accessTokens.clear();
+
+        IAuthenticationResult result = miApp.acquireTokenForManagedIdentity(
+                ManagedIdentityParameters.builder(resource)
+                        .build()).get();
+
+        assertNotNull(result.accessToken());
+
+        // Simulate token revocation by clearing the cache
+        miApp.tokenCache().accessTokens.clear();
+
+        result = miApp.acquireTokenForManagedIdentity(
+                ManagedIdentityParameters.builder(resource)
+                        .build()).get();
+
+        assertNotNull(result.accessToken());
+        verify(httpClientMock, times(2)).send(any());
     }
 
     @Test
@@ -576,6 +610,38 @@ class ManagedIdentityTests {
         // so calling acquireTokenForManagedIdentity with the same parameters in two different ManagedIdentityApplications
         // should return the same token
         assertEquals(resultMiApp1.accessToken(), resultMiApp2.accessToken());
+        verify(httpClientMock, times(1)).send(any());
+    }
+
+    // managedIdentityTest_WithClaims: Tests that acquiring a token with claims works correctly
+    @ParameterizedTest
+    @MethodSource("com.microsoft.aad.msal4j.ManagedIdentityTestDataProvider#createDataError")
+    void managedIdentityTest_WithClaims(ManagedIdentitySourceType source, String endpoint) throws Exception {
+        IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(source, endpoint);
+        ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
+        DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+        if (source == SERVICE_FABRIC) {
+            ServiceFabricManagedIdentitySource.setHttpClient(httpClientMock);
+        }
+
+        when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(200, getSuccessfulResponse(resource)));
+
+        miApp = ManagedIdentityApplication
+                .builder(ManagedIdentityId.systemAssigned())
+                .clientCapabilities(singletonList("cp1"))
+                .httpClient(httpClientMock)
+                .build();
+
+        // Clear caching to avoid cross test pollution.
+        miApp.tokenCache().accessTokens.clear();
+
+        String claimsJson = "{\"default\":\"claim\"}";
+        IAuthenticationResult result = miApp.acquireTokenForManagedIdentity(
+            ManagedIdentityParameters.builder(resource)
+                .claims(claimsJson)
+                .build()).get();
+
+        assertNotNull(result.accessToken());
         verify(httpClientMock, times(1)).send(any());
     }
 


### PR DESCRIPTION
Add APIs to the managed identity app and request to add client capabilities and claims. Bypass the cache when claims are passed.