### PR TITLE
Support multiple date formats in managed identity flows

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByManagedIdentitySupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByManagedIdentitySupplier.java
@@ -6,6 +6,7 @@ package com.microsoft.aad.msal4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -115,14 +116,13 @@ class AcquireTokenByManagedIdentitySupplier extends AuthenticationResultSupplier
 
         AuthenticationResult authenticationResult = createFromManagedIdentityResponse(managedIdentityResponse);
         clientApplication.tokenCache.saveTokens(tokenRequestExecutor, authenticationResult, clientApplication.authenticationAuthority.host);
-        AuthenticationResult result = authenticationResult;
-        result.metadata().tokenSource(TokenSource.IDENTITY_PROVIDER);
-        result.metadata().cacheRefreshReason(cacheRefreshReason);
-        return result;
+        authenticationResult.metadata().tokenSource(TokenSource.IDENTITY_PROVIDER);
+        authenticationResult.metadata().cacheRefreshReason(cacheRefreshReason);
+        return authenticationResult;
     }
 
     private AuthenticationResult createFromManagedIdentityResponse(ManagedIdentityResponse managedIdentityResponse) {
-        long expiresOn = Long.parseLong(managedIdentityResponse.expiresOn);
+        long expiresOn = getExpiresOnFromManagedIdentityTimestamp(managedIdentityResponse.expiresOn);
         long refreshOn = calculateRefreshOn(expiresOn);
         AuthenticationResultMetadata metadata = AuthenticationResultMetadata.builder()
                 .tokenSource(TokenSource.IDENTITY_PROVIDER)
@@ -137,6 +137,31 @@ class AcquireTokenByManagedIdentitySupplier extends AuthenticationResultSupplier
                 .refreshOn(refreshOn)
                 .metadata(metadata)
                 .build();
+    }
+
+    static long getExpiresOnFromManagedIdentityTimestamp(String dateTimeStamp) {
+        if (dateTimeStamp == null || dateTimeStamp.isEmpty()) {
+            return 0;
+        }
+
+        // Try parsing as Unix timestamp (seconds since epoch)
+        try {
+            return Long.parseLong(dateTimeStamp);
+        } catch (NumberFormatException e) {
+            // Not a number
+        }
+
+        // Try parsing as ISO 8601
+        try {
+            return Instant.parse(dateTimeStamp).getEpochSecond();
+        } catch (Exception e) {
+            // Not ISO 8601
+        }
+
+        throw new MsalClientException(
+                String.format("Failed to parse timestamp '%s'. Expected Unix epoch seconds or ISO 8601 format.",
+                        dateTimeStamp),
+                AuthenticationErrorCode.INVALID_TIMESTAMP_FORMAT);
     }
 
     private long calculateRefreshOn(long expiresOn) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationErrorCode.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationErrorCode.java
@@ -153,4 +153,6 @@ public class AuthenticationErrorCode {
      * or performing other cryptographic functions.
      */
     public static final String CRYPTO_ERROR = "crypto_error";
+
+    public static final String INVALID_TIMESTAMP_FORMAT = "invalid_timestamp_format";
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/DateTimeTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/DateTimeTests.java
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DateTimeTests {
+
+    @Test
+    void parseUnixTimestampInSeconds() {
+        long currentTimestamp = System.currentTimeMillis() / 1000;
+        long result = AcquireTokenByManagedIdentitySupplier.getExpiresOnFromManagedIdentityTimestamp(String.valueOf(currentTimestamp));
+
+        assertEquals(currentTimestamp, result, "Should parse Unix timestamp in seconds correctly");
+    }
+
+    @Test
+    void parseIso8601Format() {
+        // Creates a timestamp in ISO 8601 format, with 24 hours added to it to represent a 24-hour token
+        String timestamp = DateTimeFormatter.ISO_INSTANT.format(Instant.now().plus(24, ChronoUnit.HOURS));
+
+        long expected = Instant.parse(timestamp).getEpochSecond();
+        long result = AcquireTokenByManagedIdentitySupplier.getExpiresOnFromManagedIdentityTimestamp(timestamp);
+
+        assertEquals(expected, result, "Should parse ISO 8601 format correctly");
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "2025-05-15T12:34:56Z",              // Basic UTC format
+            "2025-05-15T12:34:56.1234",          // With milliseconds
+            "2025-05-15T12:34:56.123456789Z"     // With nanoseconds
+    })
+    void testValidIso8601Formats(String timestamp) {
+        long expected = Instant.parse(timestamp).getEpochSecond();
+        long result = AcquireTokenByManagedIdentitySupplier.getExpiresOnFromManagedIdentityTimestamp(timestamp);
+
+        assertEquals(expected, result, "Should parse ISO 8601 format correctly");
+    }
+
+    @Test
+    void handleNullTimestamp() {
+        long result = AcquireTokenByManagedIdentitySupplier.getExpiresOnFromManagedIdentityTimestamp(null);
+
+        assertEquals(0, result, "Should return 0 for null timestamp");
+    }
+
+    @Test
+    void handleEmptyTimestamp() {
+        long result = AcquireTokenByManagedIdentitySupplier.getExpiresOnFromManagedIdentityTimestamp("");
+
+        assertEquals(0, result, "Should return 0 for empty timestamp");
+    }
+
+    @Test
+    void handleInvalidFormat() {
+        String invalidTimestamp = "not-a-timestamp";
+
+        MsalClientException exception = assertThrows(
+                MsalClientException.class,
+                () -> AcquireTokenByManagedIdentitySupplier.getExpiresOnFromManagedIdentityTimestamp(invalidTimestamp)
+        );
+
+        assertEquals("invalid_timestamp_format", exception.errorCode());
+        assertTrue(exception.getMessage().contains(invalidTimestamp),
+                "Error message should contain the invalid timestamp");
+    }
+}

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/DateTimeTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/DateTimeTests.java
@@ -38,7 +38,7 @@ class DateTimeTests {
     @ParameterizedTest
     @ValueSource(strings = {
             "2025-05-15T12:34:56Z",              // Basic UTC format
-            "2025-05-15T12:34:56.1234",          // With milliseconds
+            "2025-05-15T12:34:56.1234Z",          // With milliseconds
             "2025-05-15T12:34:56.123456789Z"     // With nanoseconds
     })
     void testValidIso8601Formats(String timestamp) {

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -4,7 +4,6 @@
 package com.microsoft.aad.msal4j;
 
 import com.nimbusds.oauth2.sdk.util.URLUtils;
-import labapi.App;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -12,12 +11,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.SocketException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -49,6 +50,12 @@ class ManagedIdentityTests {
 
     private String getSuccessfulResponse(String resource) {
         long expiresOn = (System.currentTimeMillis() / 1000) + (24 * 3600);//A long-lived, 24 hour token
+        return "{\"access_token\":\"accesstoken\",\"expires_on\":\"" + expiresOn + "\",\"resource\":\"" + resource + "\",\"token_type\":" +
+                "\"Bearer\",\"client_id\":\"client_id\"}";
+    }
+
+    private String getSuccessfulResponseWithISOExpiresOn(String resource) {
+        String expiresOn = DateTimeFormatter.ISO_INSTANT.format(Instant.now().plus(24, ChronoUnit.HOURS));//A long-lived, 24 hour token
         return "{\"access_token\":\"accesstoken\",\"expires_on\":\"" + expiresOn + "\",\"resource\":\"" + resource + "\",\"token_type\":" +
                 "\"Bearer\",\"client_id\":\"client_id\"}";
     }
@@ -309,6 +316,39 @@ class ManagedIdentityTests {
         assertNotNull(result.accessToken());
         assertEquals(TokenSource.IDENTITY_PROVIDER, result.metadata().tokenSource());
         assertEquals((result.expiresOn() - timestampSeconds)/2, result.refreshOn() - timestampSeconds);
+
+        verify(httpClientMock, times(1)).send(any());
+    }
+
+    @Test
+    void managedIdentityTest_ISOExpiresOn() throws Exception {
+        //All managed identity flows use the same AcquireTokenByManagedIdentitySupplier where refreshOn is set,
+        //  so any of the MI options should let us verify that it's being set correctly
+        IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(ManagedIdentitySourceType.APP_SERVICE, appServiceEndpoint);
+        ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
+        DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
+
+        when(httpClientMock.send(expectedRequest(ManagedIdentitySourceType.APP_SERVICE, resource))).thenReturn(expectedResponse(200, getSuccessfulResponseWithISOExpiresOn(resource)));
+
+        miApp = ManagedIdentityApplication
+                .builder(ManagedIdentityId.systemAssigned())
+                .httpClient(httpClientMock)
+                .build();
+
+        // Clear caching to avoid cross test pollution.
+        miApp.tokenCache().accessTokens.clear();
+
+        AuthenticationResult result = (AuthenticationResult) miApp.acquireTokenForManagedIdentity(
+                ManagedIdentityParameters.builder(resource)
+                        .build()).get();
+
+        // Calculate what the expected expiration time should be
+        long expectedExpiresOn = System.currentTimeMillis() / 1000 + (24 * 3600); // 24 hours from now, used in getSuccessfulResponseWithISOExpiresOn
+
+        assertNotNull(result.accessToken());
+        assertEquals(TokenSource.IDENTITY_PROVIDER, result.metadata().tokenSource());
+        //Allow a few seconds of difference to account for execution time
+        assertTrue((result.expiresOn() - expectedExpiresOn) <= 5);
 
         verify(httpClientMock, times(1)).send(any());
     }


### PR DESCRIPTION
Fixes the issue described in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/873, similar to the issue and fix in MSAL .NET: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/4964

The expires_on value returned in a response during managed identity flows could be a simple Unix epoch timestamp or an ISO 8601 formatted date, though the current implementation only handles the timestamp.

This PR adds support for the missing date formats, clearer exception message, and tests for the new parsing method as well a mocked MI flow.