### PR TITLE
Represent query parameters with Map<String, String>

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
@@ -7,7 +7,6 @@ import javax.net.ssl.SSLSocketFactory;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
-import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -134,22 +133,22 @@ public abstract class AbstractClientApplicationBase extends AbstractApplicationB
 
         validateNotNull("parameters", parameters);
 
-        parameters.requestParameters.put("client_id", Collections.singletonList(this.clientId));
+        parameters.requestParameters.put("client_id", this.clientId);
 
         //If the client application has any client capabilities set, they must be merged into the claims parameter
         if (this.clientCapabilities != null) {
             if (parameters.requestParameters.containsKey("claims")) {
-                String claims = String.valueOf(parameters.requestParameters.get("claims").get(0));
+                String claims = String.valueOf(parameters.requestParameters.get("claims"));
                 String mergedClaimsCapabilities = JsonHelper.mergeJSONString(claims, this.clientCapabilities);
-                parameters.requestParameters.put("claims", Collections.singletonList(mergedClaimsCapabilities));
+                parameters.requestParameters.put("claims", mergedClaimsCapabilities);
             } else {
-                parameters.requestParameters.put("claims", Collections.singletonList(this.clientCapabilities));
+                parameters.requestParameters.put("claims", this.clientCapabilities);
             }
         }
 
         return parameters.createAuthorizationURL(
                 this.authenticationAuthority,
-                parameters.requestParameters());
+                parameters.requestParameters);
     }
 
     @Override

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractMsalAuthorizationGrant.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractMsalAuthorizationGrant.java
@@ -20,7 +20,7 @@ abstract class AbstractMsalAuthorizationGrant {
      *
      * @return A map contains the HTTP parameters
      */
-    abstract Map<String, List<String>> toParameters();
+    abstract Map<String, String> toParameters();
 
     static final String SCOPE_PARAM_NAME = "scope";
     static final String SCOPES_DELIMITER = " ";

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByAuthorizationGrantSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByAuthorizationGrantSupplier.java
@@ -3,8 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.nimbusds.jose.util.Base64URL;
-
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -101,24 +99,22 @@ class AcquireTokenByAuthorizationGrantSupplier extends AuthenticationResultSuppl
         }
     }
 
-    private Map<String, List<String>> getSAMLAuthGrantParameters(WSTrustResponse response) {
-        Map<String, List<String>> params = new LinkedHashMap<>();
+    private Map<String, String> getSAMLAuthGrantParameters(WSTrustResponse response) {
+        Map<String, String> params = new LinkedHashMap<>();
 
         if (response.isTokenSaml2()) {
-            params.put(GrantConstants.GRANT_TYPE_PARAMETER, Collections.singletonList(GrantConstants.SAML_2_BEARER));
+            params.put(GrantConstants.GRANT_TYPE_PARAMETER, GrantConstants.SAML_2_BEARER);
         } else {
-            params.put(GrantConstants.GRANT_TYPE_PARAMETER, Collections.singletonList(GrantConstants.SAML_1_1_BEARER));
+            params.put(GrantConstants.GRANT_TYPE_PARAMETER, GrantConstants.SAML_1_1_BEARER);
         }
 
-        params.put(GrantConstants.ASSERTION_PARAMETER, Collections.singletonList(new Base64URL(
-                Base64.getEncoder().encodeToString(response.getToken()
-                        .getBytes(StandardCharsets.UTF_8))).toString()));
+        params.put(GrantConstants.ASSERTION_PARAMETER, Base64.getUrlEncoder().encodeToString(response.getToken().getBytes(StandardCharsets.UTF_8)));
 
         return params;
     }
 
-    private Map<String, List<String>> getAuthorizationGrantIntegrated(String userName) throws Exception {
-        Map<String, List<String>> params;
+    private Map<String, String> getAuthorizationGrantIntegrated(String userName) throws Exception {
+        Map<String, String> params;
 
         String userRealmEndpoint = this.clientApplication.authenticationAuthority.
                 getUserRealmEndpoint(URLEncoder.encode(userName, StandardCharsets.UTF_8.name()));

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AppServiceManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AppServiceManagedIdentitySource.java
@@ -31,8 +31,8 @@ class AppServiceManagedIdentitySource extends AbstractManagedIdentitySource{
         managedIdentityRequest.headers.put(SECRET_HEADER_NAME, identityHeader);
 
         managedIdentityRequest.queryParameters = new HashMap<>();
-        managedIdentityRequest.queryParameters.put("api-version", Collections.singletonList(APP_SERVICE_MSI_API_VERSION));
-        managedIdentityRequest.queryParameters.put("resource", Collections.singletonList(resource));
+        managedIdentityRequest.queryParameters.put("api-version", APP_SERVICE_MSI_API_VERSION);
+        managedIdentityRequest.queryParameters.put("resource", resource);
 
         if (this.idType != null && !StringHelper.isNullOrBlank(this.userAssignedId)) {
             LOG.info("[Managed Identity] Adding user assigned ID to the request for App Service Managed Identity.");

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeRequest.java
@@ -17,17 +17,17 @@ class AuthorizationCodeRequest extends MsalRequest {
     }
 
     private static AbstractMsalAuthorizationGrant createMsalGrant(AuthorizationCodeParameters parameters) {
-        Map<String, List<String>> params = new LinkedHashMap<>();
+        Map<String, String> params = new LinkedHashMap<>();
 
-        params.put(GrantConstants.GRANT_TYPE_PARAMETER, Collections.singletonList(GrantConstants.AUTHORIZATION_CODE));
-        params.put("code", Collections.singletonList(parameters.authorizationCode()));
+        params.put(GrantConstants.GRANT_TYPE_PARAMETER, GrantConstants.AUTHORIZATION_CODE);
+        params.put("code", parameters.authorizationCode());
 
         if (parameters.redirectUri() != null) {
-            params.put("redirect_uri", Collections.singletonList(parameters.redirectUri().toString()));
+            params.put("redirect_uri", parameters.redirectUri().toString());
         }
 
         if (parameters.codeVerifier() != null) {
-            params.put("code_verifier", Collections.singletonList(parameters.codeVerifier()));
+            params.put("code_verifier", parameters.codeVerifier());
         }
 
         return new OAuthAuthorizationGrant(params, parameters.scopes(), parameters.claims());

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.nimbusds.oauth2.sdk.util.URLUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +35,7 @@ public class AuthorizationRequestUrlParameters {
 
     Map<String, String> extraQueryParameters;
 
-    Map<String, List<String>> requestParameters = new HashMap<>();
+    Map<String, String> requestParameters = new HashMap<>();
 
     Logger log = LoggerFactory.getLogger(AuthorizationRequestUrlParameters.class);
 
@@ -58,7 +57,7 @@ public class AuthorizationRequestUrlParameters {
     private AuthorizationRequestUrlParameters(Builder builder) {
         //required parameters
         this.redirectUri = builder.redirectUri;
-        requestParameters.put("redirect_uri", Collections.singletonList(this.redirectUri));
+        requestParameters.put("redirect_uri", this.redirectUri);
         this.scopes = builder.scopes;
 
         Set<String> scopesParam = new LinkedHashSet<>(AbstractMsalAuthorizationGrant.COMMON_SCOPES);
@@ -70,86 +69,86 @@ public class AuthorizationRequestUrlParameters {
         }
 
         this.scopes = scopesParam;
-        requestParameters.put("scope", Collections.singletonList(String.join(" ", scopesParam)));
-        requestParameters.put("response_type", Collections.singletonList("code"));
+        requestParameters.put("scope", String.join(" ", scopesParam));
+        requestParameters.put("response_type", "code");
 
         // Optional parameters
         if (builder.claims != null) {
             String claimsParam = String.join(" ", builder.claims);
-            requestParameters.put("claims", Collections.singletonList(claimsParam));
+            requestParameters.put("claims", claimsParam);
         }
 
         if (builder.claimsChallenge != null && builder.claimsChallenge.trim().length() > 0) {
             JsonHelper.validateJsonFormat(builder.claimsChallenge);
-            requestParameters.put("claims", Collections.singletonList(builder.claimsChallenge));
+            requestParameters.put("claims", builder.claimsChallenge);
         }
 
         if (builder.claimsRequest != null) {
             String claimsRequest = builder.claimsRequest.formatAsJSONString();
             //If there are other claims (such as part of a claims challenge), merge them with this claims request.
             if (requestParameters.get("claims") != null) {
-                claimsRequest = JsonHelper.mergeJSONString(claimsRequest, requestParameters.get("claims").get(0));
+                claimsRequest = JsonHelper.mergeJSONString(claimsRequest, requestParameters.get("claims"));
             }
-            requestParameters.put("claims", Collections.singletonList(claimsRequest));
+            requestParameters.put("claims", claimsRequest);
         }
 
         if (builder.codeChallenge != null) {
             this.codeChallenge = builder.codeChallenge;
-            requestParameters.put("code_challenge", Collections.singletonList(builder.codeChallenge));
+            requestParameters.put("code_challenge", builder.codeChallenge);
         }
 
         if (builder.codeChallengeMethod != null) {
             this.codeChallengeMethod = builder.codeChallengeMethod;
-            requestParameters.put("code_challenge_method", Collections.singletonList(builder.codeChallengeMethod));
+            requestParameters.put("code_challenge_method", builder.codeChallengeMethod);
         }
 
         if (builder.state != null) {
             this.state = builder.state;
-            requestParameters.put("state", Collections.singletonList(builder.state));
+            requestParameters.put("state", builder.state);
         }
 
         if (builder.nonce != null) {
             this.nonce = builder.nonce;
-            requestParameters.put("nonce", Collections.singletonList(builder.nonce));
+            requestParameters.put("nonce", builder.nonce);
         }
 
         if (builder.responseMode != null) {
             this.responseMode = builder.responseMode;
-            requestParameters.put("response_mode", Collections.singletonList(
-                    builder.responseMode.toString()));
+            requestParameters.put("response_mode",
+                    builder.responseMode.toString());
         } else {
             this.responseMode = ResponseMode.FORM_POST;
-            requestParameters.put("response_mode", Collections.singletonList(
-                    ResponseMode.FORM_POST.toString()));
+            requestParameters.put("response_mode",
+                    ResponseMode.FORM_POST.toString());
         }
 
         if (builder.loginHint != null) {
             this.loginHint = loginHint();
-            requestParameters.put("login_hint", Collections.singletonList(builder.loginHint));
+            requestParameters.put("login_hint", builder.loginHint);
 
             // For CCS routing
-            requestParameters.put(HttpHeaders.X_ANCHOR_MAILBOX, Collections.singletonList(
-                    String.format(HttpHeaders.X_ANCHOR_MAILBOX_UPN_FORMAT, builder.loginHint)));
+            requestParameters.put(HttpHeaders.X_ANCHOR_MAILBOX,
+                    String.format(HttpHeaders.X_ANCHOR_MAILBOX_UPN_FORMAT, builder.loginHint));
         }
 
         if (builder.domainHint != null) {
             this.domainHint = domainHint();
-            requestParameters.put("domain_hint", Collections.singletonList(builder.domainHint));
+            requestParameters.put("domain_hint", builder.domainHint);
         }
 
         if (builder.prompt != null) {
             this.prompt = builder.prompt;
-            requestParameters.put("prompt", Collections.singletonList(builder.prompt.toString()));
+            requestParameters.put("prompt", builder.prompt.toString());
         }
 
         if (builder.correlationId != null) {
             this.correlationId = builder.correlationId;
-            requestParameters.put("correlation_id", Collections.singletonList(builder.correlationId));
+            requestParameters.put("correlation_id", builder.correlationId);
         }
 
         if (builder.instanceAware) {
             this.instanceAware = builder.instanceAware;
-            requestParameters.put("instance_aware", Collections.singletonList(String.valueOf(instanceAware)));
+            requestParameters.put("instance_aware", String.valueOf(instanceAware));
         }
 
         if(null != builder.extraQueryParameters && !builder.extraQueryParameters.isEmpty()){
@@ -160,13 +159,13 @@ public class AuthorizationRequestUrlParameters {
                 if(requestParameters.containsKey(key)){
                     log.warn("A query parameter {} has been provided with values multiple times.", key);
                 }
-                requestParameters.put(key, Collections.singletonList(value));
+                requestParameters.put(key, value);
             }
         }
     }
 
     URL createAuthorizationURL(Authority authority,
-                               Map<String, List<String>> requestParameters) {
+                               Map<String, String> requestParameters) {
         URL authorizationRequestUrl;
         try {
             String authorizationCodeEndpoint;
@@ -178,7 +177,7 @@ public class AuthorizationRequestUrlParameters {
             }
 
             String uriString = authorizationCodeEndpoint + "?" +
-                    URLUtils.serializeParameters(requestParameters);
+                    StringHelper.serializeQueryParameters(requestParameters);
 
             authorizationRequestUrl = new URL(uriString);
         } catch (MalformedURLException ex) {
@@ -240,7 +239,7 @@ public class AuthorizationRequestUrlParameters {
     }
 
     public Map<String, List<String>> requestParameters() {
-        return this.requestParameters;
+        return StringHelper.convertToMultiValueMap(this.requestParameters);
     }
 
     public Logger log() {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AzureArcManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AzureArcManagedIdentitySource.java
@@ -83,8 +83,8 @@ class AzureArcManagedIdentitySource extends AbstractManagedIdentitySource{
         managedIdentityRequest.headers.put("Metadata", "true");
 
         managedIdentityRequest.queryParameters = new HashMap<>();
-        managedIdentityRequest.queryParameters.put("api-version", Collections.singletonList(ARC_API_VERSION));
-        managedIdentityRequest.queryParameters.put("resource", Collections.singletonList(resource));
+        managedIdentityRequest.queryParameters.put("api-version", ARC_API_VERSION);
+        managedIdentityRequest.queryParameters.put("resource", resource);
     }
 
     @Override

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCredentialRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCredentialRequest.java
@@ -28,9 +28,9 @@ class ClientCredentialRequest extends MsalRequest {
     }
 
     private static OAuthAuthorizationGrant createMsalGrant(ClientCredentialParameters parameters) {
-        Map<String, List<String>> params = new LinkedHashMap<>();
+        Map<String, String> params = new LinkedHashMap<>();
 
-        params.put(GrantConstants.GRANT_TYPE_PARAMETER, Collections.singletonList(GrantConstants.CLIENT_CREDENTIALS));
+        params.put(GrantConstants.GRANT_TYPE_PARAMETER, GrantConstants.CLIENT_CREDENTIALS);
 
         return new OAuthAuthorizationGrant(params, parameters.scopes(), parameters.claims());
     }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CloudShellManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CloudShellManagedIdentitySource.java
@@ -27,7 +27,7 @@ class CloudShellManagedIdentitySource extends AbstractManagedIdentitySource{
         managedIdentityRequest.headers.put("Metadata", "true");
 
         managedIdentityRequest.queryParameters = new HashMap<>();
-        managedIdentityRequest.queryParameters.put("resource", Collections.singletonList(resource));
+        managedIdentityRequest.queryParameters.put("resource", resource);
     }
 
     private CloudShellManagedIdentitySource(MsalRequest msalRequest, ServiceBundle serviceBundle, URI msiEndpoint)

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowRequest.java
@@ -3,12 +3,9 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.nimbusds.oauth2.sdk.util.URLUtils;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -55,28 +52,28 @@ class DeviceCodeFlowRequest extends MsalRequest {
     }
 
     void createAuthenticationGrant(DeviceCode deviceCode) {
-        final Map<String, List<String>> params = new LinkedHashMap<>();
+        final Map<String, String> params = new LinkedHashMap<>();
 
-        params.put(GrantConstants.GRANT_TYPE_PARAMETER, Collections.singletonList(GrantConstants.DEVICE_CODE));
-        params.put("device_code", Collections.singletonList(deviceCode.deviceCode()));
+        params.put(GrantConstants.GRANT_TYPE_PARAMETER, GrantConstants.DEVICE_CODE);
+        params.put("device_code", deviceCode.deviceCode());
 
         if (parameters.claims() != null) {
-            params.put("claims", Collections.singletonList(parameters.claims().formatAsJSONString()));
+            params.put("claims", parameters.claims().formatAsJSONString());
         }
 
         msalAuthorizationGrant = new OAuthAuthorizationGrant(params, Collections.singleton(deviceCode.scopes()), parameters.claims());
     }
 
     private String createQueryParams(String clientId) {
-        Map<String, List<String>> queryParameters = new HashMap<>();
-        queryParameters.put("client_id", Collections.singletonList(clientId));
+        Map<String, String> queryParameters = new HashMap<>();
+        queryParameters.put("client_id", clientId);
 
         String scopesParam = String.join(AbstractMsalAuthorizationGrant.SCOPES_DELIMITER, AbstractMsalAuthorizationGrant.COMMON_SCOPES) +
                 AbstractMsalAuthorizationGrant.SCOPES_DELIMITER + scopesStr;
 
-        queryParameters.put("scope", Collections.singletonList(scopesParam));
+        queryParameters.put("scope", scopesParam);
 
-        return URLUtils.serializeParameters(queryParameters);
+        return StringHelper.serializeQueryParameters(queryParameters);
     }
 
     private Map<String, String> appendToHeaders(Map<String, String> clientDataHeaders) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IMDSManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IMDSManagedIdentitySource.java
@@ -74,8 +74,8 @@ class IMDSManagedIdentitySource extends AbstractManagedIdentitySource{
         managedIdentityRequest.headers.put("Metadata", "true");
 
         managedIdentityRequest.queryParameters = new HashMap<>();
-        managedIdentityRequest.queryParameters.put("api-version", Collections.singletonList(IMDS_API_VERSION));
-        managedIdentityRequest.queryParameters.put("resource", Collections.singletonList(resource));
+        managedIdentityRequest.queryParameters.put("api-version", IMDS_API_VERSION);
+        managedIdentityRequest.queryParameters.put("resource", resource);
 
         if (this.idType != null && !StringHelper.isNullOrBlank(this.userAssignedId)) {
             LOG.info("[Managed Identity] Adding user assigned ID to the request for IMDS Managed Identity.");

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthorizationGrant.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthorizationGrant.java
@@ -18,7 +18,7 @@ class IntegratedWindowsAuthorizationGrant extends AbstractMsalAuthorizationGrant
     }
 
     @Override
-    Map<String, List<String>> toParameters() {
+    Map<String, String> toParameters() {
         return null;
     }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityRequest.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.nimbusds.oauth2.sdk.util.URLUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,8 +10,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 class ManagedIdentityRequest extends MsalRequest {
@@ -25,9 +22,9 @@ class ManagedIdentityRequest extends MsalRequest {
 
     Map<String, String> headers;
 
-    Map<String, List<String>> bodyParameters;
+    Map<String, String> bodyParameters;
 
-    Map<String, List<String>> queryParameters;
+    Map<String, String> queryParameters;
 
     public ManagedIdentityRequest(ManagedIdentityApplication managedIdentityApplication, RequestContext requestContext) {
         super(managedIdentityApplication, requestContext);
@@ -37,7 +34,7 @@ class ManagedIdentityRequest extends MsalRequest {
         if (bodyParameters == null || bodyParameters.isEmpty())
             return "";
 
-        return URLUtils.serializeParameters(bodyParameters);
+        return StringHelper.serializeQueryParameters(bodyParameters);
     }
 
     public URL computeURI() throws URISyntaxException {
@@ -54,7 +51,7 @@ class ManagedIdentityRequest extends MsalRequest {
             return baseEndpoint.toString();
         }
 
-        String queryString = URLUtils.serializeParameters(queryParameters);
+        String queryString = StringHelper.serializeQueryParameters(queryParameters);
 
         return baseEndpoint.toString() + "?" + queryString;
     }
@@ -63,15 +60,15 @@ class ManagedIdentityRequest extends MsalRequest {
         switch (idType) {
             case CLIENT_ID:
                 LOG.info("[Managed Identity] Adding user assigned client id to the request.");
-                queryParameters.put(Constants.MANAGED_IDENTITY_CLIENT_ID, Collections.singletonList(userAssignedId));
+                queryParameters.put(Constants.MANAGED_IDENTITY_CLIENT_ID, userAssignedId);
                 break;
             case RESOURCE_ID:
                 LOG.info("[Managed Identity] Adding user assigned resource id to the request.");
-                queryParameters.put(Constants.MANAGED_IDENTITY_RESOURCE_ID, Collections.singletonList(userAssignedId));
+                queryParameters.put(Constants.MANAGED_IDENTITY_RESOURCE_ID, userAssignedId);
                 break;
             case OBJECT_ID:
                 LOG.info("[Managed Identity] Adding user assigned object id to the request.");
-                queryParameters.put(Constants.MANAGED_IDENTITY_OBJECT_ID, Collections.singletonList(userAssignedId));
+                queryParameters.put(Constants.MANAGED_IDENTITY_OBJECT_ID, userAssignedId);
                 break;
         }
     }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OAuthAuthorizationGrant.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OAuthAuthorizationGrant.java
@@ -6,13 +6,12 @@ package com.microsoft.aad.msal4j;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 class OAuthAuthorizationGrant extends AbstractMsalAuthorizationGrant {
 
-    private final Map<String, List<String>> params = new LinkedHashMap<>();
+    private final Map<String, String> params = new LinkedHashMap<>();
 
     /**
      * Constructor to create an OAuthAuthorizationGrant
@@ -20,7 +19,7 @@ class OAuthAuthorizationGrant extends AbstractMsalAuthorizationGrant {
      * @param params parameters relevant for the specific authorization grant type
      * @param scopes additional scopes which will be added to a default set of common scopes
      */
-    OAuthAuthorizationGrant(Map<String, List<String>> params, Set<String> scopes) {
+    OAuthAuthorizationGrant(Map<String, String> params, Set<String> scopes) {
         this.scopes = new HashSet<>(AbstractMsalAuthorizationGrant.COMMON_SCOPES);
 
         if (scopes != null) {
@@ -28,9 +27,9 @@ class OAuthAuthorizationGrant extends AbstractMsalAuthorizationGrant {
         }
 
         // Default scopes that apply to most flows
-        this.params.put(SCOPE_PARAM_NAME, Collections.singletonList(String.join(" ", this.scopes)));
+        this.params.put(SCOPE_PARAM_NAME, String.join(" ", this.scopes));
         // Parameter to request client info from the endpoint
-        this.params.put("client_info", Collections.singletonList("1"));
+        this.params.put("client_info", "1");
 
         if (params != null) {
             this.params.putAll(params);
@@ -44,16 +43,16 @@ class OAuthAuthorizationGrant extends AbstractMsalAuthorizationGrant {
      * @param scopes additional scopes which will be added to a default set of common scopes
      * @param claims optional claims
      */
-    OAuthAuthorizationGrant(Map<String, List<String>> params, Set<String> scopes, ClaimsRequest claims) {
+    OAuthAuthorizationGrant(Map<String, String> params, Set<String> scopes, ClaimsRequest claims) {
         this(params, scopes);
 
         if (claims != null) {
             this.claims = claims;
-            this.params.put("claims", Collections.singletonList(claims.formatAsJSONString()));
+            this.params.put("claims", claims.formatAsJSONString());
         }
     }
 
-    void addAndReplaceParams(Map<String, List<String>> params) {
+    void addAndReplaceParams(Map<String, String> params) {
         if (params != null) {
             //putAll() will overwrite existing values if the key already exists in the map
             this.params.putAll(params);
@@ -61,17 +60,14 @@ class OAuthAuthorizationGrant extends AbstractMsalAuthorizationGrant {
     }
 
     String getParamValue(String paramKey) {
-        if (this.params.containsKey(paramKey)) {
-            return this.params.get(paramKey).get(0);
-        }
-        return null;
+        return this.params.get(paramKey);
     }
 
     /**
      * Returns an unmodifiable version of the parameters map
      */
     @Override
-    public Map<String, List<String>> toParameters() {
+    public Map<String, String> toParameters() {
         return Collections.unmodifiableMap(new LinkedHashMap<>(params));
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfRequest.java
@@ -19,14 +19,14 @@ class OnBehalfOfRequest extends MsalRequest {
     }
 
     private static OAuthAuthorizationGrant createAuthenticationGrant(OnBehalfOfParameters parameters) {
-        Map<String, List<String>> params = new LinkedHashMap<>();
+        Map<String, String> params = new LinkedHashMap<>();
 
-        params.put(GrantConstants.GRANT_TYPE_PARAMETER, Collections.singletonList(GrantConstants.JWT_BEARER));
-        params.put(GrantConstants.ASSERTION_PARAMETER, Collections.singletonList(parameters.userAssertion().getAssertion()));
-        params.put("requested_token_use", Collections.singletonList("on_behalf_of"));
+        params.put(GrantConstants.GRANT_TYPE_PARAMETER, GrantConstants.JWT_BEARER);
+        params.put(GrantConstants.ASSERTION_PARAMETER, parameters.userAssertion().getAssertion());
+        params.put("requested_token_use", "on_behalf_of");
 
         if (parameters.claims() != null) {
-            params.put("claims", Collections.singletonList(parameters.claims().formatAsJSONString()));
+            params.put("claims", parameters.claims().formatAsJSONString());
         }
 
         return new OAuthAuthorizationGrant(params, parameters.scopes());

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RefreshTokenRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RefreshTokenRequest.java
@@ -33,10 +33,10 @@ class RefreshTokenRequest extends MsalRequest {
     }
 
     private static AbstractMsalAuthorizationGrant createAuthenticationGrant(RefreshTokenParameters parameters) {
-        Map<String, List<String>> params = new LinkedHashMap<>();
+        Map<String, String> params = new LinkedHashMap<>();
 
-        params.put(GrantConstants.GRANT_TYPE_PARAMETER, Collections.singletonList(GrantConstants.REFRESH_TOKEN));
-        params.put("refresh_token", Collections.singletonList(parameters.refreshToken()));
+        params.put(GrantConstants.GRANT_TYPE_PARAMETER, GrantConstants.REFRESH_TOKEN);
+        params.put("refresh_token", parameters.refreshToken());
 
         return new OAuthAuthorizationGrant(params, parameters.scopes(), parameters.claims());
     }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ServiceFabricManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ServiceFabricManagedIdentitySource.java
@@ -36,8 +36,8 @@ class ServiceFabricManagedIdentitySource extends AbstractManagedIdentitySource {
         managedIdentityRequest.headers.put("secret", identityHeader);
 
         managedIdentityRequest.queryParameters = new HashMap<>();
-        managedIdentityRequest.queryParameters.put("resource", Collections.singletonList(resource));
-        managedIdentityRequest.queryParameters.put("api-version", Collections.singletonList(SERVICE_FABRIC_MSI_API_VERSION));
+        managedIdentityRequest.queryParameters.put("resource", resource);
+        managedIdentityRequest.queryParameters.put("api-version", SERVICE_FABRIC_MSI_API_VERSION);
 
         if (this.idType != null && !StringHelper.isNullOrBlank(this.userAssignedId)) {
             LOG.info("[Managed Identity] Adding user assigned ID to the request for Service Fabric Managed Identity.");

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/StringHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/StringHelper.java
@@ -125,7 +125,7 @@ final class StringHelper {
     }
 
     //Much of the library once used Map<String, List<String>> for query parameters due to reliance on a specific dependency.
-    // Although Map<String, String> is now used internally, some public APIs still return Map<String, List<String>>
+    // Although Map<String, String> is now used internally, some public APIs in AuthorizationRequestUrlParameters still return Map<String, List<String>>
     static Map<String, List<String>> convertToMultiValueMap(Map<String, String> singleValueMap) {
         Map<String, List<String>> multiValueMap = new HashMap<>();
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/StringHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/StringHelper.java
@@ -3,17 +3,20 @@
 
 package com.microsoft.aad.msal4j;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
+import java.util.*;
 
 final class StringHelper {
 
     static String EMPTY_STRING = "";
 
     static boolean isBlank(final String str) {
-        return str == null || str.trim().length() == 0;
+        return str == null || str.trim().isEmpty();
     }
 
     static String createBase64EncodedSha256Hash(String stringToHash) {
@@ -24,7 +27,7 @@ final class StringHelper {
         return createSha256Hash(stringToHash, false);
     }
 
-    static private String createSha256Hash(String stringToHash, boolean base64Encode) {
+    private static String createSha256Hash(String stringToHash, boolean base64Encode) {
         String res;
         try {
             MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
@@ -42,6 +45,96 @@ final class StringHelper {
     }
 
     public static boolean isNullOrBlank(final String str) {
-        return str == null || str.trim().length() == 0;
+        return str == null || str.trim().isEmpty();
+    }
+
+    //Converts a map of parameters into a URL query string
+    static String serializeQueryParameters(Map<String, String> params) {
+        if (params != null && !params.isEmpty()) {
+            Map<String, String> encodedParams = urlEncodeMap(params);
+            StringBuilder sb = new StringBuilder();
+
+            for (Map.Entry<String, String> entry : encodedParams.entrySet()) {
+                if (entry.getKey() == null || entry.getValue() == null) {
+                    continue;
+                }
+
+                String value = entry.getValue();
+
+                if (sb.length() > 0) {
+                    sb.append('&');
+                }
+
+                sb.append(entry.getKey());
+                sb.append('=');
+                sb.append(value);
+            }
+
+            return sb.toString();
+        } else {
+            return "";
+        }
+    }
+
+    static Map<String, String> urlEncodeMap(Map<String, String> params) {
+        if (params == null || params.isEmpty()) {
+            return params;
+        } else {
+            Map<String, String> out = new LinkedHashMap<>();
+
+            for (Map.Entry<String, String> entry : params.entrySet()) {
+                try {
+                    String newKey = entry.getKey() != null ? URLEncoder.encode(entry.getKey(), "utf-8") : null;
+                    String newValue = entry.getValue() != null ? URLEncoder.encode(entry.getValue(), "utf-8") : null;
+
+                    out.put(newKey, newValue);
+                } catch (UnsupportedEncodingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            return out;
+        }
+    }
+
+    static Map<String, String> parseQueryParameters(String query) {
+        Map<String, String> params = new LinkedHashMap<>();
+        if (StringHelper.isBlank(query)) {
+            return params;
+        } else {
+            StringTokenizer st = new StringTokenizer(query.trim(), "&");
+
+            while (st.hasMoreTokens()) {
+                String param = st.nextToken();
+                String[] pair = param.split("=", 2);
+
+                String key;
+                String value;
+                try {
+                    key = URLDecoder.decode(pair[0], "utf-8");
+                    value = pair.length > 1 ? URLDecoder.decode(pair[1], "utf-8") : "";
+                } catch (UnsupportedEncodingException | IllegalArgumentException e) {
+                    continue;
+                }
+
+                params.put(key, value);
+            }
+
+            return params;
+        }
+    }
+
+    //Much of the library once used Map<String, List<String>> for query parameters due to reliance on a specific dependency.
+    // Although Map<String, String> is now used internally, some public APIs still return Map<String, List<String>>
+    static Map<String, List<String>> convertToMultiValueMap(Map<String, String> singleValueMap) {
+        Map<String, List<String>> multiValueMap = new HashMap<>();
+
+        if (singleValueMap != null) {
+            for (Map.Entry<String, String> entry : singleValueMap.entrySet()) {
+                multiValueMap.put(entry.getKey(), Collections.singletonList(entry.getValue()));
+            }
+        }
+
+        return multiValueMap;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -5,7 +5,6 @@ package com.microsoft.aad.msal4j;
 
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.SerializeException;
-import com.nimbusds.oauth2.sdk.util.URLUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,18 +51,18 @@ class TokenRequestExecutor {
                 msalRequest.requestContext(),
                 this.serviceBundle);
 
-        final Map<String, List<String>> params = new HashMap<>(msalRequest.msalAuthorizationGrant().toParameters());
+        final Map<String, String> params = new HashMap<>(msalRequest.msalAuthorizationGrant().toParameters());
         if (msalRequest.application() instanceof AbstractClientApplicationBase
                 && ((AbstractClientApplicationBase) msalRequest.application()).clientCapabilities() != null) {
-            params.put("claims", Collections.singletonList(((AbstractClientApplicationBase) msalRequest.application()).clientCapabilities()));
+            params.put("claims", ((AbstractClientApplicationBase) msalRequest.application()).clientCapabilities());
         }
 
         if (msalRequest.msalAuthorizationGrant.getClaims() != null) {
             String claimsRequest = msalRequest.msalAuthorizationGrant.getClaims().formatAsJSONString();
             if (params.get("claims") != null) {
-                claimsRequest = JsonHelper.mergeJSONString(params.get("claims").get(0), claimsRequest);
+                claimsRequest = JsonHelper.mergeJSONString(params.get("claims"), claimsRequest);
             }
-            params.put("claims", Collections.singletonList(claimsRequest));
+            params.put("claims", claimsRequest);
         }
 
         if(msalRequest.requestContext().apiParameters().extraQueryParameters() != null ){
@@ -71,11 +70,11 @@ class TokenRequestExecutor {
                     if(params.containsKey(key)){
                        log.warn("A query parameter {} has been provided with values multiple times.", key);
                     }
-                    params.put(key, Collections.singletonList(msalRequest.requestContext().apiParameters().extraQueryParameters().get(key)));
+                    params.put(key, msalRequest.requestContext().apiParameters().extraQueryParameters().get(key));
             }
         }
 
-        oauthHttpRequest.setQuery(URLUtils.serializeParameters(params));
+        oauthHttpRequest.setQuery(StringHelper.serializeQueryParameters(params));
 
         //Certain query parameters are required by Public and Confidential client applications, but not Managed Identity
         if (msalRequest.application() instanceof AbstractClientApplicationBase) {
@@ -85,9 +84,9 @@ class TokenRequestExecutor {
     }
 
     private void addQueryParameters(OAuthHttpRequest oauthHttpRequest) {
-        Map<String, List<String>> queryParameters = URLUtils.parseParameters(oauthHttpRequest.query);
+        Map<String, String> queryParameters = StringHelper.parseQueryParameters(oauthHttpRequest.query);
         String clientID = msalRequest.application().clientId();
-        queryParameters.put("client_id", Arrays.asList(clientID));
+        queryParameters.put("client_id", clientID);
 
         // If the client application has a client assertion to apply to the request, check if a new client assertion
         //  was supplied as a request parameter. If so, use the request's assertion instead of the application's
@@ -100,17 +99,17 @@ class TokenRequestExecutor {
                     addJWTBearerAssertionParams(queryParameters, ((ConfidentialClientApplication) msalRequest.application()).assertion);
                 } else if (((ConfidentialClientApplication) msalRequest.application()).secret != null) {
                     // Client secrets have a different parameter than bearer assertions
-                    queryParameters.put("client_secret", Collections.singletonList(((ConfidentialClientApplication) msalRequest.application()).secret));
+                    queryParameters.put("client_secret", ((ConfidentialClientApplication) msalRequest.application()).secret);
                 }
             }
         }
 
-        oauthHttpRequest.setQuery(URLUtils.serializeParameters(queryParameters));
+        oauthHttpRequest.setQuery(StringHelper.serializeQueryParameters(queryParameters));
     }
 
-    private void addJWTBearerAssertionParams(Map<String, List<String>> queryParameters, String assertion) {
-        queryParameters.put("client_assertion", Collections.singletonList(assertion));
-        queryParameters.put("client_assertion_type", Collections.singletonList("urn:ietf:params:oauth:client-assertion-type:jwt-bearer"));
+    private void addJWTBearerAssertionParams(Map<String, String> queryParameters, String assertion) {
+        queryParameters.put("client_assertion", assertion);
+        queryParameters.put("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
     }
 
     private AuthenticationResult createAuthenticationResultFromOauthHttpResponse(

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordRequest.java
@@ -17,11 +17,11 @@ class UserNamePasswordRequest extends MsalRequest {
     }
 
     private static OAuthAuthorizationGrant createAuthenticationGrant(UserNamePasswordParameters parameters) {
-        Map<String, List<String>> params = new LinkedHashMap<>();
+        Map<String, String> params = new LinkedHashMap<>();
 
-        params.put(GrantConstants.GRANT_TYPE_PARAMETER, Collections.singletonList(GrantConstants.PASSWORD));
-        params.put(GrantConstants.USERNAME_PARAMETER, Collections.singletonList(parameters.username()));
-        params.put(GrantConstants.PASSWORD_PARAMETER, Collections.singletonList(new String(parameters.password())));
+        params.put(GrantConstants.GRANT_TYPE_PARAMETER, GrantConstants.PASSWORD);
+        params.put(GrantConstants.USERNAME_PARAMETER, parameters.username());
+        params.put(GrantConstants.PASSWORD_PARAMETER, new String(parameters.password()));
 
         return new OAuthAuthorizationGrant(params, parameters.scopes(), parameters.claims());
     }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/HelperAndUtilityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/HelperAndUtilityTests.java
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HelperAndUtilityTests {
+
+    @Test
+    void StringHelper_serializeQueryParameters_ValidUrlQueryStrings() {
+        //Empty map
+        Map<String, String> params = new LinkedHashMap<>();
+        String result = StringHelper.serializeQueryParameters(params);
+        assertEquals("", result);
+
+        //Null map
+        result = StringHelper.serializeQueryParameters(null);
+        assertEquals("", result);
+
+        //Basic parameters
+        params = new LinkedHashMap<>();
+        params.put("client_id", "abc123");
+        params.put("scope", "openid profile");
+        params.put("redirect_uri", "https://example.com/auth");
+
+        result = StringHelper.serializeQueryParameters(params);
+        assertEquals("client_id=abc123&scope=openid+profile&redirect_uri=https%3A%2F%2Fexample.com%2Fauth", result);
+
+        //(Unrealistic) parameters with special characters
+        params = new LinkedHashMap<>();
+        params.put("client_id", "special@client");
+        params.put("scope", "openid offline_access");
+        params.put("redirect_uri", "https://example.com/query?key=value");
+
+        result = StringHelper.serializeQueryParameters(params);
+        assertEquals("client_id=special%40client&scope=openid+offline_access&redirect_uri=https%3A%2F%2Fexample.com%2Fquery%3Fkey%3Dvalue", result);
+
+        //Null values in map
+        params = new LinkedHashMap<>();
+        params.put("client_id", "abc123");
+        params.put("scope", null);
+        params.put("redirect_uri", "https://example.com/auth");
+
+        result = StringHelper.serializeQueryParameters(params);
+        assertEquals("client_id=abc123&redirect_uri=https%3A%2F%2Fexample.com%2Fauth", result);
+    }
+
+    @Test
+    void StringHelper_convertToMultiValueMap() {
+        //Historically, much of the library once used Map<String, List<String>> to represent URL query params, though it now uses Map<String, String>.
+        // AuthorizationRequestUrlParameters unfortunately has a public API returning Map<String, List<String>>,
+        // so this test helps ensure we still return an equivalent map to what we're using internally.
+        AuthorizationRequestUrlParameters params = new AuthorizationRequestUrlParameters.Builder()
+                .redirectUri("https://myapp.com/callback")
+                .scopes(Collections.singleton("openid profile email"))
+                .state("state123")
+                .nonce("nonce123")
+                .loginHint("user@example.com")
+                .correlationId("correlation-id-123").build();
+
+        Map<String, String> internalRequestParams = params.requestParameters;
+        Map<String, List<String>> convertedInternalMap = StringHelper.convertToMultiValueMap(internalRequestParams);
+
+        // Get the map returned by the method
+        Map<String, List<String>> methodReturnedMap = params.requestParameters();
+
+        // Assert
+        assertNotNull(convertedInternalMap, "Converted map should not be null");
+        assertNotNull(methodReturnedMap, "Method returned map should not be null");
+
+        assertEquals(convertedInternalMap.size(), methodReturnedMap.size(), "Maps should have the same size");
+
+        for (String key : convertedInternalMap.keySet()) {
+            assertTrue(methodReturnedMap.containsKey(key), "Method returned map should contain key: " + key);
+
+            List<String> convertedValues = convertedInternalMap.get(key);
+            List<String> methodValues = methodReturnedMap.get(key);
+
+            assertEquals(convertedValues, methodValues,
+                    "Values for key '" + key + "' should be equal");
+        }
+    }
+}

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/MsalOauthAuthorizatonGrantTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/MsalOauthAuthorizatonGrantTest.java
@@ -19,13 +19,13 @@ class MsalOauthAuthorizatonGrantTest {
 
     @Test
     void testToParameters() {
-        Map<String, List<String>> params = new LinkedHashMap<>();
-        params.put(GrantConstants.GRANT_TYPE_PARAMETER, Collections.singletonList("SomeGrantType"));
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put(GrantConstants.GRANT_TYPE_PARAMETER, "SomeGrantType");
 
         final OAuthAuthorizationGrant grant = new OAuthAuthorizationGrant(params, null);
 
         assertNotNull(grant);
         assertNotNull(grant.toParameters());
-        assertEquals("SomeGrantType", grant.toParameters().get(GrantConstants.GRANT_TYPE_PARAMETER).get(0));
+        assertEquals("SomeGrantType", grant.toParameters().get(GrantConstants.GRANT_TYPE_PARAMETER));
     }
 }


### PR DESCRIPTION
This PR refactors and simplifies how URL query parameters and handled in the library, made possible by the removal of dependences both here and in other PRs for https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/909

Although the PR affects a lot of files, most shouldn't need much scrutiny: nearly all the changes are simply replacing `Map<String, List<String>>` with `Map<String, String>` and removing usage of `Collections.singletonList()`

However, there are a few files which need a more thorough review: 
- `StringHelper` : Several new helper methods for converting a `Map<String, String>` into a properly formatted URL query string
- `AuthorizationRequestUrlParameters`: All of the Maps are set internally, but unfortunately one public API in this class exposed its package-private Map field. The public API was untouched, but a new method was added to `StringHelper` to convert its internal Map back to the old format
- `HelperAndUtilityTests`: Unit tests for the new methods in `StringHelper`
