### PR TITLE
Dependency cleanup

### DIFF
--- a/build/tsaconfig.json
+++ b/build/tsaconfig.json
@@ -1,0 +1,14 @@
+{
+  "codebaseName": "MSAL4J",
+  "notificationAliases": [
+    "idauthsdkjava@microsoft.com"
+  ],
+  "instanceUrl": "https://identitydivision.visualstudio.com",
+  "projectName": "IDDP",
+  "areaPath": "IDDP\\DevEx-Client-SDK\\Java",
+  "iterationPath": "IDDP\\Unscheduled",
+  "tools": [
+    "credscan",
+    "policheck"
+  ]
+}

--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -34,20 +34,22 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+        </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-json</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
             <version>11.23</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-            <version>2.5.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -55,24 +57,6 @@
             <version>1.6.2</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.36</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.azure</groupId>
-            <artifactId>azure-json</artifactId>
-            <version>1.4.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.18.1</version>
-        </dependency>
-
-        <!-- test dependencies -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
@@ -115,7 +99,6 @@
             <version>1.14.5</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
@@ -181,7 +164,7 @@
     </pluginRepositories>
 
     <build>
-        <sourceDirectory>${project.build.directory}/delombok</sourceDirectory>
+        <sourceDirectory>src/main/java</sourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.revapi</groupId>
@@ -209,30 +192,6 @@
                         <goals><goal>check</goal></goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok-maven-plugin</artifactId>
-                <version>1.18.20.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.projectlombok</groupId>
-                        <artifactId>lombok</artifactId>
-                        <version>1.18.36</version>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>delombok</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <sourceDirectory>src/main/java</sourceDirectory>
-                    <outputDirectory>${project.build.directory}/delombok</outputDirectory>
-                    <addOutputDirectory>false</addOutputDirectory>
-                </configuration>
             </plugin>
 
             <plugin>
@@ -263,7 +222,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.1.0</version>
                 <configuration>
-                    <sourcepath>${project.build.directory}/delombok</sourcepath>
+                    <sourcepath>src/main/java</sourcepath>
                 </configuration>
                 <executions>
                     <execution>

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenInteractiveIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenInteractiveIT.java
@@ -208,42 +208,6 @@ class AcquireTokenInteractiveIT extends SeleniumTest {
                 .get();
     }
 
-    public void acquireTokensInHomeAndGuestClouds(String homeCloud) throws MalformedURLException {
-
-        User user = labUserProvider.getUserByGuestHomeAzureEnvironments
-                (AzureEnvironment.AZURE, homeCloud);
-
-        // use user`s upn from home cloud
-        user.setUpn(user.getHomeUPN());
-
-        ITokenCacheAccessAspect persistenceAspect = new ITokenCacheAccessAspect() {
-            String data;
-
-            @Override
-            public void beforeCacheAccess(ITokenCacheAccessContext iTokenCacheAccessContext) {
-                iTokenCacheAccessContext.tokenCache().deserialize(data);
-            }
-
-            @Override
-            public void afterCacheAccess(ITokenCacheAccessContext iTokenCacheAccessContext) {
-                data = iTokenCacheAccessContext.tokenCache().serialize();
-            }
-        };
-
-        PublicClientApplication publicCloudPca = PublicClientApplication.builder(
-                user.getAppId()).
-                authority(TestConstants.AUTHORITY_PUBLIC_TENANT_SPECIFIC).setTokenCacheAccessAspect(persistenceAspect).
-                build();
-
-        IAuthenticationResult result = acquireTokenInteractive(user, publicCloudPca, TestConstants.USER_READ_SCOPE);
-        IntegrationTestHelper.assertAccessAndIdTokensNotNull(result);
-        assertEquals(user.getHomeUPN(), result.account().username());
-
-        publicCloudPca.removeAccount(publicCloudPca.getAccounts().join().iterator().next()).join();
-
-        assertEquals(publicCloudPca.getAccounts().join().size(), 0);
-    }
-
     private IAuthenticationResult acquireTokenInteractive(
             User user,
             PublicClientApplication pca,

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/CachePersistenceIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/CachePersistenceIT.java
@@ -2,15 +2,9 @@
 // Licensed under the MIT License.
 package com.microsoft.aad.msal4j;
 
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.PlainJWT;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Collections;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CachePersistenceIT {
@@ -34,59 +28,50 @@ class CachePersistenceIT {
     }
 
     @Test
-    void cacheDeserializationSerializationTest() throws IOException, URISyntaxException {
+    void cacheDeserializationSerializationTest() {
         String dataToInitCache = TestHelper.readResource(this.getClass(), "/cache_data/serialized_cache.json");
-
-        String ID_TOKEN_PLACEHOLDER = "<idToken_placeholder>";
-        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
-                .audience(Collections.singletonList("jwtAudience"))
-                .issuer("issuer")
-                .subject("subject")
-                .build();
-        PlainJWT jwt = new PlainJWT(claimsSet);
-
-        dataToInitCache = dataToInitCache.replace(ID_TOKEN_PLACEHOLDER, jwt.serialize());
+        dataToInitCache = dataToInitCache.replace("<idToken_placeholder>", TestHelper.ENCODED_JWT);
 
         ITokenCacheAccessAspect persistenceAspect = new TokenPersistence(dataToInitCache);
 
         PublicClientApplication app = PublicClientApplication.builder("my_client_id")
                 .setTokenCacheAccessAspect(persistenceAspect).build();
 
-        assertEquals(app.getAccounts().join().size(), 1);
-        assertEquals(app.tokenCache.accounts.size(), 1);
-        assertEquals(app.tokenCache.accessTokens.size(), 1);
-        assertEquals(app.tokenCache.refreshTokens.size(), 1);
-        assertEquals(app.tokenCache.idTokens.size(), 1);
-        assertEquals(app.tokenCache.appMetadata.size(), 1);
+        assertEquals(1, app.getAccounts().join().size());
+        assertEquals(1, app.tokenCache.accounts.size());
+        assertEquals(1, app.tokenCache.accessTokens.size());
+        assertEquals(1, app.tokenCache.refreshTokens.size());
+        assertEquals(1, app.tokenCache.idTokens.size());
+        assertEquals(1, app.tokenCache.appMetadata.size());
 
         // create new instance of app to make sure in memory cache cleared
         app = PublicClientApplication.builder("my_client_id")
                 .setTokenCacheAccessAspect(persistenceAspect).build();
 
-        assertEquals(app.getAccounts().join().size(), 1);
-        assertEquals(app.tokenCache.accounts.size(), 1);
-        assertEquals(app.tokenCache.accessTokens.size(), 1);
-        assertEquals(app.tokenCache.refreshTokens.size(), 1);
-        assertEquals(app.tokenCache.idTokens.size(), 1);
-        assertEquals(app.tokenCache.appMetadata.size(), 1);
+        assertEquals(1, app.getAccounts().join().size());
+        assertEquals(1, app.tokenCache.accounts.size());
+        assertEquals(1, app.tokenCache.accessTokens.size());
+        assertEquals(1, app.tokenCache.refreshTokens.size());
+        assertEquals(1, app.tokenCache.idTokens.size());
+        assertEquals(1, app.tokenCache.appMetadata.size());
 
         app.removeAccount(app.getAccounts().join().iterator().next()).join();
 
-        assertEquals(app.getAccounts().join().size(), 0);
-        assertEquals(app.tokenCache.accounts.size(), 0);
-        assertEquals(app.tokenCache.accessTokens.size(), 0);
-        assertEquals(app.tokenCache.refreshTokens.size(), 0);
-        assertEquals(app.tokenCache.idTokens.size(), 0);
-        assertEquals(app.tokenCache.appMetadata.size(), 1);
+        assertEquals(0, app.getAccounts().join().size());
+        assertEquals(0, app.tokenCache.accounts.size());
+        assertEquals(0, app.tokenCache.accessTokens.size());
+        assertEquals(0, app.tokenCache.refreshTokens.size());
+        assertEquals(0, app.tokenCache.idTokens.size());
+        assertEquals(1, app.tokenCache.appMetadata.size());
 
         app = PublicClientApplication.builder("my_client_id")
                 .setTokenCacheAccessAspect(persistenceAspect).build();
 
-        assertEquals(app.getAccounts().join().size(), 0);
-        assertEquals(app.tokenCache.accounts.size(), 0);
-        assertEquals(app.tokenCache.accessTokens.size(), 0);
-        assertEquals(app.tokenCache.refreshTokens.size(), 0);
-        assertEquals(app.tokenCache.idTokens.size(), 0);
-        assertEquals(app.tokenCache.appMetadata.size(), 1);
+        assertEquals(0, app.getAccounts().join().size());
+        assertEquals(0, app.tokenCache.accounts.size());
+        assertEquals(0, app.tokenCache.accessTokens.size());
+        assertEquals(0, app.tokenCache.refreshTokens.size());
+        assertEquals(0, app.tokenCache.idTokens.size());
+        assertEquals(1, app.tokenCache.appMetadata.size());
     }
 }

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/Config.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/Config.java
@@ -5,11 +5,7 @@ package com.microsoft.aad.msal4j;
 
 import labapi.AppCredentialProvider;
 import labapi.AzureEnvironment;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 
-@Accessors(fluent = true)
-@Getter()
 public class Config {
     private String organizationsAuthority;
     private String tenantSpecificAuthority;
@@ -43,5 +39,25 @@ public class Config {
             default:
                 throw new UnsupportedOperationException("Azure Environment - " + azureEnvironment + " unsupported");
         }
+    }
+
+    public String organizationsAuthority() {
+        return this.organizationsAuthority;
+    }
+
+    public String tenantSpecificAuthority() {
+        return this.tenantSpecificAuthority;
+    }
+
+    public String commonAuthority() {
+        return this.commonAuthority;
+    }
+
+    public String graphDefaultScope() {
+        return this.graphDefaultScope;
+    }
+
+    public String tenant() {
+        return this.tenant;
     }
 }

--- a/msal4j-sdk/src/integrationtest/java/infrastructure/SeleniumConstants.java
+++ b/msal4j-sdk/src/integrationtest/java/infrastructure/SeleniumConstants.java
@@ -21,14 +21,6 @@ public class SeleniumConstants {
     final static String ADFS2019_PASSWORD_ID = "passwordInput";
     final static String ADFS2019_SUBMIT_ID = "submitButton";
 
-    // ADFSv2 fields
-    final static String ADFSV2_WEB_USERNAME_INPUT_ID = "ContentPlaceHolder1_UsernameTextBox";
-    final static String ADFSV2_WEB_PASSWORD_INPUT_ID = "ContentPlaceHolder1_PasswordTextBox";
-    final static String ADFSV2_ARLINGTON_WEB_PASSWORD_INPUT_ID = "passwordInput";
-    final static String ADFSV2_WEB_SUBMIT_BUTTON_ID = "ContentPlaceHolder1_SubmitButton";
-    final static String ADFSV2_ARLINGTON_WEB_SUBMIT_BUTTON_ID = "submitButton";
-
-
     //B2C Facebook
     final static String FACEBOOK_ACCOUNT_ID = "FacebookExchange";
     final static String FACEBOOK_USERNAME_ID = "email";

--- a/msal4j-sdk/src/integrationtest/java/labapi/App.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/App.java
@@ -3,30 +3,85 @@
 
 package labapi;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 
-@Getter
-public class App {
+import java.io.IOException;
 
-    @JsonProperty("appType")
-    String appType;
+public class App implements JsonSerializable<App> {
 
-    @JsonProperty("appName")
-    String appName;
+    private String appType;
+    private String appName;
+    private String appId;
+    private String redirectUri;
+    private String authority;
+    private String labName;
+    private String clientSecret;
 
-    @JsonProperty("appId")
-    String appId;
+    static App fromJson(JsonReader jsonReader) throws IOException {
+        App app = new App();
 
-    @JsonProperty("redirectUri")
-    String redirectUri;
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
 
-    @JsonProperty("authority")
-    String authority;
+                switch (fieldName) {
+                    case "appType":
+                        app.appType = reader.getString();
+                        break;
+                    case "appName":
+                        app.appName = reader.getString();
+                        break;
+                    case "appId":
+                        app.appId = reader.getString();
+                        break;
+                    case "redirectUri":
+                        app.redirectUri = reader.getString();
+                        break;
+                    case "authority":
+                        app.authority = reader.getString();
+                        break;
+                    case "labName":
+                        app.labName = reader.getString();
+                        break;
+                    case "clientSecret":
+                        app.clientSecret = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return app;
+        });
+    }
 
-    @JsonProperty("labName")
-    String labName;
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
 
-    @JsonProperty("clientSecret")
-    String clientSecret;
+        jsonWriter.writeStringField("appType", appType);
+        jsonWriter.writeStringField("appName", appName);
+        jsonWriter.writeStringField("appId", appId);
+        jsonWriter.writeStringField("redirectUri", redirectUri);
+        jsonWriter.writeStringField("authority", authority);
+        jsonWriter.writeStringField("labName", labName);
+        jsonWriter.writeStringField("clientSecret", clientSecret);
+
+        jsonWriter.writeEndObject();
+
+        return jsonWriter;
+    }
+
+    public String getAuthority() {
+        return authority;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
 }

--- a/msal4j-sdk/src/integrationtest/java/labapi/AppCredentialProvider.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/AppCredentialProvider.java
@@ -33,7 +33,7 @@ public class AppCredentialProvider {
                 oboClientId = LabConstants.ARLINGTON_OBO_APP_ID;
                 oboAppIdURI = "https://arlmsidlab1.us/IDLABS_APP_Confidential_Client";
 
-                oboPassword = keyVaultSecretsProvider.getSecret(LabService.getApp(oboClientId).clientSecret);
+                oboPassword = keyVaultSecretsProvider.getSecret(LabService.getApp(oboClientId).getClientSecret());
                 break;
             case AzureEnvironment.CIAM:
                 oboPassword = keyVaultSecretsProvider.getSecret(LabConstants.CIAM_KEY_VAULT_SECRET_KEY);

--- a/msal4j-sdk/src/integrationtest/java/labapi/AzureEnvironment.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/AzureEnvironment.java
@@ -5,10 +5,8 @@ package labapi;
 
 public class AzureEnvironment {
 
-    public static final String AZURE_B2C = "azureb2ccloud";
     public static final String AZURE_CHINA = "azurechinacloud";
     public static final String AZURE = "azurecloud";
-    public static final String AZURE_PPE = "azureppe";
     public static final String AZURE_US_GOVERNMENT = "azureusgovernment";
     public static final String CIAM = "ciam";
 }

--- a/msal4j-sdk/src/integrationtest/java/labapi/B2CProvider.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/B2CProvider.java
@@ -4,11 +4,7 @@
 package labapi;
 
 public class B2CProvider {
-    public static final String NONE = "none";
-    public static final String AMAZON = "amazon";
     public static final String FACEBOOK = "facebook";
     public static final String GOOGLE = "google";
     public static final String LOCAL = "local";
-    public static final String MICROSOFT = "microsoft";
-    public static final String TWITTER = "twitter";
 }

--- a/msal4j-sdk/src/integrationtest/java/labapi/FederationProvider.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/FederationProvider.java
@@ -8,7 +8,6 @@ public class FederationProvider {
     public static final String NONE = "none";
     public static final String ADFS_4 = "adfsv4";
     public static final String ADFS_2019 = "adfsv2019";
-    public static final String CIAM = "ciam";
     public static final String CIAMCUD = "ciamcud";
 
 }

--- a/msal4j-sdk/src/integrationtest/java/labapi/Lab.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/Lab.java
@@ -3,26 +3,74 @@
 
 package labapi;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 
-@Getter
-public class Lab {
-    @JsonProperty("labName")
-    String labName;
+import java.io.IOException;
 
-    @JsonProperty("domain")
-    String domain;
+public class Lab implements JsonSerializable<Lab> {
+    private String labName;
+    private String domain;
+    private String tenantId;
+    private String federationProvider;
+    private String azureEnvironment;
+    private String authority;
 
-    @JsonProperty("tenantId")
-    String tenantId;
+    static Lab fromJson(JsonReader jsonReader) throws IOException {
+        Lab lab = new Lab();
 
-    @JsonProperty("federationProvider")
-    String federationProvider;
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
 
-    @JsonProperty("azureEnvironment")
-    String azureEnvironment;
+                switch (fieldName) {
+                    case "labName":
+                        lab.labName = reader.getString();
+                        break;
+                    case "domain":
+                        lab.domain = reader.getString();
+                        break;
+                    case "tenantId":
+                        lab.tenantId = reader.getString();
+                        break;
+                    case "federationProvider":
+                        lab.federationProvider = reader.getString();
+                        break;
+                    case "azureEnvironment":
+                        lab.azureEnvironment = reader.getString();
+                        break;
+                    case "authority":
+                        lab.authority = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return lab;
+        });
+    }
 
-    @JsonProperty("authority")
-    String authority;
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+
+        jsonWriter.writeStringField("labName", labName);
+        jsonWriter.writeStringField("domain", domain);
+        jsonWriter.writeStringField("tenantId", tenantId);
+        jsonWriter.writeStringField("federationProvider", federationProvider);
+        jsonWriter.writeStringField("azureEnvironment", azureEnvironment);
+        jsonWriter.writeStringField("authority", authority);
+
+        jsonWriter.writeEndObject();
+
+        return jsonWriter;
+    }
+
+    public String getTenantId() {
+        return this.tenantId;
+    }
 }

--- a/msal4j-sdk/src/integrationtest/java/labapi/LabService.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/LabService.java
@@ -3,8 +3,7 @@
 
 package labapi;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.azure.json.*;
 import com.microsoft.aad.msal4j.*;
 
 import java.io.IOException;
@@ -17,17 +16,6 @@ import java.util.concurrent.ExecutionException;
 public class LabService {
 
     static ConfidentialClientApplication labApp;
-
-    static ObjectMapper mapper = new ObjectMapper()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
-    static <T> T convertJsonToObject(final String json, final Class<T> clazz) {
-        try {
-            return mapper.readValue(json, clazz);
-        } catch (IOException e) {
-            throw new RuntimeException("JSON processing error: " + e.getMessage(), e);
-        }
-    }
 
     static void initLabApp() throws MalformedURLException {
         KeyVaultSecretsProvider keyVaultSecretsProvider = new KeyVaultSecretsProvider();
@@ -56,7 +44,7 @@ public class LabService {
             String result = HttpClientHelper.sendRequestToLab(
                     LabConstants.LAB_USER_ENDPOINT, queryMap, getLabAccessToken());
 
-            User[] users = convertJsonToObject(result, User[].class);
+            User[] users = parseUserArray(result);
             User user = users[0];
             if (user.getUserType().equals("Guest")) {
                 String secretId = user.getHomeDomain().split("\\.")[0];
@@ -64,11 +52,7 @@ public class LabService {
             } else {
                 user.setPassword(getSecret(user.getLabName()));
             }
-            if (query.parameters.containsKey(UserQueryParameters.FEDERATION_PROVIDER)) {
-                user.setFederationProvider(query.parameters.get(UserQueryParameters.FEDERATION_PROVIDER));
-            } else {
-                user.setFederationProvider(FederationProvider.NONE);
-            }
+            user.setFederationProvider(query.parameters.getOrDefault(UserQueryParameters.FEDERATION_PROVIDER, FederationProvider.NONE));
             return user;
         } catch (Exception ex) {
             throw new RuntimeException("Error getting user from lab: " + ex.getMessage());
@@ -79,7 +63,7 @@ public class LabService {
         try {
             String result = HttpClientHelper.sendRequestToLab(
                     LabConstants.LAB_APP_ENDPOINT, appId, getLabAccessToken());
-            App[] apps = convertJsonToObject(result, App[].class);
+            App[] apps = parseAppArray(result);
             return apps[0];
         } catch (Exception ex) {
             throw new RuntimeException("Error getting app from lab: " + ex.getMessage());
@@ -91,7 +75,7 @@ public class LabService {
         try {
             result = HttpClientHelper.sendRequestToLab(
                     LabConstants.LAB_LAB_ENDPOINT, labId, getLabAccessToken());
-            Lab[] labs = convertJsonToObject(result, Lab[].class);
+            Lab[] labs = parseLabArray(result);
             return labs[0];
         } catch (Exception ex) {
             throw new RuntimeException("Error getting lab from lab: " + ex.getMessage());
@@ -106,9 +90,46 @@ public class LabService {
             result = HttpClientHelper.sendRequestToLab(
                     LabConstants.LAB_USER_SECRET_ENDPOINT, queryMap, getLabAccessToken());
 
-            return convertJsonToObject(result, UserSecret.class).value;
+            UserSecret userSecret = parseUserSecret(result);
+            return userSecret.value;
         } catch (Exception ex) {
             throw new RuntimeException("Error getting user secret from lab: " + ex.getMessage());
+        }
+    }
+
+    // Helper methods for parsing JSON responses into specific objects
+    private static User[] parseUserArray(String json) {
+        try (JsonReader reader = JsonProviders.createReader(json)) {
+            reader.nextToken();
+            return reader.readArray(User::fromJson).toArray(new User[0]);
+        } catch (IOException e) {
+            throw new RuntimeException("Error parsing User array: " + e.getMessage(), e);
+        }
+    }
+
+    private static App[] parseAppArray(String json) {
+        try (JsonReader reader = JsonProviders.createReader(json)) {
+            reader.nextToken();
+            return reader.readArray(App::fromJson).toArray(new App[0]);
+        } catch (IOException e) {
+            throw new RuntimeException("Error parsing App array: " + e.getMessage(), e);
+        }
+    }
+
+    private static Lab[] parseLabArray(String json) {
+        try (JsonReader reader = JsonProviders.createReader(json)) {
+            reader.nextToken();
+            return reader.readArray(Lab::fromJson).toArray(new Lab[0]);
+        } catch (IOException e) {
+            throw new RuntimeException("Error parsing Lab array: " + e.getMessage(), e);
+        }
+    }
+
+    private static UserSecret parseUserSecret(String json) {
+        try (JsonReader reader = JsonProviders.createReader(json)) {
+            return UserSecret.fromJson(reader);
+        } catch (IOException e) {
+            throw new RuntimeException("Error parsing UserSecret: " + e.getMessage(), e);
         }
     }
 }

--- a/msal4j-sdk/src/integrationtest/java/labapi/LabUserProvider.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/LabUserProvider.java
@@ -14,12 +14,10 @@ public class LabUserProvider {
 
     private static LabUserProvider instance;
 
-    private final KeyVaultSecretsProvider keyVaultSecretsProvider;
     private final LabService labService;
     private Map<UserQueryParameters, User> userCache;
 
     private LabUserProvider() {
-        keyVaultSecretsProvider = new KeyVaultSecretsProvider();
         labService = new LabService();
         userCache = new HashMap<>();
     }

--- a/msal4j-sdk/src/integrationtest/java/labapi/User.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/User.java
@@ -3,61 +3,169 @@
 
 package labapi;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.Setter;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 
-@Getter
-public class User {
-    @JsonProperty("appId")
+import java.io.IOException;
+
+public class User implements JsonSerializable<User> {
     private String appId;
-
-    @JsonProperty("objectId")
     private String objectId;
-
-    @JsonProperty("userType")
     private String userType;
-
-    @JsonProperty("displayName")
     private String displayName;
-
-    @JsonProperty("licenses")
     private String licenses;
-
-    @JsonProperty("upn")
-    @Setter
     private String upn;
-
-    @JsonProperty("mfa")
     private String mfa;
-
-    @JsonProperty("protectionPolicy")
     private String protectionPolicy;
-
-    @JsonProperty("homeDomain")
     private String homeDomain;
-
-    @JsonProperty("homeUPN")
     private String homeUPN;
-
-    @JsonProperty("b2cProvider")
     private String b2cProvider;
-
-    @JsonProperty("labName")
     private String labName;
-
-    @JsonProperty("lastUpdatedBy")
     private String lastUpdatedBy;
-
-    @JsonProperty("lastUpdatedDate")
     private String lastUpdatedDate;
-
-    @JsonProperty("tenantID")
     private String tenantID;
-
-    @Setter
     private String password;
-
-    @Setter
     private String federationProvider;
+
+    static User fromJson(JsonReader jsonReader) throws IOException {
+        User user = new User();
+
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                switch (fieldName) {
+                    case "appId":
+                        user.appId = reader.getString();
+                        break;
+                    case "objectId":
+                        user.objectId = reader.getString();
+                        break;
+                    case "userType":
+                        user.userType = reader.getString();
+                        break;
+                    case "displayName":
+                        user.displayName = reader.getString();
+                        break;
+                    case "licenses":
+                        user.licenses = reader.getString();
+                        break;
+                    case "upn":
+                        user.upn = reader.getString();
+                        break;
+                    case "mfa":
+                        user.mfa = reader.getString();
+                        break;
+                    case "protectionPolicy":
+                        user.protectionPolicy = reader.getString();
+                        break;
+                    case "homeDomain":
+                        user.homeDomain = reader.getString();
+                        break;
+                    case "homeUPN":
+                        user.homeUPN = reader.getString();
+                        break;
+                    case "b2cProvider":
+                        user.b2cProvider = reader.getString();
+                        break;
+                    case "labName":
+                        user.labName = reader.getString();
+                        break;
+                    case "lastUpdatedBy":
+                        user.lastUpdatedBy = reader.getString();
+                        break;
+                    case "lastUpdatedDate":
+                        user.lastUpdatedDate = reader.getString();
+                        break;
+                    case "tenantID":
+                        user.tenantID = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return user;
+        });
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+
+        jsonWriter.writeStringField("appId", appId);
+        jsonWriter.writeStringField("objectId", objectId);
+        jsonWriter.writeStringField("userType", userType);
+        jsonWriter.writeStringField("displayName", displayName);
+        jsonWriter.writeStringField("licenses", licenses);
+        jsonWriter.writeStringField("upn", upn);
+        jsonWriter.writeStringField("mfa", mfa);
+        jsonWriter.writeStringField("protectionPolicy", protectionPolicy);
+        jsonWriter.writeStringField("homeDomain", homeDomain);
+        jsonWriter.writeStringField("homeUPN", homeUPN);
+        jsonWriter.writeStringField("b2cProvider", b2cProvider);
+        jsonWriter.writeStringField("labName", labName);
+        jsonWriter.writeStringField("lastUpdatedBy", lastUpdatedBy);
+        jsonWriter.writeStringField("lastUpdatedDate", lastUpdatedDate);
+        jsonWriter.writeStringField("tenantID", tenantID);
+
+        jsonWriter.writeEndObject();
+
+        return jsonWriter;
+    }
+
+    public String getAppId() {
+        return this.appId;
+    }
+
+    public String getUserType() {
+        return this.userType;
+    }
+
+    public String getUpn() {
+        return this.upn;
+    }
+
+    public String getHomeDomain() {
+        return this.homeDomain;
+    }
+
+    public String getHomeUPN() {
+        return this.homeUPN;
+    }
+
+    public String getB2cProvider() {
+        return this.b2cProvider;
+    }
+
+    public String getLabName() {
+        return this.labName;
+    }
+
+    public String getTenantID() {
+        return this.tenantID;
+    }
+
+    public String getPassword() {
+        return this.password;
+    }
+
+    public String getFederationProvider() {
+        return this.federationProvider;
+    }
+
+    public void setUpn(String upn) {
+        this.upn = upn;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public void setFederationProvider(String federationProvider) {
+        this.federationProvider = federationProvider;
+    }
 }

--- a/msal4j-sdk/src/integrationtest/java/labapi/UserQueryParameters.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/UserQueryParameters.java
@@ -3,26 +3,18 @@
 
 package labapi;
 
-import lombok.EqualsAndHashCode;
-
 import java.util.HashMap;
 import java.util.Map;
 
-@EqualsAndHashCode
 public class UserQueryParameters {
 
     public static final String USER_TYPE = "usertype";
-    public static final String MFA = "mfa";
-    public static final String PROTECTION_POLICEY = "protectionpolicy";
-    public static final String HOME_DOMAIN = "homedomain";
-    public static final String HOME_UPN = "homeupn";
     public static final String B2C_PROVIDER = "b2cprovider";
     public static final String FEDERATION_PROVIDER = "federationprovider";
     public static final String AZURE_ENVIRONMENT = "azureenvironment";
     public static final String HOME_AZURE_ENVIRONMENT = "guesthomeazureenvironment";
     public static final String GUEST_HOME_DIN = "guesthomedin";
     public static final String SIGN_IN_AUDIENCE = "signInAudience";
-    public static final String PUBLIC_CLIENT = "publicClient";
 
     public Map<String, String> parameters = new HashMap<>();
 }

--- a/msal4j-sdk/src/integrationtest/java/labapi/UserSecret.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/UserSecret.java
@@ -3,13 +3,51 @@
 
 package labapi;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
 
-public class UserSecret {
+import java.io.IOException;
 
-    @JsonProperty("secret")
+public class UserSecret implements JsonSerializable<UserSecret> {
+
     String secret;
-
-    @JsonProperty("value")
     String value;
+
+    static UserSecret fromJson(JsonReader jsonReader) throws IOException {
+        UserSecret userSecret = new UserSecret();
+
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+
+                switch (fieldName) {
+                    case "secret":
+                        userSecret.secret = reader.getString();
+                        break;
+                    case "value":
+                        userSecret.value = reader.getString();
+                        break;
+                    default:
+                        reader.skipChildren();
+                        break;
+                }
+            }
+            return userSecret;
+        });
+    }
+
+    @Override
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+
+        jsonWriter.writeStringField("secret", secret);
+        jsonWriter.writeStringField("value", value);
+
+        jsonWriter.writeEndObject();
+
+        return jsonWriter;
+    }
 }

--- a/msal4j-sdk/src/integrationtest/java/labapi/UserType.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/UserType.java
@@ -4,7 +4,6 @@
 package labapi;
 
 public class UserType {
-    public static final String CLOUD = "cloud";
     public static final String FEDERATED = "federated";
     public static final String ON_PREM = "onprem";
     public static final String GUEST = "guest";

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
@@ -85,8 +85,6 @@ class AuthorizationRequestUrlParametersTest {
 
     @Test
     void testBuilder_conflictingParameters() {
-        PublicClientApplication app = PublicClientApplication.builder("client_id").build();
-
         String redirectUri = "http://localhost:8080";
         Set<String> scope = Collections.singleton("scope");
 

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
@@ -3,9 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.util.JSONObjectUtils;
-import net.minidev.json.JSONObject;
 import org.json.JSONException;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -76,7 +73,7 @@ class CacheFormatTests {
                         Paths.get(getClass().getResource(resource).toURI())));
     }
 
-    boolean doesResourceExist(String resource) throws IOException, URISyntaxException {
+    boolean doesResourceExist(String resource) {
         return getClass().getResource(resource) != null;
     }
 
@@ -113,21 +110,21 @@ class CacheFormatTests {
     }
 
     @Test
-    void AADTokenCacheEntitiesFormatTest() throws JSONException, IOException, ParseException, URISyntaxException {
+    void AADTokenCacheEntitiesFormatTest() throws JSONException, IOException, URISyntaxException {
         tokenCacheEntitiesFormatTest("/AAD_cache_data");
     }
 
     @Test
-    void MSATokenCacheEntitiesFormatTest() throws JSONException, IOException, ParseException, URISyntaxException {
+    void MSATokenCacheEntitiesFormatTest() throws JSONException, IOException, URISyntaxException {
         tokenCacheEntitiesFormatTest("/MSA_cache_data");
     }
 
     @Test
-    void FociTokenCacheEntitiesFormatTest() throws JSONException, IOException, ParseException, URISyntaxException {
+    void FociTokenCacheEntitiesFormatTest() throws JSONException, IOException, URISyntaxException {
         tokenCacheEntitiesFormatTest("/Foci_cache_data");
     }
 
-    public void tokenCacheEntitiesFormatTest(String folder) throws URISyntaxException, IOException, ParseException, JSONException {
+    public void tokenCacheEntitiesFormatTest(String folder) throws URISyntaxException, IOException, JSONException {
         String CLIENT_ID = "b6c69a37-df96-4db0-9088-2ab96e1d8215";
         String AUTHORIZE_REQUEST_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
 
@@ -158,7 +155,7 @@ class CacheFormatTests {
         doReturn(msalOAuthHttpRequest).when(request).createOauthHttpRequest();
         doReturn(httpResponse).when(msalOAuthHttpRequest).send();
         doReturn(200).when(httpResponse).statusCode();
-        doReturn(JsonHelper.convertJsonToMap((tokenResponse))).when(httpResponse).getBodyAsMap();
+        doReturn(JsonHelper.convertJsonToMap(tokenResponse)).when(httpResponse).getBodyAsMap();
 
         final AuthenticationResult result = request.executeTokenRequest();
 
@@ -174,9 +171,9 @@ class CacheFormatTests {
     }
 
     private void validateAccessTokenCacheEntity(String folder, String tokenResponse, TokenCache tokenCache)
-            throws IOException, URISyntaxException, ParseException, JSONException {
+            throws IOException, URISyntaxException, JSONException {
 
-        assertEquals(tokenCache.accessTokens.size(), 1);
+        assertEquals(1, tokenCache.accessTokens.size());
 
         String keyActual = tokenCache.accessTokens.keySet().stream().findFirst().get();
         String keyExpected = readResource(folder + AT_CACHE_ENTITY_KEY);
@@ -185,29 +182,16 @@ class CacheFormatTests {
         String valueActual = JsonHelper.convertJsonSerializableObjectToString(tokenCache.accessTokens.get(keyActual));
         String valueExpected = readResource(folder + AT_CACHE_ENTITY);
 
-        JSONObject tokenResponseJsonObj = JSONObjectUtils.parse(tokenResponse);
-        long expireIn = getLongValue(tokenResponseJsonObj, "expires_in");
-
-        long extExpireIn = getLongValue(tokenResponseJsonObj, "ext_expires_in");
+        Map<String, String> tokenResponseMap = JsonHelper.convertJsonToMap(tokenResponse);
 
         JSONAssert.assertEquals(valueExpected, valueActual,
-                new DynamicTimestampsComparator(JSONCompareMode.STRICT, expireIn, extExpireIn));
-    }
-
-    static Long getLongValue(JSONObject jsonObject, String key) throws ParseException {
-        Object value = jsonObject.get(key);
-
-        if (value instanceof Long) {
-            return JSONObjectUtils.getLong(jsonObject, key);
-        } else {
-            return Long.parseLong(JSONObjectUtils.getString(jsonObject, key));
-        }
+                new DynamicTimestampsComparator(JSONCompareMode.STRICT, Long.parseLong(tokenResponseMap.get("expires_in")), Long.parseLong(tokenResponseMap.get("ext_expires_in"))));
     }
 
     private void validateRefreshTokenCacheEntity(String folder, TokenCache tokenCache)
             throws IOException, URISyntaxException, JSONException {
 
-        assertEquals(tokenCache.refreshTokens.size(), 1);
+        assertEquals(1, tokenCache.refreshTokens.size());
 
         String actualKey = tokenCache.refreshTokens.keySet().stream().findFirst().get();
         String keyExpected = readResource(folder + RT_CACHE_ENTITY_KEY);
@@ -243,7 +227,7 @@ class CacheFormatTests {
     private void validateIdTokenCacheEntity(String folder, TokenCache tokenCache)
             throws IOException, URISyntaxException, JSONException {
 
-        assertEquals(tokenCache.idTokens.size(), 1);
+        assertEquals(1, tokenCache.idTokens.size());
 
         String actualKey = tokenCache.idTokens.keySet().stream().findFirst().get();
         String keyExpected = readResource(folder + ID_TOKEN_CACHE_ENTITY_KEY);
@@ -258,7 +242,7 @@ class CacheFormatTests {
     private void validateAccountCacheEntity(String folder, TokenCache tokenCache)
             throws IOException, URISyntaxException, JSONException {
 
-        assertEquals(tokenCache.accounts.size(), 1);
+        assertEquals(1, tokenCache.accounts.size());
 
         String actualKey = tokenCache.accounts.keySet().stream().findFirst().get();
         String keyExpected = readResource(folder + ACCOUNT_CACHE_ENTITY_KEY);
@@ -277,7 +261,7 @@ class CacheFormatTests {
             return;
         }
 
-        assertEquals(tokenCache.appMetadata.size(), 1);
+        assertEquals(1, tokenCache.appMetadata.size());
 
         String actualKey = tokenCache.appMetadata.keySet().stream().findFirst().get();
         String keyExpected = readResource(folder + APP_METADATA_ENTITY_KEY);

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/RequestThrottlingTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/RequestThrottlingTest.java
@@ -54,10 +54,6 @@ class RequestThrottlingTest {
                 .build();
     }
 
-    private AuthorizationCodeParameters getAcquireTokenApiParameters() throws URISyntaxException {
-        return getAcquireTokenApiParameters("default-scope");
-    }
-
     private PublicClientApplication getPublicClientApp() throws Exception {
         return getPublicClientApp(null);
     }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestConfiguration.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestConfiguration.java
@@ -11,11 +11,9 @@ public final class TestConfiguration {
             + "/" + AAD_TENANT_NAME + "/";
     public final static String AAD_CLIENT_ID = "9083ccb8-8a46-43e7-8439-1d696df984ae";
     public final static String AAD_CLIENT_DUMMYSECRET = "client_dummysecret";
-    public final static String AAD_RESOURCE_ID = "b7a671d8-a408-42ff-86e0-aaf447fd17c4";
     public final static String AAD_MEX_RESPONSE_FILE = "/mex-response.xml";
     public final static String AAD_MEX_RESPONSE_FILE_INTEGRATED = "/mex-response-integrated.xml";
     public final static String AAD_MEX_2005_RESPONSE_FILE = "/mex-2005-response.xml";
-    public final static String AAD_TOKEN_ERROR_FILE = "/token-error.xml";
     public final static String AAD_TOKEN_SUCCESS_FILE = "/token.xml";
     public final static String AAD_DEFAULT_REDIRECT_URI = "https://non_existing_uri.windows.com/";
     public final static String AAD_COMMON_AUTHORITY = "https://login.microsoftonline.com/common/";
@@ -23,8 +21,6 @@ public final class TestConfiguration {
     public final static String ADFS_HOST_NAME = "fs.ade2eadfs30.com";
     public final static String ADFS_TENANT_ENDPOINT = "https://"
             + ADFS_HOST_NAME + "/adfs/";
-    public final static String AAD_UNKNOWN_TENANT_ENDPOINT = "https://lgn.windows.net/"
-            + AAD_TENANT_NAME + "/";
 
     public final static String B2C_HOST_NAME = "msidlabb2c.b2clogin.com";
     public final static String B2C_SIGN_IN_POLICY = "B2C_1_SignInPolicy";
@@ -35,13 +31,6 @@ public final class TestConfiguration {
             "/msidlabb2c.onmicrosoft.com";
     public final static String B2C_AUTHORITY_CUSTOM_PORT = "https://login.microsoftonline.in:444/tfp/tenant/policy";
     public final static String B2C_AUTHORITY_CUSTOM_PORT_TAIL_SLASH = "https://login.microsoftonline.in:444/tfp/tenant/policy/";
-
-    public static String INSTANCE_DISCOVERY_RESPONSE = "{" +
-            "\"tenant_discovery_endpoint\":\"https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-appConfiguration\"," +
-            "\"api-version\":\"1.1\"," +
-            "\"metadata\":[{\"preferred_network\":\"login.microsoftonline.com\",\"preferred_cache\":\"login.windows.net\",\"aliases\":[\"login.microsoftonline.com\",\"login.windows.net\",\"login.microsoft.com\",\"sts.windows.net\"]},{\"preferred_network\":\"login.partner.microsoftonline.cn\",\"preferred_cache\":\"login.partner.microsoftonline.cn\",\"aliases\":[\"login.partner.microsoftonline.cn\",\"login.chinacloudapi.cn\"]},{\"preferred_network\":\"login.microsoftonline.de\",\"preferred_cache\":\"login.microsoftonline.de\",\"aliases\":[\"login.microsoftonline.de\"]},{\"preferred_network\":\"login.microsoftonline.us\",\"preferred_cache\":\"login.microsoftonline.us\",\"aliases\":[\"login.microsoftonline.us\",\"login.usgovcloudapi.net\"]},{\"preferred_network\":\"login-us.microsoftonline.com\",\"preferred_cache\":\"login-us.microsoftonline.com\",\"aliases\":[\"login-us.microsoftonline.com\"]}]}";
-
-    public final static String AAD_PREFERRED_NETWORK_ENV_ALIAS = "login.microsoftonline.com";
 
     public final static String TOKEN_ENDPOINT_OK_RESPONSE_ID_AND_ACCESS = "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6I"
             + "k5HVEZ2ZEstZnl0aEV1THdqcHdBSk9NOW4tQSJ9.eyJhdWQiOiJiN2E2NzFkOC1hNDA4LTQyZmYtODZlMC1hYWY0NDdmZDE3YzQiLCJpc3MiOiJod"

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/UIRequiredCacheTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/UIRequiredCacheTest.java
@@ -34,10 +34,6 @@ class UIRequiredCacheTest {
                 .build();
     }
 
-    private RefreshTokenParameters getAcquireTokenApiParameters() {
-        return getAcquireTokenApiParameters("default-scope");
-    }
-
     private PublicClientApplication getPublicClientApp() throws Exception {
         return getPublicClientApp(null);
     }


### PR DESCRIPTION
Final dependency changes in test classes, and cleanup of various unused methods/fields/imports/dependencies, to finish the work in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/909

Except for `pom.xml`, the changes were made only in test classes. The actual behavior and coverage of those tests are the same as before, and the changes mainly affect classes that get test resources from the labs API plus a few small adjustments to use the new dependencies appropriately.

The PR makes the following changes:
- Replace usage of json dependencies with azure-json, and replace usage of lombok code generation with actual implementations
  - `CachePersistenceIT`, `Config`, `App`, `Lab`, `LabService`, `User`, `UserSecret`, `CacheFormatTests`
- Remove unused dependency imports from the Maven project definition
  - `pom.xml`
- Remove unused code and make adjustments to use new helper methods
  - All the other files not mentioned above, shouldn't need a deep review