### PR TITLE
Suppressed SHA-1 CodeQL flag

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClientManagedIdentity.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClientManagedIdentity.java
@@ -136,7 +136,7 @@ class DefaultHttpClientManagedIdentity extends DefaultHttpClient {
     private static String extractCertificateThumbprint(Certificate certificate) {
         try {
             StringBuilder thumbprint = new StringBuilder();
-            MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
+            MessageDigest messageDigest = MessageDigest.getInstance("SHA-1"); // CodeQL [SM05136] We cannot control what the server uses, and must continue to use SHA-1
 
             byte[] encodedCertificate;
 


### PR DESCRIPTION
Some CodeQL flags which we cannot resolve were suppressed in https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/966

After suppressing those issues, the use of SHA-1 was flagged in a different location: https://codeql.microsoft.com/issues/d9cf0111-6156-41b9-ac71-e9070a354699?copilot_promptid=E91B0CE9-0C1B-4AC2-8A46-33F49B67E058

Much like in the first group of suppressions it must be suppressed for now, I believe this is still required and it can't be tested without a Service Fabric test environment.