### PR TITLE
Use azure-json in claims classes

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClaimsRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClaimsRequest.java
@@ -3,16 +3,16 @@
 
 package com.microsoft.aad.msal4j;
 
+import com.azure.json.JsonProviders;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -20,7 +20,7 @@ import java.util.List;
  *
  * @see <a href="https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter">https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter</a>
  */
-public class ClaimsRequest {
+public class ClaimsRequest implements JsonSerializable<ClaimsRequest> {
 
     List<RequestedClaim> idTokenRequestedClaims = new ArrayList<>();
     List<RequestedClaim> userInfoRequestedClaims = new ArrayList<>();
@@ -62,31 +62,47 @@ public class ClaimsRequest {
      * @return a String following JSON formatting
      */
     public String formatAsJSONString() {
-        ObjectMapper mapper = new ObjectMapper();
-        ObjectNode rootNode = mapper.createObjectNode();
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             JsonWriter jsonWriter = JsonProviders.createWriter(outputStream)) {
+            toJson(jsonWriter);
 
-        if (!idTokenRequestedClaims.isEmpty()) {
-            rootNode.set("id_token", convertClaimsToObjectNode(idTokenRequestedClaims));
+            jsonWriter.flush();
+            return outputStream.toString(StandardCharsets.UTF_8.name());
+        } catch (IOException e) {
+            throw new MsalClientException("Could not convert ClaimsRequest to string: " + e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
         }
-        if (!userInfoRequestedClaims.isEmpty()) {
-            rootNode.set("userinfo", convertClaimsToObjectNode(userInfoRequestedClaims));
-        }
-        if (!accessTokenRequestedClaims.isEmpty()) {
-            rootNode.set("access_token", convertClaimsToObjectNode(accessTokenRequestedClaims));
-        }
-
-        return mapper.valueToTree(rootNode).toString();
     }
 
-    private ObjectNode convertClaimsToObjectNode(List<RequestedClaim> claims) {
-        ObjectMapper mapper = new ObjectMapper();
-        ObjectNode claimsNode = mapper.createObjectNode();
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
 
+        writeClaimsToJsonWriter(jsonWriter, "id_token", idTokenRequestedClaims);
+        writeClaimsToJsonWriter(jsonWriter, "userinfo", userInfoRequestedClaims);
+        writeClaimsToJsonWriter(jsonWriter, "access_token", accessTokenRequestedClaims);
+
+        jsonWriter.writeEndObject();
+        return jsonWriter;
+    }
+
+    private void writeClaimsToJsonWriter(JsonWriter jsonWriter, String sectionName, List<RequestedClaim> claims) throws IOException {
+        if (claims.isEmpty()) {
+            return;
+        }
+
+        jsonWriter.writeStartObject(sectionName);
 
         for (RequestedClaim claim : claims) {
-            claimsNode.setAll((ObjectNode) mapper.valueToTree(claim));
+            if (claim.name != null) {
+                if (claim.getRequestedClaimAdditionalInfo() != null) {
+                    jsonWriter.writeJsonField(claim.name,  claim.getRequestedClaimAdditionalInfo());
+                } else {
+                    jsonWriter.writeNullField(claim.name);
+                }
+            }
         }
-        return claimsNode;
+
+        jsonWriter.writeEndObject();
     }
 
     /**
@@ -96,49 +112,74 @@ public class ClaimsRequest {
      * @return a ClaimsRequest instance
      */
     public static ClaimsRequest formatAsClaimsRequest(String claims) {
-        try {
-            ClaimsRequest cr = new ClaimsRequest();
+        try (JsonReader jsonReader = JsonProviders.createReader(claims)) {
+            ClaimsRequest claimsRequest = new ClaimsRequest();
 
-            ObjectMapper mapper = new ObjectMapper();
-            ObjectReader reader = mapper.readerFor(new TypeReference<List<String>>() {
+            return jsonReader.readObject(reader -> {
+                if (reader.currentToken() != JsonToken.START_OBJECT) {
+                    throw new IllegalStateException("Expected start of object but was " + reader.currentToken());
+                }
+
+                while (reader.nextToken() != JsonToken.END_OBJECT) {
+                    parseClaims(reader, claimsRequest, reader.getFieldName());
+                }
+
+                return claimsRequest;
             });
-
-            JsonNode jsonClaims = mapper.readTree(claims);
-
-            addClaimsFromJsonNode(jsonClaims.get("id_token"), "id_token", cr, reader);
-            addClaimsFromJsonNode(jsonClaims.get("userinfo"), "userinfo", cr, reader);
-            addClaimsFromJsonNode(jsonClaims.get("access_token"), "access_token", cr, reader);
-
-            return cr;
         } catch (IOException e) {
-            throw new MsalClientException("Could not convert string to ClaimsRequest: " + e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
+            throw new MsalClientException("Could not convert string to ClaimsRequest: " + e.getMessage(),
+                    AuthenticationErrorCode.INVALID_JSON);
         }
     }
 
-    private static void addClaimsFromJsonNode(JsonNode claims, String group, ClaimsRequest cr, ObjectReader reader) throws IOException {
-        Iterator<String> claimsIterator;
+    private static void parseClaims(JsonReader jsonReader, ClaimsRequest claimsRequest, String section) throws IOException {
+        if (jsonReader.currentToken() != JsonToken.FIELD_NAME) {
+            jsonReader.nextToken();
+        }
 
-        if (claims != null) {
-            claimsIterator = claims.fieldNames();
-            while (claimsIterator.hasNext()) {
-                String claim = claimsIterator.next();
-                Boolean essential = null;
+        jsonReader.nextToken();
+        if (jsonReader.currentToken() != JsonToken.START_OBJECT) {
+            throw new IllegalStateException("Expected start of object but was " + jsonReader.currentToken());
+        }
+
+        while (jsonReader.nextToken() != JsonToken.END_OBJECT) {
+            String claimName = jsonReader.getFieldName();
+            jsonReader.nextToken();
+
+            RequestedClaimAdditionalInfo claimInfo = null;
+            if (jsonReader.currentToken() == JsonToken.START_OBJECT) {
+                boolean essential = false;
                 String value = null;
                 List<String> values = null;
-                RequestedClaimAdditionalInfo claimInfo = null;
 
-                if (claims.get(claim).has("essential")) essential = claims.get(claim).get("essential").asBoolean();
-                if (claims.get(claim).has("value")) value = claims.get(claim).get("value").textValue();
-                if (claims.get(claim).has("values")) values = reader.readValue(claims.get(claim).get("values"));
+                while (jsonReader.nextToken() != JsonToken.END_OBJECT) {
+                    String fieldName = jsonReader.getFieldName();
+                    jsonReader.nextToken();
 
-                //'null' is a valid value for RequestedClaimAdditionalInfo, so only initialize it if one of the parameters is not null
-                if (essential != null || value != null || values != null) {
-                    claimInfo = new RequestedClaimAdditionalInfo(essential == null ? false : essential, value, values);
+                    switch (fieldName) {
+                        case "essential": essential = jsonReader.getBoolean(); break;
+                        case "value": value = jsonReader.getString(); break;
+                        case "values":
+                            values = new ArrayList<>();
+                            if (jsonReader.currentToken() == JsonToken.START_ARRAY) {
+                                while (jsonReader.nextToken() != JsonToken.END_ARRAY) {
+                                    values.add(jsonReader.getString());
+                                }
+                            }
+                            break;
+                        default: jsonReader.skipChildren(); break;
+                    }
                 }
 
-                if (group.equals("id_token")) cr.requestClaimInIdToken(claim, claimInfo);
-                if (group.equals("userinfo")) cr.requestClaimInUserInfo(claim, claimInfo);
-                if (group.equals("access_token")) cr.requestClaimInAccessToken(claim, claimInfo);
+                if (essential || value != null || values != null) {
+                    claimInfo = new RequestedClaimAdditionalInfo(essential, value, values);
+                }
+            }
+
+            switch (section) {
+                case "access_token": claimsRequest.requestClaimInAccessToken(claimName, claimInfo); break;
+                case "id_token": claimsRequest.requestClaimInIdToken(claimName, claimInfo); break;
+                case "userinfo": claimsRequest.requestClaimInUserInfo(claimName, claimInfo); break;
             }
         }
     }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClaimsRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClaimsRequest.java
@@ -138,6 +138,10 @@ public class ClaimsRequest implements JsonSerializable<ClaimsRequest> {
         }
 
         jsonReader.nextToken();
+        if (jsonReader.currentToken() == JsonToken.NULL) {
+            return;
+        }
+
         if (jsonReader.currentToken() != JsonToken.START_OBJECT) {
             throw new IllegalStateException("Expected start of object but was " + jsonReader.currentToken());
         }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RequestedClaim.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RequestedClaim.java
@@ -3,10 +3,12 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
@@ -15,20 +17,55 @@ import java.util.Map;
  *
  * @see <a href="https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter">https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter</a>
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public class RequestedClaim {
+public class RequestedClaim implements JsonSerializable<RequestedClaim> {
 
-    @JsonIgnore
     public String name;
+    private RequestedClaimAdditionalInfo requestedClaimAdditionalInfo;
 
-    RequestedClaimAdditionalInfo requestedClaimAdditionalInfo;
+    RequestedClaim() {}
 
     public RequestedClaim(String name, RequestedClaimAdditionalInfo requestedClaimAdditionalInfo) {
         this.name = name;
         this.requestedClaimAdditionalInfo = requestedClaimAdditionalInfo;
     }
 
-    @JsonAnyGetter
+    static RequestedClaim fromJson(JsonReader jsonReader) throws IOException {
+        RequestedClaim claim = new RequestedClaim();
+        return jsonReader.readObject(reader -> {
+            if (reader.currentToken() != JsonToken.START_OBJECT) {
+                throw new IllegalStateException("Expected start of object but was " + reader.currentToken());
+            }
+
+            claim.name = reader.getFieldName();
+
+            RequestedClaimAdditionalInfo info = new RequestedClaimAdditionalInfo(false, null, null);
+            claim.requestedClaimAdditionalInfo = info.fromJson(reader);
+
+            return claim;
+        });
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+
+        if (name != null && requestedClaimAdditionalInfo != null) {
+            jsonWriter.writeString(name);
+            requestedClaimAdditionalInfo.toJson(jsonWriter);
+        }
+
+        jsonWriter.writeEndObject();
+        return jsonWriter;
+    }
+
+    RequestedClaimAdditionalInfo getRequestedClaimAdditionalInfo() {
+        return requestedClaimAdditionalInfo;
+    }
+
+    void setRequestedClaimAdditionalInfo(RequestedClaimAdditionalInfo requestedClaimAdditionalInfo) {
+        this.requestedClaimAdditionalInfo = requestedClaimAdditionalInfo;
+    }
+
     protected Map<String, Object> any() {
         return Collections.singletonMap(name, requestedClaimAdditionalInfo);
     }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RequestedClaimAdditionalInfo.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RequestedClaimAdditionalInfo.java
@@ -3,9 +3,13 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -13,23 +17,74 @@ import java.util.List;
  *
  * @see <a href="https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter">https://openid.net/specs/openid-connect-core-1_0-final.html#ClaimsParameter</a>
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public class RequestedClaimAdditionalInfo {
+public class RequestedClaimAdditionalInfo implements JsonSerializable<RequestedClaimAdditionalInfo> {
 
-    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-    @JsonProperty("essential")
-    boolean essential;
-
-    @JsonProperty("value")
-    String value;
-
-    @JsonProperty("values")
-    List<String> values;
+    private boolean essential;
+    private String value;
+    private List<String> values;
 
     public RequestedClaimAdditionalInfo(boolean essential, String value, List<String> values) {
         this.essential = essential;
         this.value = value;
         this.values = values;
+    }
+
+    public RequestedClaimAdditionalInfo fromJson(JsonReader jsonReader) throws IOException {
+        if (jsonReader.currentToken() != JsonToken.START_OBJECT) {
+            jsonReader.nextToken();
+            if (jsonReader.currentToken() != JsonToken.START_OBJECT) {
+                throw new IllegalStateException("Expected start of object but was " + jsonReader.currentToken());
+            }
+        }
+
+        while (jsonReader.nextToken() != JsonToken.END_OBJECT) {
+            String fieldName = jsonReader.getFieldName();
+            jsonReader.nextToken();
+
+            switch (fieldName) {
+                case "essential":
+                    essential = jsonReader.getBoolean();
+                    break;
+                case "value":
+                    value = jsonReader.getString();
+                    break;
+                case "values":
+                    values = new ArrayList<>();
+                    while (jsonReader.nextToken() != JsonToken.END_ARRAY) {
+                        values.add(jsonReader.getString());
+                    }
+                    break;
+                default:
+                    jsonReader.skipChildren();
+                    break;
+            }
+        }
+
+        return this;
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+
+        if (essential) {
+            jsonWriter.writeBooleanField("essential", essential);
+        }
+
+        if (value != null) {
+            jsonWriter.writeStringField("value", value);
+        }
+
+        if (values != null && !values.isEmpty()) {
+            jsonWriter.writeStartArray("values");
+            for (String val : values) {
+                jsonWriter.writeString(val);
+            }
+            jsonWriter.writeEndArray();
+        }
+
+        jsonWriter.writeEndObject();
+        return jsonWriter;
     }
 
     public boolean isEssential() {

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClaimsTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClaimsTest.java
@@ -3,16 +3,19 @@
 
 package com.microsoft.aad.msal4j;
 
+import com.azure.json.JsonProviders;
+import com.azure.json.JsonWriter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ClaimsTest {
@@ -73,5 +76,97 @@ class ClaimsTest {
         ClaimsRequest cr = ClaimsRequest.formatAsClaimsRequest(TestConfiguration.CLAIMS_CHALLENGE);
 
         assertEquals(TestConfiguration.CLAIMS_CHALLENGE, cr.formatAsJSONString());
+    }
+
+    @Test
+    void testClaimsRequest_SerializationWithNullAdditionalInfo() {
+        // Setup a claims request with null additional info
+        ClaimsRequest request = new ClaimsRequest();
+        request.requestClaimInIdToken("email", null);
+
+        // Convert to JSON string
+        String jsonString = request.formatAsJSONString();
+
+        // Verify the output format
+        assertNotNull(jsonString);
+        assertEquals("{\"id_token\":{\"email\":null}}", jsonString);
+    }
+
+    @Test
+    void testClaimsRequest_RoundTrip() {
+        // Create original request with various claims
+        ClaimsRequest originalRequest = new ClaimsRequest();
+        originalRequest.requestClaimInIdToken("email", new RequestedClaimAdditionalInfo(true, null, null));
+        originalRequest.requestClaimInUserInfo("name", new RequestedClaimAdditionalInfo(false, "John", null));
+
+        List<String> groups = Arrays.asList("admin", "user");
+        originalRequest.requestClaimInAccessToken("groups", new RequestedClaimAdditionalInfo(false, null, groups));
+
+        // Convert to JSON string
+        String jsonString = originalRequest.formatAsJSONString();
+
+        // Parse back to a ClaimsRequest
+        ClaimsRequest parsedRequest = ClaimsRequest.formatAsClaimsRequest(jsonString);
+
+        // Verify the claims were preserved
+        assertEquals(1, parsedRequest.getIdTokenRequestedClaims().size());
+        assertEquals("email", parsedRequest.getIdTokenRequestedClaims().get(0).name);
+        assertTrue(parsedRequest.getIdTokenRequestedClaims().get(0).getRequestedClaimAdditionalInfo().isEssential());
+
+        // Check userinfo claims
+        List<RequestedClaim> userInfoClaims = parsedRequest.userInfoRequestedClaims;
+        assertEquals(1, userInfoClaims.size());
+        assertEquals("name", userInfoClaims.get(0).name);
+        assertEquals("John", userInfoClaims.get(0).getRequestedClaimAdditionalInfo().getValue());
+
+        // Check access token claims
+        List<RequestedClaim> accessTokenClaims = parsedRequest.accessTokenRequestedClaims;
+        assertEquals(1, accessTokenClaims.size());
+        assertEquals("groups", accessTokenClaims.get(0).name);
+        assertEquals(2, accessTokenClaims.get(0).getRequestedClaimAdditionalInfo().getValues().size());
+        assertTrue(accessTokenClaims.get(0).getRequestedClaimAdditionalInfo().getValues().contains("admin"));
+    }
+
+    @Test
+    void testRequestedClaimAdditionalInfo_Serialization() {
+        RequestedClaimAdditionalInfo info1 = new RequestedClaimAdditionalInfo(true, null, null);
+        String json1 = serializeAdditionalInfo(info1);
+        assertTrue(json1.contains("\"essential\":true"));
+        assertFalse(json1.contains("\"value\""));
+        assertFalse(json1.contains("\"values\""));
+
+        RequestedClaimAdditionalInfo info2 = new RequestedClaimAdditionalInfo(false, "test", null);
+        String json2 = serializeAdditionalInfo(info2);
+        assertFalse(json2.contains("\"essential\""));
+        assertTrue(json2.contains("\"value\":\"test\""));
+
+        List<String> valuesList = Arrays.asList("one", "two");
+        RequestedClaimAdditionalInfo info3 = new RequestedClaimAdditionalInfo(false, null, valuesList);
+        String json3 = serializeAdditionalInfo(info3);
+        assertTrue(json3.contains("\"values\":[\"one\",\"two\"]"));
+    }
+
+    @Test
+    void testInvalidJsonHandling() {
+        try {
+            ClaimsRequest.formatAsClaimsRequest("{invalid json}");
+            fail("Should have thrown MsalClientException");
+        } catch (MsalClientException e) {
+            assertTrue(e.getMessage().contains("Could not convert string to ClaimsRequest"));
+            assertEquals(AuthenticationErrorCode.INVALID_JSON, e.errorCode());
+        }
+    }
+
+    // Helper method to serialize RequestedClaimAdditionalInfo for testing
+    private String serializeAdditionalInfo(RequestedClaimAdditionalInfo info) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             JsonWriter jsonWriter = JsonProviders.createWriter(outputStream)) {
+
+            info.toJson(jsonWriter);
+            jsonWriter.flush();
+            return outputStream.toString(StandardCharsets.UTF_8.name());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to serialize", e);
+        }
     }
 }


### PR DESCRIPTION
Replaces usage of com.fasterxml.jackson with com.azure.json, as per https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/909

This PR changes to claims-related classes which are similar to those done in https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/918:
- Adjust classes to implement azure-json's [JsonSerializable](https://learn.microsoft.com/en-us/java/api/com.azure.json.jsonserializable?view=azure-java-stable) interface
- Remove jackson-databind's JSON annotations from those classes
- Add new unit tests to show the new methods handle JSON properly