### PR TITLE
Suppress CodeQL issues

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
@@ -110,7 +110,7 @@ final class ClientCertificate implements IClientCertificate {
     }
 
     private static byte[] getHashSha1(final byte[] inputBytes) throws NoSuchAlgorithmException {
-        final MessageDigest md = MessageDigest.getInstance("SHA-1");
+        final MessageDigest md = MessageDigest.getInstance("SHA-1"); // CodeQL [SM05136] ADFS scenarios require SHA-1 hashing, and we cannot remove our use until ADFS does.
         md.update(inputBytes);
         return md.digest();
     }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClientManagedIdentity.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClientManagedIdentity.java
@@ -87,7 +87,7 @@ class DefaultHttpClientManagedIdentity extends DefaultHttpClient {
 
         // CodeQL [SM03767] False positive: the TrustManager created later on will only trust a certificate with a specific thumbprint.
         if (httpsUrlConnection.getHostnameVerifier() != ALL_HOSTS_ACCEPT_HOSTNAME_VERIFIER) {
-            httpsUrlConnection.setHostnameVerifier(ALL_HOSTS_ACCEPT_HOSTNAME_VERIFIER);
+            httpsUrlConnection.setHostnameVerifier(ALL_HOSTS_ACCEPT_HOSTNAME_VERIFIER); // CodeQL [SM03767] We expect the connection to work against a specific server side certificate only, so it's safe to disable the host name verification.
         }
 
         // Create a Trust manager that trusts only certificate with specified thumbprint.


### PR DESCRIPTION
Recent CodeQL scans found two issues:
- [SM05136](https://codeql.microsoft.com/issues/4f4e2f94-997e-4d8d-a80b-a5ab2f8dd40b?copilot_promptid=E91B0CE9-0C1B-4AC2-8A46-33F49B67E058): Use of a weak, unapproved or risky cryptographic algorithm, hash or signature
  - This is due to the use of SHA-1 hashing in ADFS scenarios
  - All other scenarios have moved to SHA-256, however ADFS still requires SHA-1 and therefore we must keep this code in place until ADFS is updated.
- [SM03767](https://codeql.microsoft.com/issues/fcf30493-2e17-4401-9399-afefed39efa7?copilot_promptid=E91B0CE9-0C1B-4AC2-8A46-33F49B67E058): Unsafe hostname verification
  - This is due to disabling hostname verification of a specific certificate in Service Fabric scenarios
  - We expect the connection to work against a specific certificate in a Service Fabric environment only, so it's safe to disable the hostname verification for this scenario