### PR TITLE
Consistently use constants for HTTP status codes

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
@@ -235,8 +235,8 @@ class AadInstanceDiscoveryProvider {
 
         AadInstanceDiscoveryResponse response = JsonHelper.convertJsonStringToJsonSerializableObject(httpResponse.body(), AadInstanceDiscoveryResponse::fromJson);
 
-        if (httpResponse.statusCode() != HttpHelper.HTTP_STATUS_200) {
-            if (httpResponse.statusCode() == HttpHelper.HTTP_STATUS_400 && response.error().equals("invalid_instance")) {
+        if (httpResponse.statusCode() != HttpStatus.HTTP_OK) {
+            if (httpResponse.statusCode() == HttpStatus.HTTP_BAD_REQUEST && response.error().equals("invalid_instance")) {
                 // instance discovery failed due to an invalid authority, throw an exception.
                 throw MsalServiceExceptionFactory.fromHttpResponse(httpResponse);
             }
@@ -310,7 +310,7 @@ class AadInstanceDiscoveryProvider {
             log.info("Starting call to IMDS endpoint.");
             IHttpResponse httpResponse = future.get(IMDS_TIMEOUT, IMDS_TIMEOUT_UNIT);
             //If call to IMDS endpoint was successful, return region from response body
-            if (httpResponse.statusCode() == HttpHelper.HTTP_STATUS_200 && !httpResponse.body().isEmpty()) {
+            if (httpResponse.statusCode() == HttpStatus.HTTP_OK && !httpResponse.body().isEmpty()) {
                 log.info(String.format("Region retrieved from IMDS endpoint: %s", httpResponse.body()));
                 currentRequest.regionSource(RegionTelemetry.REGION_SOURCE_IMDS.telemetryValue);
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
@@ -41,7 +41,7 @@ class AuthorizationResponseHandler implements HttpHandler {
     public void handle(HttpExchange httpExchange) throws IOException {
         try {
             if (!httpExchange.getRequestURI().getPath().equalsIgnoreCase("/")) {
-                httpExchange.sendResponseHeaders(200, 0);
+                httpExchange.sendResponseHeaders(HttpStatus.HTTP_OK, 0);
                 return;
             }
             String responseBody = new BufferedReader(new InputStreamReader(
@@ -92,13 +92,13 @@ class AuthorizationResponseHandler implements HttpHandler {
     private void send302Response(HttpExchange httpExchange, String redirectUri) throws IOException {
         Headers responseHeaders = httpExchange.getResponseHeaders();
         responseHeaders.set("Location", redirectUri);
-        httpExchange.sendResponseHeaders(302, 0);
+        httpExchange.sendResponseHeaders(HttpStatus.HTTP_FOUND, 0);
     }
 
     private void send200Response(HttpExchange httpExchange, String response) throws IOException {
         byte[] responseBytes = response.getBytes("UTF-8");
         httpExchange.getResponseHeaders().set("Content-Type", "text/html; charset=UTF-8");
-        httpExchange.sendResponseHeaders(200, responseBytes.length);
+        httpExchange.sendResponseHeaders(HttpStatus.HTTP_OK, responseBytes.length);
         OutputStream os = httpExchange.getResponseBody();
         os.write(responseBytes);
         os.close();

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowRequest.java
@@ -46,7 +46,7 @@ class DeviceCodeFlowRequest extends MsalRequest {
                 this.requestContext(),
                 serviceBundle);
 
-        if (response.statusCode() != HttpHelper.HTTP_STATUS_200) {
+        if (response.statusCode() != HttpStatus.HTTP_OK) {
             throw MsalServiceExceptionFactory.fromHttpResponse(response);
         }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpHelper.java
@@ -19,11 +19,6 @@ class HttpHelper implements IHttpHelper {
     private static final Logger log = LoggerFactory.getLogger(HttpHelper.class);
     public static final String RETRY_AFTER_HEADER = "Retry-After";
 
-    public static final int HTTP_STATUS_200 = 200;
-    public static final int HTTP_STATUS_400 = 400;
-    public static final int HTTP_STATUS_429 = 429;
-    public static final int HTTP_STATUS_500 = 500;
-
     private IHttpClient httpClient;
     private IRetryPolicy retryPolicy;
 
@@ -179,8 +174,8 @@ class HttpHelper implements IHttpHelper {
             Integer retryAfterHeaderVal = getRetryAfterHeader(httpResponse);
             if (retryAfterHeaderVal != null) {
                 expirationTimestamp = System.currentTimeMillis() + retryAfterHeaderVal * 1000;
-            } else if (httpResponse.statusCode() == HTTP_STATUS_429 ||
-                    (httpResponse.statusCode() >= HTTP_STATUS_500)) {
+            } else if (httpResponse.statusCode() == HttpStatus.HTTP_TOO_MANY_REQUESTS ||
+                    (httpResponse.statusCode() >= HttpStatus.HTTP_INTERNAL_ERROR)) {
 
                 expirationTimestamp = System.currentTimeMillis() + ThrottlingCache.DEFAULT_THROTTLING_TIME_SEC * 1000;
             }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpStatus.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpStatus.java
@@ -3,35 +3,26 @@
 
 package com.microsoft.aad.msal4j;
 
-enum HttpStatus {
-    OK(200, "OK"),
-    FOUND(302, "Found"),
-    BAD_REQUEST(400, "Bad Request"),
-    NOT_FOUND(404, "Not Found"),
-    REQUEST_TIMEOUT(408, "Request Timeout"),
-    GONE(410, "Gone"),
-    TOO_MANY_REQUESTS(429, "Too Many Requests"),
-    INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
-    SERVICE_UNAVAILABLE(503, "Service Unavailable"),
-    GATEWAY_TIMEOUT(504, "Gateway Timeout");
+class HttpStatus {
 
-    private final int code;
-    private final String description;
+    static final int HTTP_OK = 200;
+    static final int HTTP_FOUND = 302;
+    static final int HTTP_BAD_REQUEST = 400;
+    static final int HTTP_UNAUTHORIZED = 401;
+    static final int HTTP_NOT_FOUND = 404;
+    static final int HTTP_REQUEST_TIMEOUT = 408;
+    static final int HTTP_GONE = 410;
+    static final int HTTP_TOO_MANY_REQUESTS = 429;
+    static final int HTTP_INTERNAL_ERROR = 500;
+    static final int HTTP_UNAVAILABLE = 503;
+    static final int HTTP_GATEWAY_TIMEOUT = 504;
 
-    HttpStatus(int code, String description) {
-        this.code = code;
-        this.description = description;
-    }
-
-    int getCode() {
-        return code;
-    }
-
-    String getDescription() {
-        return description;
-    }
-
-    //All 5xx errors
+    /**
+     * Determines if the status code represents a server error (5xx).
+     *
+     * @param code The HTTP status code
+     * @return true if the status code is between 500 and 599, inclusive
+     */
     static boolean isServerError(int code) {
         return code >= 500 && code < 600;
     }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IMDSRetryPolicy.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IMDSRetryPolicy.java
@@ -23,10 +23,10 @@ class IMDSRetryPolicy extends ManagedIdentityRetryPolicy {
 
     private static final Set<Integer> RETRYABLE_STATUS_CODES = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(
-                    HttpStatus.NOT_FOUND.getCode(),
-                    HttpStatus.REQUEST_TIMEOUT.getCode(),
-                    HttpStatus.GONE.getCode(),
-                    HttpStatus.TOO_MANY_REQUESTS.getCode()
+                    HttpStatus.HTTP_NOT_FOUND,
+                    HttpStatus.HTTP_REQUEST_TIMEOUT,
+                    HttpStatus.HTTP_GONE,
+                    HttpStatus.HTTP_TOO_MANY_REQUESTS
             ))
     );
 
@@ -40,13 +40,13 @@ class IMDSRetryPolicy extends ManagedIdentityRetryPolicy {
 
     @Override
     public int getMaxRetryCount(IHttpResponse httpResponse) {
-        return (httpResponse.statusCode() == HttpStatus.GONE.getCode()) ? LINEAR_RETRY_NUM : EXPONENTIAL_RETRY_NUM;
+        return (httpResponse.statusCode() == HttpStatus.HTTP_GONE) ? LINEAR_RETRY_NUM : EXPONENTIAL_RETRY_NUM;
     }
 
     @Override
     public int getRetryDelayMs(IHttpResponse httpResponse) {
         // Use exponential backoff for non-410 status codes
-        if (lastStatusCode == HttpStatus.GONE.getCode()) {
+        if (lastStatusCode == HttpStatus.HTTP_GONE) {
             return currentLinearRetryDelayMs;
         } else {
             return (int) (Math.pow(2, currentRetryCount) * exponentialLinearRetryDelayMs);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityRetryPolicy.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityRetryPolicy.java
@@ -19,12 +19,12 @@ class ManagedIdentityRetryPolicy implements IRetryPolicy {
 
     private static final Set<Integer> RETRYABLE_STATUS_CODES = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(
-                    HttpStatus.NOT_FOUND.getCode(),
-                    HttpStatus.REQUEST_TIMEOUT.getCode(),
-                    HttpStatus.TOO_MANY_REQUESTS.getCode(),
-                    HttpStatus.INTERNAL_SERVER_ERROR.getCode(),
-                    HttpStatus.SERVICE_UNAVAILABLE.getCode(),
-                    HttpStatus.GATEWAY_TIMEOUT.getCode()
+                    HttpStatus.HTTP_NOT_FOUND,
+                    HttpStatus.HTTP_REQUEST_TIMEOUT,
+                    HttpStatus.HTTP_TOO_MANY_REQUESTS,
+                    HttpStatus.HTTP_INTERNAL_ERROR,
+                    HttpStatus.HTTP_UNAVAILABLE,
+                    HttpStatus.HTTP_GATEWAY_TIMEOUT
             ))
     );
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OidcDiscoveryProvider.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OidcDiscoveryProvider.java
@@ -14,7 +14,7 @@ class OidcDiscoveryProvider {
 
         OidcDiscoveryResponse response = JsonHelper.convertJsonStringToJsonSerializableObject(httpResponse.body(), OidcDiscoveryResponse::fromJson);
 
-        if (httpResponse.statusCode() != HttpHelper.HTTP_STATUS_200) {
+        if (httpResponse.statusCode() != HttpStatus.HTTP_OK) {
             throw MsalServiceExceptionFactory.fromHttpResponse(httpResponse);
         }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -167,7 +167,7 @@ class TokenRequestExecutor {
 
         } else {
             // http codes indicating that STS did not log request
-            if (oauthHttpResponse.getStatusCode() == HttpHelper.HTTP_STATUS_429 || oauthHttpResponse.getStatusCode() >= HttpHelper.HTTP_STATUS_500) {
+            if (oauthHttpResponse.getStatusCode() == HttpStatus.HTTP_TOO_MANY_REQUESTS || oauthHttpResponse.getStatusCode() >= HttpStatus.HTTP_INTERNAL_ERROR) {
                 serviceBundle.getServerSideTelemetry().previousRequests.putAll(
                         serviceBundle.getServerSideTelemetry().previousRequestInProgress);
             }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserDiscoveryRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserDiscoveryRequest.java
@@ -29,7 +29,7 @@ class UserDiscoveryRequest {
         HttpRequest httpRequest = new HttpRequest(HttpMethod.GET, uri, headers);
         IHttpResponse response = serviceBundle.getHttpHelper().executeHttpRequest(httpRequest, requestContext, serviceBundle);
 
-        if (response.statusCode() != HttpHelper.HTTP_STATUS_200) {
+        if (response.statusCode() != HttpStatus.HTTP_OK) {
             throw MsalServiceExceptionFactory.fromHttpResponse(response);
         }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/WSTrustRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/WSTrustRequest.java
@@ -59,7 +59,7 @@ class WSTrustRequest {
         HttpRequest httpRequest = new HttpRequest(HttpMethod.GET, url);
         IHttpResponse mexResponse = serviceBundle.getHttpHelper().executeHttpRequest(httpRequest, requestContext, serviceBundle);
 
-        if (mexResponse.statusCode() != HttpHelper.HTTP_STATUS_200 || StringHelper.isBlank(mexResponse.body())) {
+        if (mexResponse.statusCode() != HttpStatus.HTTP_OK || StringHelper.isBlank(mexResponse.body())) {
             throw MsalServiceExceptionFactory.fromHttpResponse(mexResponse);
         }
 

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AcquireTokenSilentlyTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AcquireTokenSilentlyTest.java
@@ -137,7 +137,7 @@ class AcquireTokenSilentlyTest {
         responseParameters.put("access_token", "expiredToken");
         responseParameters.put("id_token", TestHelper.createIdToken(new HashMap<>()));
         responseParameters.put("expires_in", "0");
-        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), 200);
+        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), HttpStatus.HTTP_OK);
 
         OnBehalfOfParameters parameters = OnBehalfOfParameters.builder(Collections.singleton("someScopes"), new UserAssertion(TestHelper.signedAssertion)).build();
         IAuthenticationResult result = cca.acquireToken(parameters).get();
@@ -149,7 +149,7 @@ class AcquireTokenSilentlyTest {
         // In this test, it will be replaced with a token that expires in 1 minute
         responseParameters.put("access_token", "nearlyExpiredToken");
         responseParameters.put("expires_in", "60");
-        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), 200);
+        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), HttpStatus.HTTP_OK);
 
         SilentParameters silentParameters = SilentParameters.builder(Collections.singleton("someScopes"), result.account()).build();
         result = cca.acquireTokenSilently(silentParameters).get();
@@ -162,7 +162,7 @@ class AcquireTokenSilentlyTest {
         responseParameters.put("access_token", "refreshInToken");
         responseParameters.put("expires_in", "3600");
         responseParameters.put("refresh_in", "1");
-        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), 200);
+        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), HttpStatus.HTTP_OK);
 
         silentParameters = SilentParameters.builder(Collections.singleton("someScopes"), result.account()).build();
         result = cca.acquireTokenSilently(silentParameters).get();
@@ -174,7 +174,7 @@ class AcquireTokenSilentlyTest {
         responseParameters.put("access_token", "normalToken");
         responseParameters.put("expires_in", "3600");
         responseParameters.put("refresh_in", "0");
-        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), 200);
+        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), HttpStatus.HTTP_OK);
 
         //refresh_in values are in seconds, so we must wait to guarantee it is past the proactive refresh time
         TimeUnit.SECONDS.sleep(2);
@@ -186,7 +186,7 @@ class AcquireTokenSilentlyTest {
 
         //Force the token to be refreshed
         responseParameters.put("access_token", "forcedRefreshToken");
-        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), 200);
+        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), HttpStatus.HTTP_OK);
 
         silentParameters = SilentParameters.builder(Collections.singleton("someScopes"), result.account()).forceRefresh(true).build();
         result = cca.acquireTokenSilently(silentParameters).get();
@@ -195,7 +195,7 @@ class AcquireTokenSilentlyTest {
 
         //Finally, force a refresh by setting claims
         responseParameters.put("access_token", "claimsToken");
-        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), 200);
+        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), HttpStatus.HTTP_OK);
 
         silentParameters = SilentParameters.builder(Collections.singleton("someScopes"), result.account()).claims(new ClaimsRequest()).build();
         result = cca.acquireTokenSilently(silentParameters).get();

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheFormatTests.java
@@ -158,7 +158,7 @@ class CacheFormatTests {
 
         doReturn(msalOAuthHttpRequest).when(request).createOauthHttpRequest();
         doReturn(httpResponse).when(msalOAuthHttpRequest).send();
-        doReturn(200).when(httpResponse).getStatusCode();
+        doReturn(HttpStatus.HTTP_OK).when(httpResponse).getStatusCode();
         doReturn(JSONObjectUtils.parse(tokenResponse)).when(httpResponse).getContentAsJSONObject();
 
         final AuthenticationResult result = request.executeTokenRequest();

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/CacheTests.java
@@ -35,7 +35,7 @@ class CacheTests {
         responseParameters.put("access_token", "accessTokenNoAccount");
 
         ClientCredentialParameters clientCredentialParameters = ClientCredentialParameters.builder(Collections.singleton("someScopes")).build();
-        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(200, TestHelper.getSuccessfulTokenResponse(responseParameters)));
+        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(HttpStatus.HTTP_OK, TestHelper.getSuccessfulTokenResponse(responseParameters)));
         IAuthenticationResult resultNoAccount = cca.acquireToken(clientCredentialParameters).get();
 
         //Ensure there is one token in the cache, and the result had no account
@@ -47,7 +47,7 @@ class CacheTests {
         responseParameters.put("access_token", "accessTokenWithAccount");
         responseParameters.put("id_token", TestHelper.createIdToken(new HashMap<>()));
 
-        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(200, TestHelper.getSuccessfulTokenResponse(responseParameters)));
+        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(HttpStatus.HTTP_OK, TestHelper.getSuccessfulTokenResponse(responseParameters)));
         OnBehalfOfParameters onBehalfOfParametersarameters = OnBehalfOfParameters.builder(Collections.singleton("someOtherScopes"), new UserAssertion(TestHelper.signedAssertion)).build();
         IAuthenticationResult resultWithAccount = cca.acquireToken(onBehalfOfParametersarameters).get();
 

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClientCertificateTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClientCertificateTest.java
@@ -76,7 +76,7 @@ class ClientCertificateTest {
             if (request.body().contains(((PrivateKeyJWT) cca.clientAuthentication()).getClientAssertion().serialize())
                     && headerParams.contains("x5t#S256")) {
 
-                return TestHelper.expectedResponse(200, TestHelper.getSuccessfulTokenResponse(tokenResponseValues));
+                return TestHelper.expectedResponse(HttpStatus.HTTP_OK, TestHelper.getSuccessfulTokenResponse(tokenResponseValues));
             }
             return null;
         });

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClientCredentialTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ClientCredentialTest.java
@@ -47,7 +47,7 @@ class ClientCredentialTest {
     void OnBehalfOf_InternalCacheLookup_Success() throws Exception {
         DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
 
-        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(200, TestHelper.getSuccessfulTokenResponse(new HashMap<>())));
+        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(HttpStatus.HTTP_OK, TestHelper.getSuccessfulTokenResponse(new HashMap<>())));
 
         ConfidentialClientApplication cca =
                 ConfidentialClientApplication.builder("clientId", ClientCredentialFactory.createFromSecret("password"))
@@ -82,7 +82,7 @@ class ClientCredentialTest {
         HashMap<String, String> tokenResponseValues = new HashMap<>();
         tokenResponseValues.put("access_token", "accessTokenFirstCall");
 
-        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(200, TestHelper.getSuccessfulTokenResponse(tokenResponseValues)));
+        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(HttpStatus.HTTP_OK, TestHelper.getSuccessfulTokenResponse(tokenResponseValues)));
         ClientCredentialParameters parameters = ClientCredentialParameters.builder(Collections.singleton("scopes")).build();
 
         //The two acquireToken calls have the same parameters...
@@ -95,7 +95,7 @@ class ClientCredentialTest {
 
         tokenResponseValues.put("access_token", "accessTokenSecondCall");
 
-        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(200, TestHelper.getSuccessfulTokenResponse(tokenResponseValues)));
+        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(HttpStatus.HTTP_OK, TestHelper.getSuccessfulTokenResponse(tokenResponseValues)));
         parameters = ClientCredentialParameters.builder(Collections.singleton("scopes")).tenant("otherTenant").build();
 
         //Overriding the tenant parameter in the request should lead to a new token call being made...

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -30,7 +30,6 @@ import static com.microsoft.aad.msal4j.MsalError.MANAGED_IDENTITY_FILE_READ_ERRO
 import static com.microsoft.aad.msal4j.MsalError.MANAGED_IDENTITY_REQUEST_FAILED;
 import static com.microsoft.aad.msal4j.MsalErrorMessage.*;
 import static java.util.Collections.*;
-import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -267,7 +266,7 @@ class ManagedIdentityTests {
         void managedIdentityTest_SystemAssigned_SuccessfulResponse(ManagedIdentitySourceType source, String endpoint, String resource) throws Exception {
             setUpCommonTest(source, endpoint, ManagedIdentityId.systemAssigned());
 
-            when(httpClientMock.send(any())).thenReturn(expectedResponse(200, getSuccessfulResponse(resource)));
+            when(httpClientMock.send(any())).thenReturn(expectedResponse(HttpStatus.HTTP_OK, getSuccessfulResponse(resource)));
 
             IAuthenticationResult result = acquireTokenCommon(resource).get();
 
@@ -285,7 +284,7 @@ class ManagedIdentityTests {
             setUpCommonTest(source, endpoint, id);
 
             when(httpClientMock.send(expectedRequest(source, ManagedIdentityTestConstants.RESOURCE, id)))
-                    .thenReturn(expectedResponse(200, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_OK, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
 
             IAuthenticationResult result = acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE).get();
 
@@ -298,7 +297,7 @@ class ManagedIdentityTests {
         void managedIdentity_SharedCache(ManagedIdentitySourceType source, String endpoint) throws Exception {
             setUpCommonTest(source, endpoint, ManagedIdentityId.systemAssigned());
 
-            when(httpClientMock.send(any())).thenReturn(expectedResponse(200, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
+            when(httpClientMock.send(any())).thenReturn(expectedResponse(HttpStatus.HTTP_OK, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
 
             ManagedIdentityApplication miApp2 = ManagedIdentityApplication
                     .builder(ManagedIdentityId.systemAssigned())
@@ -327,11 +326,11 @@ class ManagedIdentityTests {
         void managedIdentityTest_DifferentScopes_RequestsNewToken(ManagedIdentitySourceType source, String endpoint) throws Exception {
             setUpCommonTest(source, endpoint, ManagedIdentityId.systemAssigned());
 
-            when(httpClientMock.send(any())).thenReturn(expectedResponse(200, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
+            when(httpClientMock.send(any())).thenReturn(expectedResponse(HttpStatus.HTTP_OK, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
 
             String anotherResource = "https://graph.microsoft.com";
 
-            when(httpClientMock.send(expectedRequest(source, anotherResource))).thenReturn(expectedResponse(200, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
+            when(httpClientMock.send(expectedRequest(source, anotherResource))).thenReturn(expectedResponse(HttpStatus.HTTP_OK, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
 
             IAuthenticationResult result = acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE).get();
 
@@ -353,7 +352,7 @@ class ManagedIdentityTests {
         void managedIdentityTest_WithClaims(ManagedIdentitySourceType source, String endpoint) throws Exception {
             setUpCommonTest(source, endpoint, ManagedIdentityId.systemAssigned());
 
-            when(httpClientMock.send(any())).thenReturn(expectedResponse(200, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
+            when(httpClientMock.send(any())).thenReturn(expectedResponse(HttpStatus.HTTP_OK, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
 
             String claimsJson = "{\"default\":\"claim\"}";
 
@@ -369,7 +368,7 @@ class ManagedIdentityTests {
 
             String expectedTokenHash = StringHelper.createSha256HashHexString(result.accessToken());
             when(httpClientMock.send(expectedRequest(source, ManagedIdentityTestConstants.RESOURCE, true, false, expectedTokenHash)))
-                    .thenReturn(expectedResponse(200, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_OK, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
 
             // Third call, when claims are passed bypass the cache.
             result = miApp.acquireTokenForManagedIdentity(
@@ -389,7 +388,7 @@ class ManagedIdentityTests {
             initHttpClientMock(source);
 
             when(httpClientMock.send(expectedRequest(source, ManagedIdentityTestConstants.RESOURCE, false, true, null)))
-                    .thenReturn(expectedResponse(200, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_OK, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
 
             miApp = ManagedIdentityApplication
                     .builder(ManagedIdentityId.systemAssigned())
@@ -418,7 +417,7 @@ class ManagedIdentityTests {
             setUpCommonTest(source, endpoint, ManagedIdentityId.systemAssigned());
 
             when(httpClientMock.send(expectedRequest(source, ManagedIdentityTestConstants.RESOURCE, false, true, null)))
-                    .thenReturn(expectedResponse(200, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_OK, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
 
             miApp = ManagedIdentityApplication
                     .builder(ManagedIdentityId.systemAssigned())
@@ -439,7 +438,7 @@ class ManagedIdentityTests {
 
             String expectedTokenHash = StringHelper.createSha256HashHexString(result.accessToken());
             when(httpClientMock.send(expectedRequest(source, ManagedIdentityTestConstants.RESOURCE, true, true, expectedTokenHash)))
-                    .thenReturn(expectedResponse(200, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_OK, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
 
             // Third call, when claims are passed bypass the cache.
             result = miApp.acquireTokenForManagedIdentity(
@@ -467,7 +466,7 @@ class ManagedIdentityTests {
             //  so any of the MI options should let us verify that it's being set correctly
             setUpCommonTest(APP_SERVICE, ManagedIdentityTestConstants.APP_SERVICE_ENDPOINT, ManagedIdentityId.systemAssigned());
 
-            when(httpClientMock.send(expectedRequest(APP_SERVICE, ManagedIdentityTestConstants.RESOURCE))).thenReturn(expectedResponse(200, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
+            when(httpClientMock.send(expectedRequest(APP_SERVICE, ManagedIdentityTestConstants.RESOURCE))).thenReturn(expectedResponse(HttpStatus.HTTP_OK, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
 
             AuthenticationResult result = (AuthenticationResult) acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE).get();
 
@@ -488,7 +487,7 @@ class ManagedIdentityTests {
             //  so any of the MI options should let us verify that it's being set correctly
             setUpCommonTest(APP_SERVICE, ManagedIdentityTestConstants.APP_SERVICE_ENDPOINT, ManagedIdentityId.systemAssigned());
 
-            when(httpClientMock.send(expectedRequest(ManagedIdentitySourceType.APP_SERVICE, ManagedIdentityTestConstants.RESOURCE))).thenReturn(expectedResponse(200, getSuccessfulResponseWithISOExpiresOn(ManagedIdentityTestConstants.RESOURCE)));
+            when(httpClientMock.send(expectedRequest(ManagedIdentitySourceType.APP_SERVICE, ManagedIdentityTestConstants.RESOURCE))).thenReturn(expectedResponse(HttpStatus.HTTP_OK, getSuccessfulResponseWithISOExpiresOn(ManagedIdentityTestConstants.RESOURCE)));
 
             AuthenticationResult result = (AuthenticationResult) miApp.acquireTokenForManagedIdentity(
                     ManagedIdentityParameters.builder(ManagedIdentityTestConstants.RESOURCE)
@@ -513,7 +512,7 @@ class ManagedIdentityTests {
         void managedIdentityTest_SuccessfulResponse_WithInvalidJson(ManagedIdentitySourceType source, String endpoint, String resource) throws Exception {
             setUpCommonTest(source, endpoint, ManagedIdentityId.systemAssigned());
 
-            when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(200, ManagedIdentityTestConstants.RESPONSE_MALFORMED_JSON));
+            when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(HttpStatus.HTTP_OK, ManagedIdentityTestConstants.RESPONSE_MALFORMED_JSON));
 
             assertMsalServiceException(acquireTokenCommon(resource), source, MsalError.MANAGED_IDENTITY_RESPONSE_PARSE_FAILURE);
         }
@@ -532,9 +531,9 @@ class ManagedIdentityTests {
             setUpCommonTest(source, endpoint, ManagedIdentityId.systemAssigned());
 
             if (environmentVariables.getEnvironmentVariable("SourceType").equals(CLOUD_SHELL.toString())) {
-                when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(500, ManagedIdentityTestConstants.CLOUDSHELL_ERROR_RESPONSE));
+                when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(HttpStatus.HTTP_INTERNAL_ERROR, ManagedIdentityTestConstants.CLOUDSHELL_ERROR_RESPONSE));
             } else {
-                when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(500, ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500));
+                when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(HttpStatus.HTTP_INTERNAL_ERROR, ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500));
             }
 
             assertMsalServiceException(acquireTokenCommon(resource), source, MsalError.MANAGED_IDENTITY_REQUEST_FAILED);
@@ -557,7 +556,7 @@ class ManagedIdentityTests {
                     .build();
 
             //Several specific 4xx and 5xx errors, such as 500, should trigger MSAL's retry logic
-            when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(500, ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500));
+            when(httpClientMock.send(expectedRequest(source, resource))).thenReturn(expectedResponse(HttpStatus.HTTP_INTERNAL_ERROR, ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500));
 
             try {
                 acquireTokenCommon(resource).get();
@@ -600,7 +599,7 @@ class ManagedIdentityTests {
                     .build();
 
             // IMDS has different retry logic for certain status codes, such as 410
-            when(httpClientMock.send(expectedRequest(IMDS, ManagedIdentityTestConstants.RESOURCE))).thenReturn(expectedResponse(HttpStatus.GONE.getCode(), ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500));
+            when(httpClientMock.send(expectedRequest(IMDS, ManagedIdentityTestConstants.RESOURCE))).thenReturn(expectedResponse(HttpStatus.HTTP_GONE, ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500));
 
             try {
                 acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE).get();
@@ -612,7 +611,7 @@ class ManagedIdentityTests {
             }
 
             clearInvocations(httpClientMock);
-            when(httpClientMock.send(expectedRequest(IMDS, ManagedIdentityTestConstants.RESOURCE))).thenReturn(expectedResponse(HttpStatus.INTERNAL_SERVER_ERROR.getCode(), ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500));
+            when(httpClientMock.send(expectedRequest(IMDS, ManagedIdentityTestConstants.RESOURCE))).thenReturn(expectedResponse(HttpStatus.HTTP_INTERNAL_ERROR, ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500));
 
             try {
                 acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE).get();
@@ -642,8 +641,8 @@ class ManagedIdentityTests {
 
             // First call returns 500, subsequent calls return 200
             when(httpClientMock.send(expectedRequest(IMDS, ManagedIdentityTestConstants.RESOURCE)))
-                    .thenReturn(expectedResponse(HttpStatus.INTERNAL_SERVER_ERROR.getCode(), ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500))
-                    .thenReturn(expectedResponse(HttpStatus.OK.getCode(), getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_INTERNAL_ERROR, ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500))
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_OK, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
 
             IAuthenticationResult result = acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE).get();
 
@@ -697,8 +696,8 @@ class ManagedIdentityTests {
 
             // First call returns 500, subsequent calls return 200
             when(httpClientMock.send(expectedRequest(IMDS, ManagedIdentityTestConstants.RESOURCE)))
-                    .thenReturn(expectedResponse(HttpStatus.INTERNAL_SERVER_ERROR.getCode(), ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500))
-                    .thenReturn(expectedResponse(HttpStatus.OK.getCode(), getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_INTERNAL_ERROR, ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500))
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_OK, getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
 
             IAuthenticationResult result = acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE).get();
 
@@ -710,7 +709,7 @@ class ManagedIdentityTests {
 
             //All calls return 500
             when(httpClientMock.send(expectedRequest(IMDS, "otherResource")))
-                    .thenReturn(expectedResponse(HttpStatus.INTERNAL_SERVER_ERROR.getCode(), ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500));
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_INTERNAL_ERROR, ManagedIdentityTestConstants.MSI_ERROR_RESPONSE_500));
 
             CompletableFuture<IAuthenticationResult> future = acquireTokenCommon("otherResource");
 
@@ -740,7 +739,7 @@ class ManagedIdentityTests {
         void managedIdentity_RequestFailed_NullResponse(ManagedIdentitySourceType source, String endpoint) throws Exception {
             setUpCommonTest(source, endpoint, ManagedIdentityId.systemAssigned());
 
-            when(httpClientMock.send(expectedRequest(source, ManagedIdentityTestConstants.RESOURCE))).thenReturn(expectedResponse(200, ""));
+            when(httpClientMock.send(expectedRequest(source, ManagedIdentityTestConstants.RESOURCE))).thenReturn(expectedResponse(HttpStatus.HTTP_OK, ""));
 
             assertMsalServiceException(acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE), source, MsalError.MANAGED_IDENTITY_REQUEST_FAILED);
 
@@ -851,7 +850,7 @@ class ManagedIdentityTests {
             setUpCommonTest(AZURE_ARC, ManagedIdentityTestConstants.AZURE_ARC_ENDPOINT, ManagedIdentityId.systemAssigned());
 
             HttpResponse response = new HttpResponse();
-            response.statusCode(SC_UNAUTHORIZED);
+            response.statusCode(HttpStatus.HTTP_UNAUTHORIZED);
             response.headers().putAll(responseHeaders);
 
             when(httpClientMock.send(

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/OnBehalfOfTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/OnBehalfOfTests.java
@@ -24,7 +24,7 @@ class OnBehalfOfTests {
     void OnBehalfOf_InternalCacheLookup_Success() throws Exception {
         DefaultHttpClient httpClientMock = mock(DefaultHttpClient.class);
 
-        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(200, TestHelper.getSuccessfulTokenResponse(new HashMap<>())));
+        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(HttpStatus.HTTP_OK, TestHelper.getSuccessfulTokenResponse(new HashMap<>())));
 
         ConfidentialClientApplication cca =
                 ConfidentialClientApplication.builder("clientId", ClientCredentialFactory.createFromSecret("password"))
@@ -59,7 +59,7 @@ class OnBehalfOfTests {
         HashMap<String, String> tokenResponseValues = new HashMap<>();
         tokenResponseValues.put("access_token", "accessTokenFirstCall");
 
-        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(200, TestHelper.getSuccessfulTokenResponse(tokenResponseValues)));
+        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(HttpStatus.HTTP_OK, TestHelper.getSuccessfulTokenResponse(tokenResponseValues)));
         OnBehalfOfParameters parameters = OnBehalfOfParameters.builder(Collections.singleton("scopes"), new UserAssertion(TestHelper.signedAssertion)).build();
 
         //The two acquireToken calls have the same parameters...
@@ -72,7 +72,7 @@ class OnBehalfOfTests {
 
         tokenResponseValues.put("access_token", "accessTokenSecondCall");
 
-        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(200, TestHelper.getSuccessfulTokenResponse(tokenResponseValues)));
+        when(httpClientMock.send(any(HttpRequest.class))).thenReturn(TestHelper.expectedResponse(HttpStatus.HTTP_OK, TestHelper.getSuccessfulTokenResponse(tokenResponseValues)));
         parameters = OnBehalfOfParameters.builder(Collections.singleton("scopes"), new UserAssertion(TestHelper.signedAssertion)).tenant("otherTenant").build();
 
         //Overriding the tenant parameter in the request should lead to a new token call being made...

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/RequestThrottlingTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/RequestThrottlingTest.java
@@ -103,20 +103,20 @@ class RequestThrottlingTest {
                 headers.put("Retry-After", Arrays.asList(THROTTLE_IN_SEC.toString()));
                 break;
             case STATUS_CODE_429:
-                httpResponse.statusCode(429);
+                httpResponse.statusCode(HttpStatus.HTTP_TOO_MANY_REQUESTS);
                 httpResponse.body(TestConfiguration.TOKEN_ENDPOINT_INVALID_GRANT_ERROR_RESPONSE);
                 break;
             case STATUS_CODE_429_RETRY_AFTER_HEADER:
-                httpResponse.statusCode(429);
+                httpResponse.statusCode(HttpStatus.HTTP_TOO_MANY_REQUESTS);
                 httpResponse.body(TestConfiguration.TOKEN_ENDPOINT_INVALID_GRANT_ERROR_RESPONSE);
                 headers.put("Retry-After", Arrays.asList(THROTTLE_IN_SEC.toString()));
                 break;
             case STATUS_CODE_500:
-                httpResponse.statusCode(500);
+                httpResponse.statusCode(HttpStatus.HTTP_INTERNAL_ERROR);
                 httpResponse.body(TestConfiguration.TOKEN_ENDPOINT_INVALID_GRANT_ERROR_RESPONSE);
                 break;
             case STATUS_CODE_500_RETRY_AFTER_HEADER:
-                httpResponse.statusCode(500);
+                httpResponse.statusCode(HttpStatus.HTTP_INTERNAL_ERROR);
                 httpResponse.body(TestConfiguration.TOKEN_ENDPOINT_INVALID_GRANT_ERROR_RESPONSE);
                 headers.put("Retry-After", Arrays.asList(THROTTLE_IN_SEC.toString()));
                 break;

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TelemetryTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TelemetryTests.java
@@ -68,7 +68,7 @@ class TelemetryTests {
 
         HttpEvent httpEvent1 = createHttpEvent();
         telemetryManager.startEvent(reqId, httpEvent1);
-        httpEvent1.setHttpResponseStatus(200);
+        httpEvent1.setHttpResponseStatus(HttpStatus.HTTP_OK);
         telemetryManager.stopEvent(reqId, httpEvent1);
 
         telemetryManager.flush(reqId, clientId);
@@ -93,7 +93,7 @@ class TelemetryTests {
 
         HttpEvent httpEvent1 = createHttpEvent();
         telemetryManager.startEvent(reqId, httpEvent1);
-        httpEvent1.setHttpResponseStatus(200);
+        httpEvent1.setHttpResponseStatus(HttpStatus.HTTP_OK);
         telemetryManager.stopEvent(reqId, httpEvent1);
 
         telemetryManager.flush(reqId, clientId);

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
@@ -238,9 +238,9 @@ class TokenRequestExecutorTest {
         doReturn(httpResponse).when(msalOAuthHttpRequest).send();
         doReturn(JSONObjectUtils.parse(TestConfiguration.TOKEN_ENDPOINT_OK_RESPONSE)).when(httpResponse).getContentAsJSONObject();
 
-        httpResponse.ensureStatusCode(200);
+        httpResponse.ensureStatusCode(HttpStatus.HTTP_OK);
 
-        doReturn(200).when(httpResponse).getStatusCode();
+        doReturn(HttpStatus.HTTP_OK).when(httpResponse).getStatusCode();
 
         final AuthenticationResult result = request.executeTokenRequest();
 
@@ -326,7 +326,7 @@ class TokenRequestExecutorTest {
         HashMap<String, String> responseParameters = new HashMap<>();
         responseParameters.put("id_token", encodedIDToken);
         responseParameters.put("access_token", "token");
-        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), 200);
+        TestHelper.createTokenRequestMock(httpClientMock, TestHelper.getSuccessfulTokenResponse(responseParameters), HttpStatus.HTTP_OK);
 
         OnBehalfOfParameters parameters = OnBehalfOfParameters.builder(Collections.singleton("someScopes"), new UserAssertion(TestHelper.signedAssertion)).build();
         IAuthenticationResult result = cca.acquireToken(parameters).get();

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/UIRequiredCacheTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/UIRequiredCacheTest.java
@@ -76,7 +76,7 @@ class UIRequiredCacheTest {
             throws Exception {
         IHttpClient httpClientMock = mock(IHttpClient.class);
 
-        HttpResponse httpResponse = getHttpResponse(400,
+        HttpResponse httpResponse = getHttpResponse(HttpStatus.HTTP_BAD_REQUEST,
                 TestConfiguration.TOKEN_ENDPOINT_INVALID_GRANT_ERROR_RESPONSE);
 
         doReturn(httpResponse).when(httpClientMock).send(any());


### PR DESCRIPTION
The changes in https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/960 made it clear that the library is inconsistent when it comes to HTTP status codes: not all codes had a constant, and even when there was a constant it often wasn't used.

This PR adjusts the `HttpStatus` enum introduced in https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/960 to be a simpler class of constants and helper methods, and refactors every status code reference to use these constants.

This is a separate PR in order to be much easier to review, each individual change is minor and they should not affect any existing behavior.

The status code constants follow the style in HttpURLConnection, a standard Java package that also has these sorts of constants: https://docs.oracle.com/javase/8/docs/api/java/net/HttpURLConnection.html

However, I didn't want to rely on that since we only need a small subset and none of the other code, plus this allows us to add custom helper methods (like the isServerError() that checks for 5xx errors)