### PR TITLE
Add API to disable internal retry behavior

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractApplicationBase.java
@@ -32,6 +32,7 @@ public abstract class AbstractApplicationBase implements IApplicationBase {
     private IHttpClient httpClient;
     private Integer connectTimeoutForDefaultHttpClient;
     private Integer readTimeoutForDefaultHttpClient;
+    private boolean disableInternalRetries;
     String tenant;
 
     //The following fields are set in only some applications and/or set internally by the library. To avoid excessive
@@ -150,6 +151,10 @@ public abstract class AbstractApplicationBase implements IApplicationBase {
         return this.readTimeoutForDefaultHttpClient;
     }
 
+    boolean retriesDisabled() {
+        return this.disableInternalRetries;
+    }
+
     String tenant() {
         return this.tenant;
     }
@@ -190,6 +195,7 @@ public abstract class AbstractApplicationBase implements IApplicationBase {
         Boolean onlySendFailureTelemetry = false;
         Integer connectTimeoutForDefaultHttpClient;
         Integer readTimeoutForDefaultHttpClient;
+        boolean disableInternalRetries;
         private String clientId;
         private Authority authenticationAuthority = createDefaultAADAuthority();
 
@@ -319,6 +325,17 @@ public abstract class AbstractApplicationBase implements IApplicationBase {
             return self();
         }
 
+        /**
+         * Disables the library's internal retry logic for HTTP requests. Used alongside
+         *
+         * @param val timeout value in milliseconds
+         * @return instance of the Builder on which method was called
+         */
+        public T disableInternalRetries(boolean val) {
+            disableInternalRetries = val;
+            return self();
+        }
+
         T telemetryConsumer(Consumer<List<HashMap<String, String>>> val) {
             validateNotNull("telemetryConsumer", val);
 
@@ -356,5 +373,16 @@ public abstract class AbstractApplicationBase implements IApplicationBase {
         readTimeoutForDefaultHttpClient = builder.readTimeoutForDefaultHttpClient;
         authenticationAuthority = builder.authenticationAuthority;
         clientId = builder.clientId;
+        disableInternalRetries = builder.disableInternalRetries;
+
+        if (builder.httpClient == null) {
+            httpClient = new DefaultHttpClient(
+                    builder.proxy,
+                    builder.sslSocketFactory,
+                    builder.connectTimeoutForDefaultHttpClient,
+                    builder.readTimeoutForDefaultHttpClient);
+        } else {
+            httpClient = builder.httpClient;
+        }
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractApplicationBase.java
@@ -326,13 +326,14 @@ public abstract class AbstractApplicationBase implements IApplicationBase {
         }
 
         /**
-         * Disables the library's internal retry logic for HTTP requests. Used alongside
+         * The library has a number of policies for retrying HTTP calls in different scenarios.
+         * <p>
+         * This will disable all internal retry behavior, allowing customized retry behavior via your own implementation of {@link IHttpClient}
          *
-         * @param val timeout value in milliseconds
          * @return instance of the Builder on which method was called
          */
-        public T disableInternalRetries(boolean val) {
-            disableInternalRetries = val;
+        public T disableInternalRetries() {
+            disableInternalRetries = true;
             return self();
         }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractApplicationBase.java
@@ -32,7 +32,7 @@ public abstract class AbstractApplicationBase implements IApplicationBase {
     private IHttpClient httpClient;
     private Integer connectTimeoutForDefaultHttpClient;
     private Integer readTimeoutForDefaultHttpClient;
-    private boolean disableInternalRetries;
+    private boolean retryDisabled;
     String tenant;
 
     //The following fields are set in only some applications and/or set internally by the library. To avoid excessive
@@ -151,8 +151,8 @@ public abstract class AbstractApplicationBase implements IApplicationBase {
         return this.readTimeoutForDefaultHttpClient;
     }
 
-    boolean retriesDisabled() {
-        return this.disableInternalRetries;
+    boolean isRetryDisabled() {
+        return this.retryDisabled;
     }
 
     String tenant() {
@@ -374,7 +374,7 @@ public abstract class AbstractApplicationBase implements IApplicationBase {
         readTimeoutForDefaultHttpClient = builder.readTimeoutForDefaultHttpClient;
         authenticationAuthority = builder.authenticationAuthority;
         clientId = builder.clientId;
-        disableInternalRetries = builder.disableInternalRetries;
+        retryDisabled = builder.disableInternalRetries;
 
         if (builder.httpClient == null) {
             httpClient = new DefaultHttpClient(

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractClientApplicationBase.java
@@ -566,10 +566,7 @@ public abstract class AbstractClientApplicationBase extends AbstractApplicationB
         super.serviceBundle = new ServiceBundle(
                 builder.executorService,
                 new TelemetryManager(telemetryConsumer, builder.onlySendFailureTelemetry),
-                new HttpHelper(builder.httpClient == null ?
-                        new DefaultHttpClient(builder.proxy, builder.sslSocketFactory, builder.connectTimeoutForDefaultHttpClient, builder.readTimeoutForDefaultHttpClient) :
-                        builder.httpClient,
-                        new DefaultRetryPolicy())
+                new HttpHelper(this, new DefaultRetryPolicy())
         );
 
         if (aadAadInstanceDiscoveryResponse != null) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpHelper.java
@@ -26,9 +26,16 @@ class HttpHelper implements IHttpHelper {
 
     private IHttpClient httpClient;
     private IRetryPolicy retryPolicy;
+    private boolean retriesDisabled;
 
     HttpHelper(IHttpClient httpClient, IRetryPolicy retryPolicy) {
         this.httpClient = httpClient;
+        this.retryPolicy = retryPolicy != null ? retryPolicy : new DefaultRetryPolicy();
+    }
+
+    HttpHelper(AbstractApplicationBase application, IRetryPolicy retryPolicy) {
+        this.httpClient = application.httpClient();
+        this.retriesDisabled = application.retriesDisabled();
         this.retryPolicy = retryPolicy != null ? retryPolicy : new DefaultRetryPolicy();
     }
 
@@ -144,6 +151,10 @@ class HttpHelper implements IHttpHelper {
     IHttpResponse executeHttpRequestWithRetries(HttpRequest httpRequest, IHttpClient httpClient)
             throws Exception {
         IHttpResponse httpResponse = httpClient.send(httpRequest);
+
+        if (retriesDisabled) {
+            return httpResponse;
+        }
 
         int retryCount = 0;
         int maxRetries = retryPolicy.getMaxRetryCount(httpResponse);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpHelper.java
@@ -26,7 +26,7 @@ class HttpHelper implements IHttpHelper {
 
     private IHttpClient httpClient;
     private IRetryPolicy retryPolicy;
-    private boolean retriesDisabled;
+    private boolean retryDisabled;
 
     HttpHelper(IHttpClient httpClient, IRetryPolicy retryPolicy) {
         this.httpClient = httpClient;
@@ -35,7 +35,7 @@ class HttpHelper implements IHttpHelper {
 
     HttpHelper(AbstractApplicationBase application, IRetryPolicy retryPolicy) {
         this.httpClient = application.httpClient();
-        this.retriesDisabled = application.retriesDisabled();
+        this.retryDisabled = application.isRetryDisabled();
         this.retryPolicy = retryPolicy != null ? retryPolicy : new DefaultRetryPolicy();
     }
 
@@ -152,7 +152,7 @@ class HttpHelper implements IHttpHelper {
             throws Exception {
         IHttpResponse httpResponse = httpClient.send(httpRequest);
 
-        if (retriesDisabled) {
+        if (retryDisabled) {
             return httpResponse;
         }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
@@ -37,10 +37,7 @@ public class ManagedIdentityApplication extends AbstractApplicationBase implemen
         super.serviceBundle = new ServiceBundle(
                 builder.executorService,
                 new TelemetryManager(telemetryConsumer, builder.onlySendFailureTelemetry),
-                new HttpHelper(builder.httpClient == null ?
-                        new DefaultHttpClient(builder.proxy, builder.sslSocketFactory, builder.connectTimeoutForDefaultHttpClient, builder.readTimeoutForDefaultHttpClient) :
-                        builder.httpClient,
-                        new ManagedIdentityRetryPolicy())
+                new HttpHelper(this, new ManagedIdentityRetryPolicy())
         );
         log = LoggerFactory.getLogger(ManagedIdentityApplication.class);
 

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -601,7 +601,7 @@ class ManagedIdentityTests {
             miApp = ManagedIdentityApplication
                     .builder(ManagedIdentityId.systemAssigned())
                     .httpClient(httpClientMock)
-                    .disableInternalRetries(true)
+                    .disableInternalRetries()
                     .build();
 
             //Several specific 4xx and 5xx errors, such as 500, should trigger MSAL's retry logic

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -587,6 +587,40 @@ class ManagedIdentityTests {
             fail("MsalServiceException is expected but not thrown.");
         }
 
+        @ParameterizedTest
+        @MethodSource("com.microsoft.aad.msal4j.ManagedIdentityTestDataProvider#createDataWrongScope")
+        void managedIdentityTest_RetriesDisabled(ManagedIdentitySourceType source, String endpoint, String resource) throws Exception {
+            IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(source, endpoint);
+            ManagedIdentityApplication.setEnvironmentVariables(environmentVariables);
+
+            DefaultHttpClientManagedIdentity httpClientMock = mock(DefaultHttpClientManagedIdentity.class);
+            if (source == SERVICE_FABRIC) {
+                ServiceFabricManagedIdentitySource.setHttpClient(httpClientMock);
+            }
+
+            miApp = ManagedIdentityApplication
+                    .builder(ManagedIdentityId.systemAssigned())
+                    .httpClient(httpClientMock)
+                    .disableInternalRetries(true)
+                    .build();
+
+            //Several specific 4xx and 5xx errors, such as 500, should trigger MSAL's retry logic
+            when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(500, ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500));
+
+            try {
+                acquireTokenCommon(resource).get();
+            } catch (Exception exception) {
+                assert(exception.getCause() instanceof MsalServiceException);
+
+                //But because retries are disabled at the app level, there should be no retries for any source except Service Fabric, which uses its own HttpClient
+                if (source == SERVICE_FABRIC) {
+                    verify(httpClientMock, times(4)).send(any());
+                } else {
+                    verify(httpClientMock, times(1)).send(any());
+                }
+            }
+        }
+
         @Test
         void managedIdentityTest_IMDSRetry() throws Exception {
             IEnvironmentVariables environmentVariables = new EnvironmentVariablesHelper(IMDS, ManagedIdentityTestConstants.IMDS_ENDPOINT);


### PR DESCRIPTION
Adds a public API to `AbstractApplicationBase` to disable internal retry behavior for HTTP requests, similar to what was done in MSAL Node and .NET:
https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/7603
https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5252

Internally, `HttpHelper` was given a new constructor more easily and cleanly use this new field and the new `IRetryPolicy` introduce in https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/960, and some minor refactoring was done to related classes.

`ManagedIdentityTests` received a new parameterized test which uses the API with several `IRetryPolicy` implementations.