### PR TITLE
Replace com.fasterxml.jackson with com.azure.json

### DIFF
--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/CachePersistenceIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/CachePersistenceIT.java
@@ -54,7 +54,7 @@ class CachePersistenceIT {
 
         assertEquals(app.getAccounts().join().size(), 1);
         assertEquals(app.tokenCache.accounts.size(), 1);
-        assertEquals(app.tokenCache.accessTokens.size(), 2);
+        assertEquals(app.tokenCache.accessTokens.size(), 1);
         assertEquals(app.tokenCache.refreshTokens.size(), 1);
         assertEquals(app.tokenCache.idTokens.size(), 1);
         assertEquals(app.tokenCache.appMetadata.size(), 1);
@@ -65,7 +65,7 @@ class CachePersistenceIT {
 
         assertEquals(app.getAccounts().join().size(), 1);
         assertEquals(app.tokenCache.accounts.size(), 1);
-        assertEquals(app.tokenCache.accessTokens.size(), 2);
+        assertEquals(app.tokenCache.accessTokens.size(), 1);
         assertEquals(app.tokenCache.refreshTokens.size(), 1);
         assertEquals(app.tokenCache.idTokens.size(), 1);
         assertEquals(app.tokenCache.appMetadata.size(), 1);
@@ -74,7 +74,7 @@ class CachePersistenceIT {
 
         assertEquals(app.getAccounts().join().size(), 0);
         assertEquals(app.tokenCache.accounts.size(), 0);
-        assertEquals(app.tokenCache.accessTokens.size(), 1);
+        assertEquals(app.tokenCache.accessTokens.size(), 0);
         assertEquals(app.tokenCache.refreshTokens.size(), 0);
         assertEquals(app.tokenCache.idTokens.size(), 0);
         assertEquals(app.tokenCache.appMetadata.size(), 1);
@@ -84,7 +84,7 @@ class CachePersistenceIT {
 
         assertEquals(app.getAccounts().join().size(), 0);
         assertEquals(app.tokenCache.accounts.size(), 0);
-        assertEquals(app.tokenCache.accessTokens.size(), 1);
+        assertEquals(app.tokenCache.accessTokens.size(), 0);
         assertEquals(app.tokenCache.refreshTokens.size(), 0);
         assertEquals(app.tokenCache.idTokens.size(), 0);
         assertEquals(app.tokenCache.appMetadata.size(), 1);

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/TokenCacheIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/TokenCacheIT.java
@@ -163,7 +163,7 @@ class TokenCacheIT {
         // RemoveAccount should remove both cache entities
         pca2.removeAccount(account).join();
 
-        assertEquals(pca.getAccounts().join().size(), 0);
+        assertEquals(0, pca2.getAccounts().join().size());
 
         //clean up file
         TestHelper.deleteFileContent(

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractManagedIdentitySource.java
@@ -113,7 +113,7 @@ abstract class AbstractManagedIdentitySource {
 
         ManagedIdentityErrorResponse managedIdentityErrorResponse;
         try {
-            managedIdentityErrorResponse = JsonHelper.convertJsonToObject(response.body(), ManagedIdentityErrorResponse.class);
+            managedIdentityErrorResponse = JsonHelper.convertJsonStringToJsonSerializableObject(response.body(), ManagedIdentityErrorResponse::fromJson);
         } catch (MsalJsonParsingException e) {
             throw new MsalJsonParsingException(String.format(MsalErrorMessage.MANAGED_IDENTITY_RESPONSE_PARSE_FAILURE, response.statusCode(), e.getMessage()), MsalError.MANAGED_IDENTITY_RESPONSE_PARSE_FAILURE, managedIdentitySourceType);
         }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AccessTokenCacheEntity.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AccessTokenCacheEntity.java
@@ -3,32 +3,23 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-class AccessTokenCacheEntity extends Credential {
+class AccessTokenCacheEntity extends Credential implements JsonSerializable<Credential> {
 
-    @JsonProperty("credential_type")
     private String credentialType;
-
-    @JsonProperty("realm")
     protected String realm;
-
-    @JsonProperty("target")
     private String target;
-
-    @JsonProperty("cached_at")
     private String cachedAt;
-
-    @JsonProperty("expires_on")
     private String expiresOn;
-
-    @JsonProperty("extended_expires_on")
     private String extExpiresOn;
-
-    @JsonProperty("refresh_on")
     private String refreshOn;
 
     String getKey() {
@@ -44,12 +35,80 @@ class AccessTokenCacheEntity extends Credential {
         return String.join(Constants.CACHE_KEY_SEPARATOR, keyParts).toLowerCase();
     }
 
-    String credentialType() {
-        return this.credentialType;
+    static AccessTokenCacheEntity fromJson(JsonReader jsonReader) throws IOException {
+        AccessTokenCacheEntity entity = new AccessTokenCacheEntity();
+
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                switch (fieldName) {
+                    case "home_account_id":
+                        entity.homeAccountId = reader.getString();
+                        break;
+                    case "environment":
+                        entity.environment = reader.getString();
+                        break;
+                    case "credential_type":
+                        entity.credentialType = reader.getString();
+                        break;
+                    case "client_id":
+                        entity.clientId = reader.getString();
+                        break;
+                    case "secret":
+                        entity.secret = reader.getString();
+                        break;
+                    case "realm":
+                        entity.realm = reader.getString();
+                        break;
+                    case "target":
+                        entity.target = reader.getString();
+                        break;
+                    case "cached_at":
+                        entity.cachedAt = reader.getString();
+                        break;
+                    case "expires_on":
+                        entity.expiresOn = reader.getString();
+                        break;
+                    case "extended_expires_on":
+                        entity.extExpiresOn = reader.getString();
+                        break;
+                    case "refresh_on":
+                        entity.refreshOn = reader.getString();
+                        break;
+                    case "user_assertion_hash":
+                        entity.userAssertionHash = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return entity;
+        });
     }
 
-    String realm() {
-        return this.realm;
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+
+        jsonWriter.writeStringField("home_account_id", homeAccountId);
+        jsonWriter.writeStringField("environment", environment);
+        jsonWriter.writeStringField("credential_type", credentialType);
+        jsonWriter.writeStringField("client_id", clientId);
+        jsonWriter.writeStringField("secret", secret);
+        jsonWriter.writeStringField("realm", realm);
+        jsonWriter.writeStringField("target", target);
+        jsonWriter.writeStringField("cached_at", cachedAt);
+        jsonWriter.writeStringField("expires_on", expiresOn);
+        jsonWriter.writeStringField("extended_expires_on", extExpiresOn);
+        jsonWriter.writeStringField("refresh_on", refreshOn);
+        jsonWriter.writeStringField("user_assertion_hash", userAssertionHash);
+
+        jsonWriter.writeEndObject();
+
+        return jsonWriter;
     }
 
     String target() {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AccountCacheEntity.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AccountCacheEntity.java
@@ -3,51 +3,101 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-class AccountCacheEntity implements Serializable {
+class AccountCacheEntity implements JsonSerializable<AccountCacheEntity>, Serializable {
 
     static final String MSSTS_ACCOUNT_TYPE = "MSSTS";
     static final String ADFS_ACCOUNT_TYPE = "ADFS";
 
-    @JsonProperty("home_account_id")
     protected String homeAccountId;
-
-    @JsonProperty("environment")
     protected String environment;
-
-    @JsonProperty("realm")
     protected String realm;
-
-    @JsonProperty("local_account_id")
     protected String localAccountId;
-
-    @JsonProperty("username")
     protected String username;
-
-    @JsonProperty("name")
     protected String name;
-
-    @JsonProperty("client_info")
     protected String clientInfoStr;
-
-    @JsonProperty("user_assertion_hash")
     protected String userAssertionHash;
+    protected String authorityType;
+
+    static AccountCacheEntity fromJson(JsonReader jsonReader) throws IOException {
+        AccountCacheEntity entity = new AccountCacheEntity();
+
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                switch (fieldName) {
+                    case "home_account_id":
+                        entity.homeAccountId = reader.getString();
+                        break;
+                    case "environment":
+                        entity.environment = reader.getString();
+                        break;
+                    case "realm":
+                        entity.realm = reader.getString();
+                        break;
+                    case "local_account_id":
+                        entity.localAccountId = reader.getString();
+                        break;
+                    case "username":
+                        entity.username = reader.getString();
+                        break;
+                    case "name":
+                        entity.name = reader.getString();
+                        break;
+                    case "client_info":
+                        entity.clientInfoStr = reader.getString();
+                        break;
+                    case "user_assertion_hash":
+                        entity.userAssertionHash = reader.getString();
+                        break;
+                    case "authority_type":
+                        entity.authorityType = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return entity;
+        });
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+
+        jsonWriter.writeStringField("home_account_id", homeAccountId);
+        jsonWriter.writeStringField("environment", environment);
+        jsonWriter.writeStringField("realm", realm);
+        jsonWriter.writeStringField("local_account_id", localAccountId);
+        jsonWriter.writeStringField("username", username);
+        jsonWriter.writeStringField("name", name);
+        jsonWriter.writeStringField("client_info", clientInfoStr);
+        jsonWriter.writeStringField("user_assertion_hash", userAssertionHash);
+        jsonWriter.writeStringField("authority_type", authorityType);
+
+        jsonWriter.writeEndObject();
+
+        return jsonWriter;
+    }
 
     ClientInfo clientInfo() {
         return ClientInfo.createFromJson(clientInfoStr);
     }
 
-    @JsonProperty("authority_type")
-    protected String authorityType;
-
     String getKey() {
-
         List<String> keyParts = new ArrayList<>();
 
         keyParts.add(homeAccountId);
@@ -58,7 +108,6 @@ class AccountCacheEntity implements Serializable {
     }
 
     static AccountCacheEntity create(String clientInfoStr, Authority requestAuthority, IdToken idToken, String policy) {
-
         AccountCacheEntity account = new AccountCacheEntity();
         account.authorityType(MSSTS_ACCOUNT_TYPE);
         account.clientInfoStr = clientInfoStr;
@@ -80,7 +129,6 @@ class AccountCacheEntity implements Serializable {
     }
 
     static AccountCacheEntity createADFSAccount(Authority requestAuthority, IdToken idToken) {
-
         AccountCacheEntity account = new AccountCacheEntity();
         account.authorityType(ADFS_ACCOUNT_TYPE);
         account.homeAccountId(idToken.subject);
@@ -173,8 +221,6 @@ class AccountCacheEntity implements Serializable {
         this.authorityType = authorityType;
     }
 
-    //These methods are based on those generated by Lombok's @EqualsAndHashCode annotation.
-    //They have the same functionality as the generated methods, but were refactored for readability.
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AppMetadataCacheEntity.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AppMetadataCacheEntity.java
@@ -3,22 +3,62 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-class AppMetadataCacheEntity {
+class AppMetadataCacheEntity implements JsonSerializable<AppMetadataCacheEntity> {
 
     public static final String APP_METADATA_CACHE_ENTITY_ID = "appmetadata";
 
-    @JsonProperty("client_id")
     private String clientId;
-
-    @JsonProperty("environment")
     private String environment;
-
-    @JsonProperty("family_id")
     private String familyId;
+
+    static AppMetadataCacheEntity fromJson(JsonReader jsonReader) throws IOException {
+        AppMetadataCacheEntity entity = new AppMetadataCacheEntity();
+
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                switch (fieldName) {
+                    case "client_id":
+                        entity.clientId = reader.getString();
+                        break;
+                    case "environment":
+                        entity.environment = reader.getString();
+                        break;
+                    case "family_id":
+                        entity.familyId = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return entity;
+        });
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+
+        jsonWriter.writeStringField("client_id", clientId);
+        jsonWriter.writeStringField( "environment", environment);
+        jsonWriter.writeStringField("family_id", familyId);
+
+        jsonWriter.writeEndObject();
+
+        return jsonWriter;
+    }
 
     String getKey() {
         List<String> keyParts = new ArrayList<>();

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientInfo.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientInfo.java
@@ -3,19 +3,17 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.*;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import static com.microsoft.aad.msal4j.Constants.POINT_DELIMITER;
 
-class ClientInfo {
+class ClientInfo implements JsonSerializable<ClientInfo> {
 
-    @JsonProperty("uid")
     private String uniqueIdentifier;
-
-    @JsonProperty("utid")
     private String uniqueTenantIdentifier;
 
     public static ClientInfo createFromJson(String clientInfoJsonBase64Encoded) {
@@ -25,7 +23,40 @@ class ClientInfo {
 
         byte[] decodedInput = Base64.getUrlDecoder().decode(clientInfoJsonBase64Encoded.getBytes(StandardCharsets.UTF_8));
 
-        return JsonHelper.convertJsonToObject(new String(decodedInput, StandardCharsets.UTF_8), ClientInfo.class);
+        return JsonHelper.convertJsonStringToJsonSerializableObject(new String(decodedInput, StandardCharsets.UTF_8), ClientInfo::fromJson);
+    }
+
+    static ClientInfo fromJson(JsonReader jsonReader) throws IOException {
+        ClientInfo clientInfo = new ClientInfo();
+
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                switch (fieldName) {
+                    case "uid":
+                        clientInfo.uniqueIdentifier = reader.getString();
+                        break;
+                    case "utid":
+                        clientInfo.uniqueTenantIdentifier = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return clientInfo;
+        });
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+        jsonWriter.writeStringField("uid", uniqueIdentifier);
+        jsonWriter.writeStringField("utid", uniqueTenantIdentifier);
+        jsonWriter.writeEndObject();
+        return jsonWriter;
     }
 
     String toAccountIdentifier() {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Credential.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Credential.java
@@ -3,24 +3,66 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 
-class Credential {
+import java.io.IOException;
 
-    @JsonProperty("home_account_id")
+class Credential implements JsonSerializable<Credential> {
+
     protected String homeAccountId;
-
-    @JsonProperty("environment")
     protected String environment;
-
-    @JsonProperty("client_id")
     protected String clientId;
-
-    @JsonProperty("secret")
     protected String secret;
-
-    @JsonProperty("user_assertion_hash")
     protected String userAssertionHash;
+
+    static Credential fromJson(JsonReader jsonReader) throws IOException {
+        Credential credential = new Credential();
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+                switch (fieldName) {
+                    case "home_account_id":
+                        credential.homeAccountId = reader.getString();
+                        break;
+                    case "environment":
+                        credential.environment = reader.getString();
+                        break;
+                    case "client_id":
+                        credential.clientId = reader.getString();
+                        break;
+                    case "secret":
+                        credential.secret = reader.getString();
+                        break;
+                    case "user_assertion_hash":
+                        credential.userAssertionHash = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return credential;
+        });
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+
+        jsonWriter.writeStringField("home_account_id", homeAccountId);
+        jsonWriter.writeStringField("environment", environment);
+        jsonWriter.writeStringField("client_id", clientId);
+        jsonWriter.writeStringField("secret", secret);
+        jsonWriter.writeStringField("user_assertion_hash", userAssertionHash);
+
+        jsonWriter.writeEndObject();
+
+        return jsonWriter;
+    }
 
     String homeAccountId() {
         return this.homeAccountId;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCode.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCode.java
@@ -3,35 +3,81 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
+
+import java.io.IOException;
 
 /**
  * Response returned from the STS device code endpoint containing information necessary for
  * device code flow
  */
-public final class DeviceCode {
+public final class DeviceCode implements JsonSerializable<DeviceCode> {
 
-    @JsonProperty("user_code")
     private String userCode;
-
-    @JsonProperty("device_code")
     private String deviceCode;
-
-    @JsonProperty("verification_uri")
     private String verificationUri;
-
-    @JsonProperty("expires_in")
     private long expiresIn;
-
-    @JsonProperty("interval")
     private long interval;
-
-    @JsonProperty("message")
     private String message;
 
     private transient String correlationId = null;
     private transient String clientId = null;
     private transient String scopes = null;
+
+    public static DeviceCode fromJson(JsonReader jsonReader) throws IOException {
+        DeviceCode deviceCode = new DeviceCode();
+
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                switch (fieldName) {
+                    case "user_code":
+                        deviceCode.userCode = reader.getString();
+                        break;
+                    case "device_code":
+                        deviceCode.deviceCode = reader.getString();
+                        break;
+                    case "verification_uri":
+                        deviceCode.verificationUri = reader.getString();
+                        break;
+                    case "expires_in":
+                        deviceCode.expiresIn = reader.getLong();
+                        break;
+                    case "interval":
+                        deviceCode.interval = reader.getLong();
+                        break;
+                    case "message":
+                        deviceCode.message = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return deviceCode;
+        });
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+
+        jsonWriter.writeStringField("user_code", userCode);
+        jsonWriter.writeStringField("device_code", deviceCode);
+        jsonWriter.writeStringField("verification_uri", verificationUri);
+        jsonWriter.writeNumberField("expires_in", expiresIn);
+        jsonWriter.writeNumberField("interval", interval);
+        jsonWriter.writeStringField("message", message);
+
+        jsonWriter.writeEndObject();
+
+        return jsonWriter;
+    }
 
     /**
      * code which user needs to provide when authenticating at the verification URI

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCode.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCode.java
@@ -23,9 +23,9 @@ public final class DeviceCode implements JsonSerializable<DeviceCode> {
     private long interval;
     private String message;
 
-    private transient String correlationId = null;
-    private transient String clientId = null;
-    private transient String scopes = null;
+    private String correlationId = null;
+    private String clientId = null;
+    private String scopes = null;
 
     public static DeviceCode fromJson(JsonReader jsonReader) throws IOException {
         DeviceCode deviceCode = new DeviceCode();

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowRequest.java
@@ -89,7 +89,7 @@ class DeviceCodeFlowRequest extends MsalRequest {
             String clientId) {
 
         DeviceCode result;
-        result = JsonHelper.convertJsonToObject(json, DeviceCode.class);
+        result = JsonHelper.convertJsonStringToJsonSerializableObject(json, DeviceCode::fromJson);
 
         String correlationIdHeader = headers.get(HttpHeaders.CORRELATION_ID_HEADER_NAME);
         if (correlationIdHeader != null) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ErrorResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ErrorResponse.java
@@ -3,36 +3,97 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 
-class ErrorResponse {
+import java.io.IOException;
+
+class ErrorResponse implements JsonSerializable<ErrorResponse> {
 
     private Integer statusCode;
     private String statusMessage;
-
-    @JsonProperty("error")
     protected String error;
-
-    @JsonProperty("error_description")
     protected String errorDescription;
-
-    @JsonProperty("error_codes")
     protected long[] errorCodes;
-
-    @JsonProperty("suberror")
     protected String subError;
-
-    @JsonProperty("trace_id")
     protected String traceId;
-
-    @JsonProperty("timestamp")
     protected String timestamp;
-
-    @JsonProperty("correlation_id")
     protected String correlation_id;
-
-    @JsonProperty("claims")
     private String claims;
+
+    static ErrorResponse fromJson(JsonReader jsonReader) throws IOException {
+        ErrorResponse entity = new ErrorResponse();
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+                switch (fieldName) {
+                    case "error":
+                        entity.error = reader.getString();
+                        break;
+                    case "error_description":
+                        entity.errorDescription = reader.getString();
+                        break;
+                    case "error_codes":
+                        entity.errorCodes = reader.readArray(JsonReader::getLong).stream().mapToLong(Long::longValue).toArray();
+                        break;
+                    case "suberror":
+                        entity.subError = reader.getString();
+                        break;
+                    case "trace_id":
+                        entity.traceId = reader.getString();
+                        break;
+                    case "timestamp":
+                        entity.timestamp = reader.getString();
+                        break;
+                    case "correlation_id":
+                        entity.correlation_id = reader.getString();
+                        break;
+                    case "claims":
+                        entity.claims = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return entity;
+        });
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+
+        jsonWriter.writeStartObject();
+
+        jsonWriter.writeNumberField("statusCode", statusCode);
+        jsonWriter.writeStringField("statusMessage", statusMessage);
+        jsonWriter.writeStringField("error", error);
+        jsonWriter.writeStringField("error_description", errorDescription);
+
+        if (errorCodes != null) {
+            jsonWriter.writeStartArray("error_codes");
+            for (long code : errorCodes) {
+                jsonWriter.writeNumber(code);
+            }
+            jsonWriter.writeEndArray();
+        } else {
+            jsonWriter.writeNullField("error_codes");
+        }
+
+        jsonWriter.writeStringField("suberror", subError);
+        jsonWriter.writeStringField("trace_id", traceId);
+        jsonWriter.writeStringField("timestamp", timestamp);
+        jsonWriter.writeStringField("correlation_id", correlation_id);
+        jsonWriter.writeStringField("claims", claims);
+
+        jsonWriter.writeEndObject();
+
+        return jsonWriter;
+    }
 
     Integer statusCode() {
         return this.statusCode;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IdToken.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IdToken.java
@@ -3,44 +3,102 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
+
+import java.io.IOException;
 import java.io.Serializable;
 
-class IdToken implements Serializable {
+class IdToken implements Serializable, JsonSerializable<IdToken> {
 
-    @JsonProperty("iss")
     protected String issuer;
-
-    @JsonProperty("sub")
     protected String subject;
-
-    @JsonProperty("aud")
     protected String audience;
-
-    @JsonProperty("exp")
     protected Long expirationTime;
-
-    @JsonProperty("iat")
     protected Long issuedAt;
-
-    @JsonProperty("nbf")
     protected Long notBefore;
-
-    @JsonProperty("name")
     protected String name;
-
-    @JsonProperty("preferred_username")
     protected String preferredUsername;
-
-    @JsonProperty("oid")
     protected String objectIdentifier;
-
-    @JsonProperty("tid")
     protected String tenantIdentifier;
-
-    @JsonProperty("upn")
     protected String upn;
-
-    @JsonProperty("unique_name")
     protected String uniqueName;
+
+    static IdToken fromJson(JsonReader jsonReader) throws IOException {
+        IdToken idToken = new IdToken();
+
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                switch (fieldName) {
+                    case "iss":
+                        idToken.issuer = reader.getString();
+                        break;
+                    case "sub":
+                        idToken.subject = reader.getString();
+                        break;
+                    case "aud":
+                        idToken.audience = reader.getString();
+                        break;
+                    case "exp":
+                        idToken.expirationTime = reader.getLong();
+                        break;
+                    case "iat":
+                        idToken.issuedAt = reader.getLong();
+                        break;
+                    case "nbf":
+                        idToken.notBefore = reader.getLong();
+                        break;
+                    case "name":
+                        idToken.name = reader.getString();
+                        break;
+                    case "preferred_username":
+                        idToken.preferredUsername = reader.getString();
+                        break;
+                    case "oid":
+                        idToken.objectIdentifier = reader.getString();
+                        break;
+                    case "tid":
+                        idToken.tenantIdentifier = reader.getString();
+                        break;
+                    case "upn":
+                        idToken.upn = reader.getString();
+                        break;
+                    case "unique_name":
+                        idToken.uniqueName = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return idToken;
+        });
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+
+        jsonWriter.writeStringField("iss", issuer);
+        jsonWriter.writeStringField("sub", subject);
+        jsonWriter.writeStringField("aud", audience);
+        jsonWriter.writeNumberField("exp", expirationTime);
+        jsonWriter.writeNumberField("iat", issuedAt);
+        jsonWriter.writeNumberField("nbf", notBefore);
+        jsonWriter.writeStringField("name", name);
+        jsonWriter.writeStringField("preferred_username", preferredUsername);
+        jsonWriter.writeStringField("oid", objectIdentifier);
+        jsonWriter.writeStringField("tid", tenantIdentifier);
+        jsonWriter.writeStringField("upn", upn);
+        jsonWriter.writeStringField("unique_name", uniqueName);
+
+        jsonWriter.writeEndObject();
+
+        return jsonWriter;
+    }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IdTokenCacheEntity.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IdTokenCacheEntity.java
@@ -3,17 +3,17 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 class IdTokenCacheEntity extends Credential {
 
-    @JsonProperty("credential_type")
     private String credentialType;
-
-    @JsonProperty("realm")
     protected String realm;
 
     String getKey() {
@@ -29,6 +29,62 @@ class IdTokenCacheEntity extends Credential {
         keyParts.add("");
 
         return String.join(Constants.CACHE_KEY_SEPARATOR, keyParts).toLowerCase();
+    }
+
+    static IdTokenCacheEntity fromJson(JsonReader jsonReader) throws IOException {
+        IdTokenCacheEntity entity = new IdTokenCacheEntity();
+
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                switch (fieldName) {
+                    case "home_account_id":
+                        entity.homeAccountId = reader.getString();
+                        break;
+                    case "environment":
+                        entity.environment = reader.getString();
+                        break;
+                    case "credential_type":
+                        entity.credentialType = reader.getString();
+                        break;
+                    case "client_id":
+                        entity.clientId = reader.getString();
+                        break;
+                    case "secret":
+                        entity.secret = reader.getString();
+                        break;
+                    case "realm":
+                        entity.realm = reader.getString();
+                        break;
+                    case "user_assertion_hash":
+                        entity.userAssertionHash = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return entity;
+        });
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+
+        jsonWriter.writeStringField("home_account_id", homeAccountId);
+        jsonWriter.writeStringField("environment", environment);
+        jsonWriter.writeStringField("credential_type", credentialType);
+        jsonWriter.writeStringField("client_id", clientId);
+        jsonWriter.writeStringField("secret", secret);
+        jsonWriter.writeStringField("realm", realm);
+        jsonWriter.writeStringField("user_assertion_hash", userAssertionHash);
+
+        jsonWriter.writeEndObject();
+
+        return jsonWriter;
     }
 
     String credentialType() {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JsonHelper.java
@@ -7,41 +7,22 @@ import com.azure.json.JsonProviders;
 import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 import com.azure.json.ReadValueCallback;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.JsonNode;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 class JsonHelper {
-    static ObjectMapper mapper;
-
-    static {
-        mapper = new ObjectMapper();
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, true);
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-    }
 
     private JsonHelper() {
     }
 
-    static <T> T convertJsonToObject(final String json, final Class<T> tClass) {
-        try {
-            return mapper.readValue(json, tClass);
-        } catch (Exception e) {
-            throw new MsalJsonParsingException(e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
-        }
-    }
-
     static IdToken createIdTokenFromEncodedTokenString(String token) {
-        return JsonHelper.convertJsonToObject(getTokenPayloadClaims(token), IdToken.class);
+        return convertJsonStringToJsonSerializableObject(getTokenPayloadClaims(token), IdToken::fromJson);
     }
 
     static String getTokenPayloadClaims(String token) {
@@ -53,7 +34,6 @@ class JsonHelper {
         }
     }
 
-    //Converts a generic JSON string to a Map<String, Object> with relevant types
     static Map<String, Object> parseJsonToMap(String jsonString) {
         if (StringHelper.isBlank(jsonString)) {
             return new HashMap<>();
@@ -92,29 +72,23 @@ class JsonHelper {
         JsonToken token = jsonReader.currentToken();
 
         switch (token) {
-            case STRING:
-                return jsonReader.getString();
+            case STRING: return jsonReader.getString();
             case NUMBER:
                 try {
                     return jsonReader.getLong();
                 } catch (ArithmeticException e) {
                     return jsonReader.getDouble();
                 }
-            case BOOLEAN:
-                return jsonReader.getBoolean();
-            case NULL:
-                return null;
-            case START_ARRAY:
-                return parseJsonArray(jsonReader);
-            case START_OBJECT:
-                return parseJsonObject(jsonReader);
+            case BOOLEAN: return jsonReader.getBoolean();
+            case NULL: return null;
+            case START_ARRAY: return parseJsonArray(jsonReader);
+            case START_OBJECT: return parseJsonObject(jsonReader);
             default:
                 jsonReader.skipChildren();
                 return null;
         }
     }
 
-    //This method is used to convert a JSON string to an object which implements the JsonSerializable interface from com.azure.json
     static <T extends JsonSerializable<T>> T convertJsonStringToJsonSerializableObject(String jsonResponse, ReadValueCallback<JsonReader, T> readFunction) {
         try (JsonReader jsonReader = JsonProviders.createReader(jsonResponse)) {
             return readFunction.read(jsonReader);
@@ -123,90 +97,102 @@ class JsonHelper {
         }
     }
 
-    //Converts a JSON string to a Map<String, String>
+    static <T extends JsonSerializable<T>> String convertJsonSerializableObjectToString(T jsonSerializable) {
+        try {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            JsonWriter jsonWriter = JsonProviders.createWriter(outputStream);
+
+            jsonSerializable.toJson(jsonWriter);
+            jsonWriter.flush();
+
+            return outputStream.toString(StandardCharsets.UTF_8.name());
+        } catch (Exception e) {
+            throw new MsalClientException("Error serializing object to JSON: " + e.getMessage(),
+                    AuthenticationErrorCode.INVALID_JSON);
+        }
+    }
+
     static Map<String, String> convertJsonToMap(String jsonString) {
         try (JsonReader reader = JsonProviders.createReader(jsonString)) {
             reader.nextToken();
             return reader.readMap(JsonReader::getString);
         } catch (IOException e) {
-            throw new MsalClientException("Could not parse JSON from HttpResponse body: " + e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
+            throw new MsalClientException("Could not parse JSON from HttpResponse body: " + e.getMessage(),
+                    AuthenticationErrorCode.INVALID_JSON);
         }
     }
 
-    /**
-     * Throws exception if given String does not follow JSON syntax
-     */
     static void validateJsonFormat(String jsonString) {
-        try {
-            mapper.readTree(jsonString);
+        try (JsonReader reader = JsonProviders.createReader(jsonString)) {
+            while (reader.nextToken() != JsonToken.END_DOCUMENT) {
+                reader.skipChildren();
+            }
         } catch (IOException e) {
             throw new MsalClientException(e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
         }
     }
 
-    /**
-     * Take a set of Strings and return a String representing a JSON object of the format:
-     *  {
-     *    "access_token": {
-     *      "xms_cc": {
-     *        "values": [ clientCapabilities ]
-     *      }
-     *    }
-     *  }
-     */
     public static String formCapabilitiesJson(Set<String> clientCapabilities) {
-        if (clientCapabilities != null && !clientCapabilities.isEmpty()) {
-            ClaimsRequest cr = new ClaimsRequest();
-            RequestedClaimAdditionalInfo capabilitiesValues = new RequestedClaimAdditionalInfo(false, null, new ArrayList<>(clientCapabilities));
-            cr.requestClaimInAccessToken("xms_cc", capabilitiesValues);
-
-            return cr.formatAsJSONString();
-        } else {
+        if (clientCapabilities == null || clientCapabilities.isEmpty()) {
             return null;
         }
+
+        ClaimsRequest cr = new ClaimsRequest();
+        RequestedClaimAdditionalInfo capabilitiesValues = new RequestedClaimAdditionalInfo(
+                false, null, new ArrayList<>(clientCapabilities));
+        cr.requestClaimInAccessToken("xms_cc", capabilitiesValues);
+
+        return cr.formatAsJSONString();
     }
 
-    /**
-     * Merges given JSON strings into one Jackson JSONNode object, which is returned as a String
-     */
     static String mergeJSONString(String mainJsonString, String addJsonString) {
-        JsonNode mainJson;
-        JsonNode addJson;
-
         try {
-            mainJson = mapper.readTree(mainJsonString);
-            addJson = mapper.readTree(addJsonString);
+            Map<String, Object> mainMap = parseJsonToMap(mainJsonString);
+            Map<String, Object> addMap = parseJsonToMap(addJsonString);
+
+            mergeJsonMaps(mainMap, addMap);
+
+            return writeJsonMap(mainMap);
         } catch (IOException e) {
             throw new MsalClientException(e.getMessage(), AuthenticationErrorCode.INVALID_JSON);
         }
-
-        mergeJSONNode(mainJson, addJson);
-
-        return mainJson.toString();
     }
 
-    /**
-     * Merges given Jackson JsonNode object into another JsonNode
-     */
-    static void mergeJSONNode(JsonNode mainNode, JsonNode addNode) {
-        if (addNode == null) {
+    @SuppressWarnings("unchecked")
+    private static void mergeJsonMaps(Map<String, Object> mainMap, Map<String, Object> addMap) {
+        if (addMap == null) {
             return;
         }
 
-        Iterator<String> fieldNames = addNode.fieldNames();
-        while (fieldNames.hasNext()) {
+        for (Map.Entry<String, Object> entry : addMap.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
 
-            String fieldName = fieldNames.next();
-            JsonNode jsonNode = mainNode.get(fieldName);
-
-            if (jsonNode != null && jsonNode.isObject()) {
-                mergeJSONNode(jsonNode, addNode.get(fieldName));
+            if (mainMap.containsKey(key) && mainMap.get(key) instanceof Map && value instanceof Map) {
+                mergeJsonMaps((Map<String, Object>) mainMap.get(key), (Map<String, Object>) value);
             } else {
-                if (mainNode instanceof ObjectNode) {
-                    JsonNode value = addNode.get(fieldName);
-                    ((ObjectNode) mainNode).put(fieldName, value);
-                }
+                mainMap.put(key, value);
             }
+        }
+    }
+
+    static String writeJsonMap(Map<String, Object> map) throws IOException {
+        StringWriter stringWriter = new StringWriter();
+        try (JsonWriter jsonWriter = JsonProviders.createWriter(stringWriter)) {
+
+            jsonWriter.writeStartObject();
+
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                jsonWriter.writeUntypedField(entry.getKey(), entry.getValue());
+            }
+
+            jsonWriter.writeEndObject();
+            jsonWriter.flush();
+
+            return stringWriter.toString();
+        } catch (Exception e) {
+            throw new MsalClientException("Error writing JSON map to string: " + e.getMessage(),
+                    AuthenticationErrorCode.INVALID_JSON);
         }
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JwtHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/JwtHelper.java
@@ -53,8 +53,8 @@ final class JwtHelper {
             payload.put("sub", clientId);
 
             // Concatenate header and payload
-            String jsonHeader = JsonHelper.mapper.writeValueAsString(header);
-            String jsonPayload = JsonHelper.mapper.writeValueAsString(payload);
+            String jsonHeader = JsonHelper.writeJsonMap(header);
+            String jsonPayload = JsonHelper.writeJsonMap(payload);
 
             String encodedHeader = base64UrlEncode(jsonHeader.getBytes(StandardCharsets.UTF_8));
             String encodedPayload = base64UrlEncode(jsonPayload.getBytes(StandardCharsets.UTF_8));

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityErrorResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityErrorResponse.java
@@ -3,29 +3,70 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 
-public class ManagedIdentityErrorResponse {
+import java.io.IOException;
 
-    @JsonProperty("message")
+public class ManagedIdentityErrorResponse implements JsonSerializable<ManagedIdentityErrorResponse> {
+
     private String message;
-
-    @JsonProperty("correlationId")
     private String correlationId;
+    private String error;
+    private String errorDescription;
 
-    //In some MSI scenarios such as Cloud Shell, the actual error info is in a JSON within the main JSON. To parse that second
-    // JSON layer, we need to first pass it into a subclass, parse it using the usual @JsonProperty annotation, and then retrieve the values.
-    @JsonProperty("error")
-    private void parseErrorField(ErrorField errorResponse) {
-        this.error = errorResponse.code;
-        this.message = errorResponse.message;
+    public static ManagedIdentityErrorResponse fromJson(JsonReader jsonReader) throws IOException {
+        ManagedIdentityErrorResponse response = new ManagedIdentityErrorResponse();
+
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                switch (fieldName) {
+                    case "message":
+                        response.message = reader.getString();
+                        break;
+                    case "correlationId":
+                        response.correlationId = reader.getString();
+                        break;
+                    case "error":
+                        if (reader.currentToken() == JsonToken.START_OBJECT) {
+                            // Handle nested JSON error object
+                            ErrorField errorField = ErrorField.fromJson(reader);
+                            response.error = errorField.getCode();
+                            response.message = errorField.getMessage();
+                        } else {
+                            response.error = reader.getString();
+                        }
+                        break;
+                    case "error_description":
+                        response.errorDescription = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return response;
+        });
     }
 
-    @JsonProperty("error")
-    private String error;
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
 
-    @JsonProperty("error_description")
-    private String errorDescription;
+        jsonWriter.writeStringField("message", message);
+        jsonWriter.writeStringField("correlationId", correlationId);
+        jsonWriter.writeStringField("error", error);
+        jsonWriter.writeStringField("error_description", errorDescription);
+
+        jsonWriter.writeEndObject();
+
+        return jsonWriter;
+    }
 
     public String getMessage() {
         return this.message;
@@ -44,13 +85,34 @@ public class ManagedIdentityErrorResponse {
     }
 
     private static class ErrorField {
-        @JsonProperty("code")
         private String code;
-
-        @JsonProperty("message")
         private String message;
 
-       String getCode() {
+        static ErrorField fromJson(JsonReader jsonReader) throws IOException {
+            ErrorField errorField = new ErrorField();
+
+            return jsonReader.readObject(reader -> {
+                while (reader.nextToken() != JsonToken.END_OBJECT) {
+                    String fieldName = reader.getFieldName();
+                    reader.nextToken();
+
+                    switch (fieldName) {
+                        case "code":
+                            errorField.code = reader.getString();
+                            break;
+                        case "message":
+                            errorField.message = reader.getString();
+                            break;
+                        default:
+                            reader.skipChildren();
+                            break;
+                    }
+                }
+                return errorField;
+            });
+        }
+
+        String getCode() {
             return this.code;
         }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalServiceExceptionFactory.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalServiceExceptionFactory.java
@@ -22,9 +22,7 @@ class MsalServiceExceptionFactory {
                     AuthenticationErrorCode.UNKNOWN);
         }
 
-        ErrorResponse errorResponse = JsonHelper.convertJsonToObject(
-                responseBody,
-                ErrorResponse.class);
+        ErrorResponse errorResponse = JsonHelper.convertJsonStringToJsonSerializableObject(responseBody, ErrorResponse::fromJson);
 
         if (errorResponse.error() != null &&
                 errorResponse.error().equalsIgnoreCase(AuthenticationErrorCode.INVALID_GRANT) && isInteractionRequired(errorResponse.subError)) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RefreshTokenCacheEntity.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RefreshTokenCacheEntity.java
@@ -3,18 +3,70 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 class RefreshTokenCacheEntity extends Credential {
 
-    @JsonProperty("credential_type")
     private String credentialType;
-
-    @JsonProperty("family_id")
     private String family_id;
+
+    static RefreshTokenCacheEntity fromJson(JsonReader jsonReader) throws IOException {
+        RefreshTokenCacheEntity entity = new RefreshTokenCacheEntity();
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+                switch (fieldName) {
+                    case "credential_type":
+                        entity.credentialType = reader.getString();
+                        break;
+                    case "family_id":
+                        entity.family_id = reader.getString();
+                        break;
+                    // Include other fields from the Credential parent class
+                    case "home_account_id":
+                        entity.homeAccountId = reader.getString();
+                        break;
+                    case "environment":
+                        entity.environment = reader.getString();
+                        break;
+                    case "client_id":
+                        entity.clientId = reader.getString();
+                        break;
+                    case "secret":
+                        entity.secret = reader.getString();
+                        break;
+                    // Add other Credential fields as needed
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return entity;
+        });
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+
+        jsonWriter.writeStringField("credential_type", credentialType);
+        jsonWriter.writeStringField("family_id", family_id);
+        jsonWriter.writeStringField("home_account_id", homeAccountId);
+        jsonWriter.writeStringField("environment", environment);
+        jsonWriter.writeStringField("client_id", clientId);
+        jsonWriter.writeStringField("secret", secret);
+
+        jsonWriter.writeEndObject();
+
+        return jsonWriter;
+    }
 
     boolean isFamilyRT() {
         return !StringHelper.isBlank(family_id);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenCache.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenCache.java
@@ -3,11 +3,11 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.azure.json.*;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -41,19 +41,10 @@ public class TokenCache implements ITokenCache {
     public TokenCache() {
     }
 
-    @JsonProperty("AccessToken")
     Map<String, AccessTokenCacheEntity> accessTokens = new LinkedHashMap<>();
-
-    @JsonProperty("RefreshToken")
     Map<String, RefreshTokenCacheEntity> refreshTokens = new LinkedHashMap<>();
-
-    @JsonProperty("IdToken")
     Map<String, IdTokenCacheEntity> idTokens = new LinkedHashMap<>();
-
-    @JsonProperty("Account")
     Map<String, AccountCacheEntity> accounts = new LinkedHashMap<>();
-
-    @JsonProperty("AppMetadata")
     Map<String, AppMetadataCacheEntity> appMetadata = new LinkedHashMap<>();
 
     transient ITokenCacheAccessAspect tokenCacheAccessAspect;
@@ -67,70 +58,64 @@ public class TokenCache implements ITokenCache {
         }
         serializedCachedSnapshot = data;
 
-        TokenCache deserializedCache = JsonHelper.convertJsonToObject(data, TokenCache.class);
+        try {
+            JsonReader jsonReader = JsonProviders.createReader(data);
+            deserializeFromJson(jsonReader);
+        } catch (IOException e) {
+            throw new MsalClientException(e);
+        }
+    }
 
+    private void deserializeFromJson(JsonReader jsonReader) throws IOException {
         lock.writeLock().lock();
         try {
-            this.accounts = deserializedCache.accounts;
-            this.accessTokens = deserializedCache.accessTokens;
-            this.refreshTokens = deserializedCache.refreshTokens;
-            this.idTokens = deserializedCache.idTokens;
-            this.appMetadata = deserializedCache.appMetadata;
+            jsonReader.readObject(reader -> {
+                while (reader.nextToken() != JsonToken.END_OBJECT) {
+                    String fieldName = reader.getFieldName();
+                    reader.nextToken();
+
+                    switch (fieldName) {
+                        case "AccessToken":
+                            deserializeCollection(reader, accessTokens, AccessTokenCacheEntity::fromJson);
+                            break;
+                        case "RefreshToken":
+                            deserializeCollection(reader, refreshTokens, RefreshTokenCacheEntity::fromJson);
+                            break;
+                        case "IdToken":
+                            deserializeCollection(reader, idTokens, IdTokenCacheEntity::fromJson);
+                            break;
+                        case "Account":
+                            deserializeCollection(reader, accounts, AccountCacheEntity::fromJson);
+                            break;
+                        case "AppMetadata":
+                            deserializeCollection(reader, appMetadata, AppMetadataCacheEntity::fromJson);
+                            break;
+                        default:
+                            reader.skipChildren();
+                            break;
+                    }
+                }
+                return null;
+            });
         } finally {
             lock.writeLock().unlock();
         }
     }
 
-    private static void mergeJsonObjects(JsonNode old, JsonNode update) {
-        mergeRemovals(old, update);
-        mergeUpdates(old, update);
-    }
+    private <T> void deserializeCollection(
+            JsonReader reader,
+            Map<String, T> targetCollection,
+            ReadValueCallback<JsonReader, T> deserializer) throws IOException {
 
-    private static void mergeUpdates(JsonNode old, JsonNode update) {
-        Iterator<String> fieldNames = update.fieldNames();
-        while (fieldNames.hasNext()) {
-            String uKey = fieldNames.next();
-            JsonNode uValue = update.get(uKey);
-
-            // add new property
-            if (!old.has(uKey)) {
-                if (!uValue.isNull() &&
-                        !(uValue.isObject() && uValue.size() == 0)) {
-                    ((ObjectNode) old).set(uKey, uValue);
-                }
+        reader.readObject(entityReader -> {
+            while (entityReader.nextToken() != JsonToken.END_OBJECT) {
+                String key = entityReader.getFieldName();
+                entityReader.nextToken();
+                T entity = deserializer.read(entityReader);
+                targetCollection.put(key, entity);
             }
-            // merge old and new property
-            else {
-                JsonNode oValue = old.get(uKey);
-                if (uValue.isObject()) {
-                    mergeUpdates(oValue, uValue);
-                } else {
-                    ((ObjectNode) old).set(uKey, uValue);
-                }
-            }
-        }
-    }
-
-    private static void mergeRemovals(JsonNode old, JsonNode update) {
-        Set<String> msalEntities =
-                new HashSet<>(Arrays.asList("Account", "AccessToken", "RefreshToken", "IdToken", "AppMetadata"));
-
-        for (String msalEntity : msalEntities) {
-            JsonNode oldEntries = old.get(msalEntity);
-            JsonNode newEntries = update.get(msalEntity);
-            if (oldEntries != null) {
-                Iterator<Map.Entry<String, JsonNode>> iterator = oldEntries.fields();
-
-                while (iterator.hasNext()) {
-                    Map.Entry<String, JsonNode> oEntry = iterator.next();
-
-                    String key = oEntry.getKey();
-                    if (newEntries == null || !newEntries.has(key)) {
-                        iterator.remove();
-                    }
-                }
-            }
-        }
+            return null;
+        });
     }
 
     @Override
@@ -138,19 +123,87 @@ public class TokenCache implements ITokenCache {
         lock.readLock().lock();
         try {
             if (!StringHelper.isBlank(serializedCachedSnapshot)) {
-                JsonNode cache = JsonHelper.mapper.readTree(serializedCachedSnapshot);
-                JsonNode update = JsonHelper.mapper.valueToTree(this);
-
-                mergeJsonObjects(cache, update);
-
-                return JsonHelper.mapper.writeValueAsString(cache);
+                String updatedCache = mergeWithExistingCache();
+                if (updatedCache != null) {
+                    return updatedCache;
+                }
             }
-            return JsonHelper.mapper.writeValueAsString(this);
-        } catch (IOException e) {
-            throw new MsalClientException(e);
+            return serializeToJson();
         } finally {
             lock.readLock().unlock();
         }
+    }
+
+    private String serializeToJson() {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             JsonWriter jsonWriter = JsonProviders.createWriter(outputStream)) {
+
+            jsonWriter.writeStartObject();
+
+            // Write all collections
+            writeCollection(jsonWriter, "AccessToken", accessTokens);
+            writeCollection(jsonWriter, "RefreshToken", refreshTokens);
+            writeCollection(jsonWriter, "IdToken", idTokens);
+            writeCollection(jsonWriter, "Account", accounts);
+            writeCollection(jsonWriter, "AppMetadata", appMetadata);
+
+            jsonWriter.writeEndObject();
+            jsonWriter.flush();
+
+            return outputStream.toString(StandardCharsets.UTF_8.name());
+        } catch (IOException e) {
+            throw new MsalClientException(e);
+        }
+    }
+
+    private <T> void writeCollection(
+            JsonWriter jsonWriter,
+            String collectionName,
+            Map<String, T> collection) throws IOException {
+
+        jsonWriter.writeFieldName(collectionName);
+
+        jsonWriter.writeStartObject();
+
+        for (Map.Entry<String, T> entry : collection.entrySet()) {
+            jsonWriter.writeFieldName(entry.getKey());
+            if (entry.getValue() instanceof JsonSerializable) {
+                ((JsonSerializable<?>) entry.getValue()).toJson(jsonWriter);
+            }
+        }
+
+        jsonWriter.writeEndObject();
+    }
+
+    private String mergeWithExistingCache() {
+        try {
+            // Parse existing cache snapshot
+            TokenCache updatedCache = new TokenCache();
+            updatedCache.deserialize(serializedCachedSnapshot);
+
+            // Merge current in-memory cache with the snapshot
+            mergeCache(updatedCache);
+
+            // Serialize merged cache
+            return updatedCache.serializeToJson();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private void mergeCache(TokenCache targetCache) {
+        targetCache.accessTokens.putAll(accessTokens);
+        targetCache.refreshTokens.putAll(refreshTokens);
+        targetCache.idTokens.putAll(idTokens);
+        targetCache.accounts.putAll(accounts);
+        targetCache.appMetadata.putAll(appMetadata);
+
+        // Handle removals by removing keys that are not in the current cache
+        targetCache.accessTokens.keySet().retainAll(accessTokens.keySet());
+        targetCache.refreshTokens.keySet().retainAll(refreshTokens.keySet());
+        targetCache.idTokens.keySet().retainAll(idTokens.keySet());
+        targetCache.accounts.keySet().retainAll(accounts.keySet());
+        targetCache.appMetadata.keySet().retainAll(appMetadata.keySet());
     }
 
     private class CacheAspect implements AutoCloseable {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenCache.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenCache.java
@@ -23,7 +23,7 @@ public class TokenCache implements ITokenCache {
 
     protected static final int MIN_ACCESS_TOKEN_EXPIRE_IN_SEC = 5 * 60;
 
-    transient private ReadWriteLock lock = new ReentrantReadWriteLock();
+    private ReadWriteLock lock = new ReentrantReadWriteLock();
 
     /**
      * Constructor for token cache
@@ -47,9 +47,9 @@ public class TokenCache implements ITokenCache {
     Map<String, AccountCacheEntity> accounts = new LinkedHashMap<>();
     Map<String, AppMetadataCacheEntity> appMetadata = new LinkedHashMap<>();
 
-    transient ITokenCacheAccessAspect tokenCacheAccessAspect;
+    ITokenCacheAccessAspect tokenCacheAccessAspect;
 
-    private transient String serializedCachedSnapshot;
+    private String serializedCachedSnapshot;
 
     @Override
     public void deserialize(String data) {

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
@@ -153,7 +153,7 @@ class AuthorizationRequestUrlParametersTest {
         assertEquals(queryParameters.get("correlation_id"), "corr_id");
         assertEquals(queryParameters.get("login_hint"), "hint");
         assertEquals(queryParameters.get("domain_hint"), "domain_hint");
-        assertEquals(queryParameters.get("claims"), "{\"id_token\":{\"auth_time\":{\"essential\":true}},\"access_token\":{\"auth_time\":{\"essential\":true},\"xms_cc\":{\"values\":[\"llt\",\"ssm\"]}}}");
+        assertEquals(queryParameters.get("claims"), "{\"access_token\":{\"auth_time\":{\"essential\":true},\"xms_cc\":{\"values\":[\"llt\",\"ssm\"]}},\"id_token\":{\"auth_time\":{\"essential\":true}}}");
 
         // CCS routing
         assertEquals(queryParameters.get(HttpHeaders.X_ANCHOR_MAILBOX), String.format(HttpHeaders.X_ANCHOR_MAILBOX_UPN_FORMAT, "hint"));

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
@@ -182,7 +182,7 @@ class CacheFormatTests {
         String keyExpected = readResource(folder + AT_CACHE_ENTITY_KEY);
         assertEquals(keyActual, keyExpected);
 
-        String valueActual = JsonHelper.mapper.writeValueAsString(tokenCache.accessTokens.get(keyActual));
+        String valueActual = JsonHelper.convertJsonSerializableObjectToString(tokenCache.accessTokens.get(keyActual));
         String valueExpected = readResource(folder + AT_CACHE_ENTITY);
 
         JSONObject tokenResponseJsonObj = JSONObjectUtils.parse(tokenResponse);
@@ -213,7 +213,7 @@ class CacheFormatTests {
         String keyExpected = readResource(folder + RT_CACHE_ENTITY_KEY);
         assertEquals(actualKey, keyExpected);
 
-        String actualValue = JsonHelper.mapper.writeValueAsString(tokenCache.refreshTokens.get(actualKey));
+        String actualValue = JsonHelper.convertJsonSerializableObjectToString(tokenCache.refreshTokens.get(actualKey));
         String valueExpected = readResource(folder + RT_CACHE_ENTITY);
         JSONAssert.assertEquals(valueExpected, actualValue, JSONCompareMode.STRICT);
     }
@@ -249,7 +249,7 @@ class CacheFormatTests {
         String keyExpected = readResource(folder + ID_TOKEN_CACHE_ENTITY_KEY);
         assertEquals(actualKey, keyExpected);
 
-        String actualValue = JsonHelper.mapper.writeValueAsString(tokenCache.idTokens.get(actualKey));
+        String actualValue = JsonHelper.convertJsonSerializableObjectToString(tokenCache.idTokens.get(actualKey));
         String valueExpected = readResource(folder + ID_TOKEN_CACHE_ENTITY);
         JSONAssert.assertEquals(valueExpected, actualValue,
                 new IdTokenComparator(JSONCompareMode.STRICT, folder));
@@ -264,7 +264,7 @@ class CacheFormatTests {
         String keyExpected = readResource(folder + ACCOUNT_CACHE_ENTITY_KEY);
         assertEquals(actualKey, keyExpected);
 
-        String actualValue = JsonHelper.mapper.writeValueAsString(tokenCache.accounts.get(actualKey));
+        String actualValue = JsonHelper.convertJsonSerializableObjectToString(tokenCache.accounts.get(actualKey));
         String valueExpected = readResource(folder + ACCOUNT_CACHE_ENTITY);
 
         JSONAssert.assertEquals(valueExpected, actualValue, JSONCompareMode.STRICT);
@@ -283,7 +283,7 @@ class CacheFormatTests {
         String keyExpected = readResource(folder + APP_METADATA_ENTITY_KEY);
         assertEquals(actualKey, keyExpected);
 
-        String actualValue = JsonHelper.mapper.writeValueAsString(tokenCache.appMetadata.get(actualKey));
+        String actualValue = JsonHelper.convertJsonSerializableObjectToString(tokenCache.appMetadata.get(actualKey));
         String valueExpected = readResource(folder + APP_METADATA_CACHE_ENTITY);
 
         JSONAssert.assertEquals(valueExpected, actualValue, JSONCompareMode.STRICT);

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheTests.java
@@ -3,13 +3,18 @@
 
 package com.microsoft.aad.msal4j;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -17,6 +22,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class CacheTests {
+
+    private TokenCache tokenCache;
+
+    @BeforeEach
+    void setUp() {
+        tokenCache = new TokenCache();
+    }
 
     @Test
     void cacheLookup_MixAccountBasedAndAssertionBasedSilentFlows() throws Exception {
@@ -66,5 +78,252 @@ class CacheTests {
         //Ensure the correct access tokens were returned from each silent call
         assertEquals("accessTokenNoAccount", resultNoAccount.accessToken());
         assertEquals("accessTokenWithAccount", resultWithAccount.accessToken());
+    }
+
+    @Test
+    void serializeDeserialize_EmptyCache_Success() {
+        // Serialize empty cache
+        String serializedCache = tokenCache.serialize();
+
+        // Should have all required sections but be empty
+        assertTrue(serializedCache.contains("\"Account\":{}"));
+        assertTrue(serializedCache.contains("\"AccessToken\":{}"));
+        assertTrue(serializedCache.contains("\"RefreshToken\":{}"));
+        assertTrue(serializedCache.contains("\"IdToken\":{}"));
+        assertTrue(serializedCache.contains("\"AppMetadata\":{}"));
+
+        // Create new cache and deserialize
+        TokenCache newCache = new TokenCache();
+        newCache.deserialize(serializedCache);
+
+        // Verify all collections are empty
+        assertTrue(newCache.accessTokens.isEmpty());
+        assertTrue(newCache.refreshTokens.isEmpty());
+        assertTrue(newCache.idTokens.isEmpty());
+        assertTrue(newCache.accounts.isEmpty());
+        assertTrue(newCache.appMetadata.isEmpty());
+    }
+
+    @Test
+    void serializeDeserialize_WithAccountData_PreservesData() {
+        // Add an account to the cache
+        AccountCacheEntity account = new AccountCacheEntity();
+        account.homeAccountId("home-account-id");
+        account.environment("login.microsoftonline.com");
+        account.realm("tenant-id");
+        account.localAccountId("local-id");
+        account.username("user@example.com");
+        account.name("Test User");
+
+        tokenCache.accounts.put(account.getKey(), account);
+
+        // Serialize the cache
+        String serializedCache = tokenCache.serialize();
+
+        // Create new cache and deserialize
+        TokenCache newCache = new TokenCache();
+        newCache.deserialize(serializedCache);
+
+        // Verify account was preserved
+        assertEquals(1, newCache.accounts.size());
+        AccountCacheEntity deserializedAccount = newCache.accounts.get(account.getKey());
+        assertNotNull(deserializedAccount);
+        assertEquals("home-account-id", deserializedAccount.homeAccountId());
+        assertEquals("login.microsoftonline.com", deserializedAccount.environment());
+        assertEquals("tenant-id", deserializedAccount.realm());
+        assertEquals("user@example.com", deserializedAccount.username());
+        assertEquals("Test User", deserializedAccount.name());
+    }
+
+    @Test
+    void removeAccount_RemovesAllRelatedEntities() {
+        // Setup test data
+        String homeAccountId = "home-account-id";
+        String environment = "login.microsoftonline.com";
+        String clientId = "client-id";
+        String realm = "tenant-id";
+        String username = "user@example.com";
+
+        // Create account
+        AccountCacheEntity account = new AccountCacheEntity();
+        account.homeAccountId(homeAccountId);
+        account.environment(environment);
+        account.realm(realm);
+        account.username(username);
+        tokenCache.accounts.put(account.getKey(), account);
+
+        // Create access token
+        AccessTokenCacheEntity accessToken = new AccessTokenCacheEntity();
+        accessToken.homeAccountId(homeAccountId);
+        accessToken.environment(environment);
+        accessToken.clientId(clientId);
+        accessToken.realm(realm);
+        accessToken.target("scope1 scope2");
+        accessToken.secret("access-token-secret");
+        accessToken.cachedAt("1600000000");
+        accessToken.expiresOn("1600100000");
+        tokenCache.accessTokens.put(accessToken.getKey(), accessToken);
+
+        // Create refresh token
+        RefreshTokenCacheEntity refreshToken = new RefreshTokenCacheEntity();
+        refreshToken.homeAccountId(homeAccountId);
+        refreshToken.environment(environment);
+        refreshToken.clientId(clientId);
+        refreshToken.secret("refresh-token-secret");
+        tokenCache.refreshTokens.put(refreshToken.getKey(), refreshToken);
+
+        // Create ID token
+        IdTokenCacheEntity idToken = new IdTokenCacheEntity();
+        idToken.homeAccountId(homeAccountId);
+        idToken.environment(environment);
+        idToken.clientId(clientId);
+        idToken.realm(realm);
+        idToken.secret("id-token-secret");
+        tokenCache.idTokens.put(idToken.getKey(), idToken);
+
+        // Remove the account
+        tokenCache.removeAccount(clientId, new Account(homeAccountId, environment, username, null));
+
+        // Verify all related entities are removed
+        assertTrue(tokenCache.accounts.isEmpty());
+        assertTrue(tokenCache.accessTokens.isEmpty());
+        assertTrue(tokenCache.refreshTokens.isEmpty());
+        assertTrue(tokenCache.idTokens.isEmpty());
+    }
+
+    @Test
+    void removeAccount_WithMultipleAccounts_OnlyRemovesSpecificAccount() {
+        // Create two accounts with different homeAccountIds
+        String homeAccountId1 = "home-account-id-1";
+        String homeAccountId2 = "home-account-id-2";
+        String environment = "login.microsoftonline.com";
+        String clientId = "client-id";
+        String username = "user@example.com";
+
+        // Account 1
+        AccountCacheEntity account1 = new AccountCacheEntity();
+        account1.homeAccountId(homeAccountId1);
+        account1.environment(environment);
+        tokenCache.accounts.put(account1.getKey(), account1);
+
+        // Account 2
+        AccountCacheEntity account2 = new AccountCacheEntity();
+        account2.homeAccountId(homeAccountId2);
+        account2.environment(environment);
+        tokenCache.accounts.put(account2.getKey(), account2);
+
+        // Add tokens for both accounts
+        AccessTokenCacheEntity accessToken1 = new AccessTokenCacheEntity();
+        accessToken1.homeAccountId(homeAccountId1);
+        accessToken1.environment(environment);
+        accessToken1.clientId(clientId);
+        accessToken1.expiresOn("1600100000");
+        tokenCache.accessTokens.put(accessToken1.getKey(), accessToken1);
+
+        AccessTokenCacheEntity accessToken2 = new AccessTokenCacheEntity();
+        accessToken2.homeAccountId(homeAccountId2);
+        accessToken2.environment(environment);
+        accessToken2.clientId(clientId);
+        accessToken2.expiresOn("1600100000");
+        tokenCache.accessTokens.put(accessToken2.getKey(), accessToken2);
+
+        // Remove account1
+        tokenCache.removeAccount(clientId, new Account(homeAccountId1, environment, username, null));
+
+        // Verify only account1 and its tokens are removed
+        assertEquals(1, tokenCache.accounts.size());
+        assertEquals(1, tokenCache.accessTokens.size());
+        assertTrue(tokenCache.accounts.containsKey(account2.getKey()));
+        assertFalse(tokenCache.accounts.containsKey(account1.getKey()));
+    }
+
+    @Test
+    void mergeCache_PreservesRemovals() {
+        // Setup initial cache with two accounts
+        String homeAccountId1 = "home-account-id-1";
+        String homeAccountId2 = "home-account-id-2";
+        String environment = "login.microsoftonline.com";
+        String clientId = "client-id";
+        String username = "user@example.com";
+
+        // Account 1
+        AccountCacheEntity account1 = new AccountCacheEntity();
+        account1.homeAccountId(homeAccountId1);
+        account1.environment(environment);
+        tokenCache.accounts.put(account1.getKey(), account1);
+
+        // Account 2
+        AccountCacheEntity account2 = new AccountCacheEntity();
+        account2.homeAccountId(homeAccountId2);
+        account2.environment(environment);
+        tokenCache.accounts.put(account2.getKey(), account2);
+
+        // Serialize the cache with both accounts
+        String serializedWithTwoAccounts = tokenCache.serialize();
+
+        // Create a new cache with this serialized data
+        TokenCache deserializedCache = new TokenCache();
+        deserializedCache.deserialize(serializedWithTwoAccounts);
+        assertEquals(2, deserializedCache.accounts.size());
+
+        // Now remove account1 from the original cache
+        tokenCache.removeAccount(clientId, new Account(homeAccountId1, environment, username, null));
+
+        // Serialize the cache with just one account
+        String serializedWithOneAccount = tokenCache.serialize();
+
+        // Deserialize into a new cache
+        TokenCache finalCache = new TokenCache();
+        finalCache.deserialize(serializedWithOneAccount);
+
+        // Verify only one account exists
+        assertEquals(1, finalCache.accounts.size());
+        assertTrue(finalCache.accounts.containsKey(account2.getKey()));
+        assertFalse(finalCache.accounts.containsKey(account1.getKey()));
+    }
+
+    @Test
+    void getAccounts_ReturnsCorrectAccounts() {
+        // Setup multiple accounts in the cache
+        String homeAccountId1 = "home-account-id-1";
+        String localAccountId1 = "local-id-1";
+        String homeAccountId2 = "home-account-id-2";
+        String environment = "login.microsoftonline.com";
+        String clientId = "client-id";
+        String realm = "tenant-id";
+
+        // Account 1
+        AccountCacheEntity account1 = new AccountCacheEntity();
+        account1.homeAccountId(homeAccountId1);
+        account1.localAccountId(localAccountId1);
+        account1.environment(environment);
+        account1.realm(realm);
+        account1.username("user1@example.com");
+        tokenCache.accounts.put(account1.getKey(), account1);
+
+        // Account 2
+        AccountCacheEntity account2 = new AccountCacheEntity();
+        account2.homeAccountId(homeAccountId2);
+        account2.environment(environment);
+        account2.realm(realm);
+        account2.username("user2@example.com");
+        tokenCache.accounts.put(account2.getKey(), account2);
+
+        // Get accounts
+        Set<IAccount> accounts = tokenCache.getAccounts(clientId);
+
+        // Verify correct accounts are returned
+        assertEquals(2, accounts.size());
+
+        // Verify account details
+        for (IAccount account : accounts) {
+            if (account.homeAccountId().equals(homeAccountId1)) {
+                assertEquals("user1@example.com", account.username());
+            } else if (account.homeAccountId().equals(homeAccountId2)) {
+                assertEquals("user2@example.com", account.username());
+            } else {
+                fail("Unexpected account returned");
+            }
+        }
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -396,6 +396,8 @@ class ManagedIdentityTests {
             assert(exception.getCause() instanceof MsalServiceException);
 
             MsalServiceException miException = (MsalServiceException) exception.getCause();
+            System.out.println(miException.getMessage());
+            System.out.println(miException.errorCode());
             assertEquals(source.name(), miException.managedIdentitySource());
             assertEquals(AuthenticationErrorCode.MANAGED_IDENTITY_REQUEST_FAILED, miException.errorCode());
             return;
@@ -488,7 +490,7 @@ class ManagedIdentityTests {
 
             MsalServiceException miException = (MsalServiceException) exception.getCause();
             assertEquals(source.name(), miException.managedIdentitySource());
-            assertEquals(MsalError.MANAGED_IDENTITY_RESPONSE_PARSE_FAILURE, miException.errorCode());
+            assertEquals(MANAGED_IDENTITY_REQUEST_FAILED, miException.errorCode());
             return;
         }
 

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestConfiguration.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestConfiguration.java
@@ -97,7 +97,7 @@ public final class TestConfiguration {
     public final static String CLAIMS_REQUEST = "{\"id_token\":{\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\",\"urn:mace:incommon:iap:bronze\"]},\"sub\":{\"essential\":true,\"value\":\"248289761001\"},\"auth_time\":{}},\"access_token\":{\"given_name\":{\"essential\":true},\"email\":null}}";
     public final static String CLAIMS_CHALLENGE = "{\"access_token\":{\"nbf\":{\"essential\":true,\"value\":\"1701477303\"}}}";
     public final static String CLIENT_CAPABILITIES = "{\"access_token\":{\"xms_cc\":{\"values\":[\"cp1\"]}}}";
-    public final static String MERGED_CLAIMS_AND_CAPABILITIES = "{\"access_token\":{\"nbf\":{\"essential\":true,\"value\":\"1701477303\"},\"xms_cc\":{\"values\":[\"cp1\"]}}}";
-    public final static String MERGED_CLAIMS_AND_CHALLENGE = "{\"access_token\":{\"nbf\":{\"essential\":true,\"value\":\"1701477303\"}}}";
-    public final static String MERGED_CLAIMS_CAPABILITIES_AND_CHALLENGE = "{\"access_token\":{\"nbf\":{\"essential\":true,\"value\":\"1701477303\"},\"xms_cc\":{\"values\":[\"cp1\"]}}}";
+    public final static String MERGED_CLAIMS_AND_CAPABILITIES = "{\"access_token\":{\"nbf\":{\"value\":\"1701477303\",\"essential\":true},\"xms_cc\":{\"values\":[\"cp1\"]}}}";
+    public final static String MERGED_CLAIMS_AND_CHALLENGE = "{\"access_token\":{\"nbf\":{\"value\":\"1701477303\",\"essential\":true}}}";
+    public final static String MERGED_CLAIMS_CAPABILITIES_AND_CHALLENGE = "{\"access_token\":{\"nbf\":{\"value\":\"1701477303\",\"essential\":true},\"xms_cc\":{\"values\":[\"cp1\"]}}}";
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
@@ -273,16 +273,8 @@ class TokenRequestExecutorTest {
 
         doReturn(msalOAuthHttpRequest).when(request).createOauthHttpRequest();
         doReturn(httpResponse).when(msalOAuthHttpRequest).send();
-        lenient().doReturn(402).when(httpResponse).statusCode();
-        doReturn(new HashMap<>()).when(httpResponse).headers();
         doReturn(TestConfiguration.HTTP_ERROR_RESPONSE).when(httpResponse).body();
 
-        final ErrorResponse errorResponse = mock(ErrorResponse.class);
-
-        lenient().doReturn("invalid_request").when(errorResponse).error();
-        lenient().doReturn(null).when(httpResponse).getHeader("User-Agent");
-        lenient().doReturn(null).when(httpResponse).getHeader("x-ms-request-id");
-        lenient().doReturn(null).when(httpResponse).getHeader("x-ms-clitelem");
         doReturn(402).when(httpResponse).statusCode();
 
         assertThrows(MsalException.class, request::executeTokenRequest);

--- a/msal4j-sdk/src/test/resources/cache_data/serialized_cache.json
+++ b/msal4j-sdk/src/test/resources/cache_data/serialized_cache.json
@@ -11,7 +11,6 @@
   },
   "RefreshToken": {
     "uid.utid-login.windows.net-refreshtoken-my_client_id--s2 s1 s3": {
-      "target": "s2 s1 s3",
       "environment": "login.windows.net",
       "credential_type": "RefreshToken",
       "secret": "a refresh token",
@@ -20,9 +19,6 @@
     }
   },
   "AccessToken": {
-    "an-entry": {
-      "foo": "bar"
-    },
     "uid.utid-login.windows.net-accesstoken-my_client_id-contoso-s2 s1 s3": {
       "environment": "login.windows.net",
       "credential_type": "AccessToken",
@@ -46,14 +42,9 @@
       "home_account_id": "uid.utid"
     }
   },
-  "unknownEntity": {
-    "field1": "1",
-    "field2": "whats"
-  },
   "AppMetadata": {
     "appmetadata-login.windows.net-my_client_id": {
       "environment": "login.windows.net",
-      "family_id": null,
       "client_id": "my_client_id"
     }
   }


### PR DESCRIPTION
Replace final usages of com.fasterxml.jackson with com.azure.json, as per https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/909

This PR makes changes to a lot of files, as they were unfortunately very interconnected and could not be split up into to multiple PRs like previous dependency removals.

However, most of the files received the same set of changes:
- Adjust classes to implement azure-json's [JsonSerializable](https://learn.microsoft.com/en-us/java/api/com.azure.json.jsonserializable?view=azure-java-stable) interface, mainly by adding two methods:
  - `toJson()`, which creates a JsonWriter that can be used to create a JSON-formatted String
  - `fromJson()`, which creates an instance of that class from a JsonReader (which is give a JSON-formatted string)
- Remove jackson-databind's JSON annotations from those classes

The following files are the exception, and have more bespoke changes that need a more thorough review:
 - `JsonHelper`: Received new methods and refactoring in order to better provide JSON helper methods to the rest of the codebase
 - `TokenCache`: Complete overhaul of the serialization/deserialization code
 
 Finally, there were a few files that only received small changes to use the new JsonHelper methods.
 
 
For testing, many integration tests deal with the cache and received some small changes to work with the new helper methods and exact serialization results, and new unit tests were added to `CacheTests` specifically to ensure the serialization/deserialization changes in `TokenCache` were covered
- One issue that became clear during this refactoring is that some tests used junk data in their persistent caches which was not used in anyway by the library (i.e., random field names), but was nonetheless added to the in-memory cache. Under the new system this type of junk data is no longer added to the in-memory cache, however this should not be a breaking change since the library would not have used it anyway