### PR TITLE
Ensure Base64URL decoding is used

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -119,7 +119,7 @@ class TokenRequestExecutor {
             if (!StringHelper.isNullOrBlank(tokens.getIDTokenString())) {
                 String idTokenJson;
                 try {
-                    idTokenJson = new String(Base64.getDecoder().decode(tokens.getIDTokenString().split("\\.")[1]), StandardCharsets.UTF_8);
+                    idTokenJson = new String(Base64.getUrlDecoder().decode(tokens.getIDTokenString().split("\\.")[1]), StandardCharsets.UTF_8);
                 } catch (ArrayIndexOutOfBoundsException e) {
                     throw new MsalServiceException("Error parsing ID token, missing payload section. Ensure that the ID token is following the JWT format.",
                             AuthenticationErrorCode.INVALID_JWT);

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
@@ -27,8 +27,10 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.concurrent.ExecutionException;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -293,5 +295,45 @@ class TokenRequestExecutorTest {
         doReturn(402).when(httpResponse).getStatusCode();
 
         assertThrows(MsalException.class, request::executeTokenRequest);
+    }
+
+    @Test
+    void testBase64UrlEncoding() throws MalformedURLException, ExecutionException, InterruptedException {
+        DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+        ConfidentialClientApplication cca =
+                ConfidentialClientApplication.builder("clientId", ClientCredentialFactory.createFromSecret("password"))
+                        .authority("https://login.microsoftonline.com/tenant/")
+                        .instanceDiscovery(false)
+                        .validateAuthority(false)
+                        .httpClient(httpClientMock)
+                        .build();
+
+        //ID token payloads are parsed to get certain info to create Account and AccountCacheEntity objects, and the library must decode them using a Base64URL decoder.
+        HashMap<String, String> tokenParameters = new HashMap<>();
+        tokenParameters.put("preferred_username", "~nameWith~specialChars");
+        String encodedIDToken = TestHelper.createIdToken(tokenParameters);
+        try {
+            //TestHelper.createIdToken() should use Base64URL encoding, so first we prove that the encoded token it produces cannot be decoded with Base64 decoder
+            Base64.getDecoder().decode(encodedIDToken.split("\\.")[1]);
+
+            fail("IllegalArgumentException was expected but not thrown.");
+        } catch (IllegalArgumentException e) {
+            //Encoded token should have some "-" characters in it
+            assertTrue(e.getMessage().contains("Illegal base64 character 2d"));
+        }
+
+        //Now, send that encoded token through the library's token request flow, which will decode it using a Base64URL decoder
+        HashMap<String, String> responseParameters = new HashMap<>();
+        responseParameters.put("id_token", encodedIDToken);
+        responseParameters.put("access_token", "token");
+        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), 200);
+
+        OnBehalfOfParameters parameters = OnBehalfOfParameters.builder(Collections.singleton("someScopes"), new UserAssertion(TestHelper.signedAssertion)).build();
+        IAuthenticationResult result = cca.acquireToken(parameters).get();
+
+        //Ensure that the name was successfully parsed out of the encoded ID token
+        assertNotNull(result.idToken());
+        assertNotNull(result.account());
+        assertEquals("~nameWith~specialChars", result.account().username());
     }
 }


### PR DESCRIPTION
In https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/894, some of the nimbus dependency was removed to simplify how the tokens were handled by the library.

Unfortunately, as discovered by https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/922 and https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/937, the replacement code introduced a regression: despite the name, nimbus's `Base64Codec.decode()` was decoding them as Base64URL, not Base64. This was not caught during testing because none of the library's tests happened to produce an encoded token with characters that a Base64 decoder would not accept.

This PR fixes that bug by using `Base64.getUrlDecoder()` instead of `Base64.getDecoder()` in `TokenRequestExecutor.createAuthenticationResultFromOauthHttpResponse()`. In addition, it adds a unit tests showing the behavior is now correct:
- It uses `TestHelper.createIdToken()` to get an encoded token, and shows that token would throw an `IllegalArgumentException` if passed into `Base64.getDecoder()` like was used in the old code
- It then sends encoded token through a typical flow, and shows the token was successfully decoded by checking the username which would've caused an `IllegalArgumentException` in the old code