### PR TITLE
Add/improve javadocs for interface classes

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IAcquireTokenParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IAcquireTokenParameters.java
@@ -7,16 +7,61 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Parameters shared by all acquireToken methods
+ * Interface representing common parameters shared across all token acquisition methods in MSAL.
+ * <p>
+ * This interface defines the core parameters that are common to all token acquisition operations,
+ * regardless of the specific authentication flow being used (interactive, silent, username/password, etc.).
+ * Various parameter classes in the library implement this interface to provide a consistent way to
+ * configure token requests.
  */
 interface IAcquireTokenParameters {
+
+    /**
+     * Gets the set of scopes (permissions) requested for the access token.
+     * <p>
+     * Scopes represent the permissions that the application is requesting access to.
+     *
+     * @return A set of scope strings being requested for the access token.
+     */
     Set<String> scopes();
 
+    /**
+     * Gets the claims request parameter that will be sent with the authentication request.
+     * <p>
+     * The claims request parameter can be used to request specific claims to be returned in the token,
+     * to request MFA authentication, or to control other aspects of token issuance.
+     *
+     * @return A {@link ClaimsRequest} object containing the requested claims, or null if no claims are specified.
+     */
     ClaimsRequest claims();
 
+    /**
+     * Gets additional HTTP headers to be included in the token request.
+     * <p>
+     * These headers will be added to the HTTP requests sent to the token endpoint.
+     * This can be useful for scenarios requiring custom headers for proxies or for diagnostic purposes.
+     *
+     * @return A map of additional HTTP headers to include with the token request, or null if no extra headers are needed.
+     */
     Map<String, String> extraHttpHeaders();
 
+    /**
+     * Gets the tenant identifier for the token request.
+     * <p>
+     * When specified, this value overrides the tenant specified in the application's authority URL.
+     * It can be a tenant ID (GUID), domain name, or one of the special values like "common" or "organizations".
+     *
+     * @return The tenant identifier to use for the token request, or null to use the tenant from the authority URL.
+     */
     String tenant();
 
+    /**
+     * Gets additional query parameters to be included in the token request.
+     * <p>
+     * These parameters will be added to the query string in requests to the authorization and token endpoints.
+     * This can be useful for scenarios requiring custom parameters that aren't explicitly supported in the library.
+     *
+     * @return A map of additional query parameters to include with the token request, or null if no extra parameters are needed.
+     */
     Map<String, String> extraQueryParameters();
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IApplicationBase.java
@@ -9,38 +9,48 @@ import java.net.Proxy;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Interface representing an application for which tokens can be acquired.
+ * Base interface representing a client application that can acquire tokens from the Microsoft identity platform.
+ * Defines common functionality across different application types (public client, confidential client,
+ * and managed identity applications).
  */
 interface IApplicationBase {
 
     String DEFAULT_AUTHORITY = "https://login.microsoftonline.com/common/";
 
     /**
-     * @return a boolean value which determines whether Pii (personally identifiable information) will be logged in
+     * Gets whether personally identifiable information (PII) is included in log messages.
+     *
+     * @return A boolean value which determines whether PII (personally identifiable information) will be included in log messages.
+     * When true, PII will be logged; when false, PII will be masked or omitted from logs.
      */
     boolean logPii();
 
     /**
-     * @return Correlation ID which is used for diagnostics purposes, is attached to token service requests
-     * Default value is random UUID
+     * Gets the correlation ID used for tracing requests through the authentication system.
+     *
+     * @return Correlation ID which is used for diagnostics purposes and is attached to token service requests.
+     * The default value is a random UUID.
      */
     String correlationId();
 
     /**
-     * Sets HTTP client to be used by the client application for all HTTP requests. Allows for fine-grained
-     * configuration of HTTP client.
-
-     * @return instance of IHttpClient used by the application
+     * Gets the HTTP client used by the application for all HTTP requests.
+     *
+     * @return Instance of IHttpClient used by the application for network communication with the Microsoft identity platform.
      */
     IHttpClient httpClient();
 
     /**
-     * @return proxy used by the application for all network communication.
+     * Gets the proxy configuration used by the application for network communication.
+     *
+     * @return Proxy used by the application for all network communication. Returns null if no proxy is configured.
      */
     Proxy proxy();
 
     /**
-     * @return SSLSocketFactory used by the application for all network communication.
+     * Gets the SSL socket factory used by the application for secure network communication.
+     *
+     * @return SSLSocketFactory used by the application for all secure network communication. Returns null if no custom SSL socket factory is configured.
      */
     SSLSocketFactory sslSocketFactory();
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IBroker.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IBroker.java
@@ -9,44 +9,84 @@ import java.net.URL;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Used to define the basic set of methods that all Brokers must implement
+ * Interface defining the core functionality required for authentication brokers.
+ * <p>
+ * Authentication brokers provide a centralized way to handle authentication across multiple applications
+ * on a device or platform. They can offer benefits such as single sign-on (SSO) between applications,
+ * consistent authentication experiences, and leveraging platform security features.
  * <p>
  * All methods are marked as default so they can be referenced by MSAL Java without an implementation,
- * and most will simply throw an exception if not overridden by an IBroker implementation
+ * and most will simply throw an exception if not overridden by an IBroker implementation.
  */
 public interface IBroker {
 
     /**
-     * Acquire a token silently, i.e. without direct user interaction
+     * Acquires a token silently without user interaction.
      * <p>
      * This may be accomplished by returning tokens from a token cache, using cached refresh tokens to get new tokens,
-     * or via any authentication flow where a user is not prompted to enter credentials
+     * or via any authentication flow where a user is not prompted to enter credentials.
+     *
+     * @param application The public client application requesting the token
+     * @param requestParameters Parameters for the silent token request
+     * @return A CompletableFuture containing the authentication result with tokens and account information
+     * @throws MsalClientException If no broker implementation is available
      */
     default CompletableFuture<IAuthenticationResult> acquireToken(PublicClientApplication application, SilentParameters requestParameters) {
         throw new MsalClientException("Broker implementation missing", AuthenticationErrorCode.MISSING_BROKER);
     }
 
     /**
-     * Acquire a token interactively, by prompting users to enter their credentials in some way
+     * Acquires a token interactively by prompting the user to enter credentials.
+     * <p>
+     * This method presents a user interface requesting credentials from the user and handles the
+     * interactive authentication flow.
+     *
+     * @param application The public client application requesting the token
+     * @param parameters Parameters for the interactive token request
+     * @return A CompletableFuture containing the authentication result with tokens and account information
+     * @throws MsalClientException If no broker implementation is available
      */
     default CompletableFuture<IAuthenticationResult> acquireToken(PublicClientApplication application, InteractiveRequestParameters parameters) {
         throw new MsalClientException("Broker implementation missing", AuthenticationErrorCode.MISSING_BROKER);
     }
 
     /**
-     * Acquire a token silently, i.e. without direct user interaction, using username/password authentication
+     * Acquires a token silently using username and password authentication.
+     * <p>
+     * This method enables resource owner password credentials (ROPC) flow through a broker.
+     * Note that this flow is not recommended for production applications as it requires handling
+     * user credentials directly.
+     *
+     * @param application The public client application requesting the token
+     * @param parameters Parameters containing username, password and other request details
+     * @return A CompletableFuture containing the authentication result with tokens and account information
+     * @throws MsalClientException If no broker implementation is available
      */
     default CompletableFuture<IAuthenticationResult> acquireToken(PublicClientApplication application, UserNamePasswordParameters parameters) {
         throw new MsalClientException("Broker implementation missing", AuthenticationErrorCode.MISSING_BROKER);
     }
 
+    /**
+     * Removes an account from the broker's token cache.
+     * <p>
+     * This method allows applications to sign out users and remove their tokens from the broker cache.
+     *
+     * @param application The public client application requesting the account removal
+     * @param account The account to be removed from the token cache
+     * @throws MsalClientException If no broker implementation is available
+     */
     default void removeAccount(PublicClientApplication application, IAccount account) throws MsalClientException {
         throw new MsalClientException("Broker implementation missing", AuthenticationErrorCode.MISSING_BROKER);
     }
 
     /**
-     * Returns whether a broker is available and ready to use on this machine, allowing the use of the methods
-     * in this interface and other broker-only features in MSAL Java
+     * Checks whether a broker is available and ready to use on this machine.
+     * <p>
+     * Applications should call this method before attempting to use broker-specific features
+     * to determine if a broker is installed and accessible.
+     *
+     * @return true if a broker is available for authentication, false otherwise
+     * @throws MsalClientException If no broker implementation is available
      */
     default boolean isBrokerAvailable() {
         throw new MsalClientException("Broker implementation missing", AuthenticationErrorCode.MISSING_BROKER);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IClientApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IClientApplicationBase.java
@@ -11,31 +11,39 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Interface representing an application for which tokens can be acquired.
+ * Interface representing a client application that can acquire tokens from the Microsoft identity platform.
+ * This interface serves as the base for both public client applications (desktop/mobile apps) and
+ * confidential client applications (web apps/APIs), defining common functionality for token acquisition.
+ * <p>
+ * Client applications are registered in the Microsoft identity platform and have their own identity,
+ * represented by an application ID (client ID).
  */
 interface IClientApplicationBase extends IApplicationBase {
 
     /**
+     * Gets the client ID (application ID) for this application.
+     *
      * @return Client ID (Application ID) of the application as registered in the application registration portal
      * (portal.azure.com) and as passed in the constructor of the application
      */
     String clientId();
 
     /**
+     * Gets the authority URL for this application.
+     *
      * @return URL of the authority, or security token service (STS) from which MSAL will acquire security tokens.
      * Default value is {@link IClientApplicationBase#DEFAULT_AUTHORITY}
      */
     String authority();
 
     /**
-     * @return a boolean value which determines whether the authority needs to be verified against a list of known authorities.
+     * Gets whether the authority URL should be validated against a list of known authorities.
+     *
+     * @return A boolean value which determines whether the authority needs to be verified against a list of known authorities.
+     * When true, MSAL will validate the authority against a list of well-known authorities. Set to false only for
+     * development/testing with custom authority URLs.
      */
     boolean validateAuthority();
-
-//    /**
-//     * @return Telemetry consumer that will receive telemetry events emitted by the library.
-//     */
-//     java.util.function.Consumer<java.util.List<java.util.HashMap<String, String>>> telemetryConsumer();
 
     /**
      * Computes the URL of the authorization request letting the user sign-in and consent to the
@@ -43,19 +51,25 @@ interface IClientApplicationBase extends IApplicationBase {
      * application object.
      * <p>
      * Once the user successfully authenticates, the response should contain an authorization code,
-     * which can then be passed in to{@link AbstractClientApplicationBase#acquireToken(AuthorizationCodeParameters)}
-     * to be exchanged for a token
+     * which can then be passed in to {@link AbstractClientApplicationBase#acquireToken(AuthorizationCodeParameters)}
+     * to be exchanged for a token.
      *
-     * @param parameters {@link AuthorizationRequestUrlParameters}
-     * @return url of the authorization endpoint where the user can sign-in and consent to the application.
+     * @param parameters {@link AuthorizationRequestUrlParameters} containing the details needed to create the authorization URL,
+     *                   such as scopes, response type, and redirect URI
+     * @return URL of the authorization endpoint where the user can sign-in and consent to the application
      */
     URL getAuthorizationRequestUrl(AuthorizationRequestUrlParameters parameters);
 
     /**
      * Acquires security token from the authority using an authorization code previously received.
+     * <p>
+     * This is typically used as the second step in an authorization code flow, after the user has
+     * authenticated and provided consent at the authorization endpoint, resulting in an authorization code.
      *
-     * @param parameters {@link AuthorizationCodeParameters}
-     * @return A {@link CompletableFuture} object representing the {@link IAuthenticationResult} of the call.
+     * @param parameters {@link AuthorizationCodeParameters} containing the authorization code and other information
+     *                   required to exchange the code for tokens
+     * @return A {@link CompletableFuture} object representing the {@link IAuthenticationResult} of the call,
+     *         which contains the requested tokens and account information
      */
     CompletableFuture<IAuthenticationResult> acquireToken(AuthorizationCodeParameters parameters);
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IClientAssertion.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IClientAssertion.java
@@ -7,11 +7,17 @@ package com.microsoft.aad.msal4j;
  * Credential type containing an assertion of type
  * "urn:ietf:params:oauth:token-type:jwt".
  * <p>
+ * Client assertions provide a way for confidential client applications to authenticate themselves
+ * to the Microsoft identity platform without sending a client secret. Instead, the application
+ * uses a JWT token as a credential.
+ * <p>
  * For more details, see https://aka.ms/msal4j-client-credentials
  */
 public interface IClientAssertion extends IClientCredential {
 
     /**
+     * Gets the JWT token used for client authentication.
+     *
      * @return Jwt token encoded as a base64 URL encoded string
      */
     String assertion();

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IClientCredential.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IClientCredential.java
@@ -4,7 +4,19 @@
 package com.microsoft.aad.msal4j;
 
 /**
- * Interface representing an application credential
+ * Interface representing an application credential used for client authentication.
+ * <p>
+ * Client credentials are used by confidential client applications to authenticate themselves
+ * to the Microsoft identity platform when requesting tokens. This is used in scenarios where the
+ * application is acting on its own behalf (client credentials flow) or on behalf of a user
+ * (authorization code flow with client authentication).
+ * <p>
+ * MSAL supports several types of client credentials:
+ * <ul>
+ *   <li>Client secrets - A string secret configured for the application in the Azure portal</li>
+ *   <li>Client certificates - An X.509 certificate that can be used to authenticate the application</li>
+ *   <li>Client assertions - A JWT token signed with a private key that proves the client's identity</li>
+ * </ul>
  * <p>
  * For more details, see https://aka.ms/msal4j-client-credentials
  */

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IEnvironmentVariables.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IEnvironmentVariables.java
@@ -3,8 +3,24 @@
 
 package com.microsoft.aad.msal4j;
 
+/**
+ * Interface for accessing environment variables within the library.
+ * <p>
+ * This interface abstracts the mechanism for retrieving environment variables,
+ * which allows for better testability and flexibility in different hosting environments.
+ * It's primarily used within the library for accessing configuration settings and
+ * credentials that may be stored in environment variables.
+ */
 interface IEnvironmentVariables {
 
-
+    /**
+     * Retrieves the value of the specified environment variable.
+     * <p>
+     * This method provides access to system environment variables that may contain
+     * configuration settings or credentials needed for authentication.
+     *
+     * @param envVariable The name of the environment variable to retrieve.
+     * @return The string value of the environment variable, or null if the variable is not defined.
+     */
     String getEnvironmentVariable(String envVariable);
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IHttpClient.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IHttpClient.java
@@ -4,21 +4,35 @@
 package com.microsoft.aad.msal4j;
 
 /**
- * Interface to be implemented when configuring http client for {@link IPublicClientApplication} or
+ * Interface to be implemented when configuring a custom HTTP client for {@link IPublicClientApplication} or
  * {@link IConfidentialClientApplication}.
+ * <p>
+ * MSAL Java uses HTTP to communicate with the Microsoft identity platform for authentication and token acquisition.
+ * By default, MSAL uses the JDK's HttpURLConnection, but this interface allows applications to provide
+ * their own HTTP client implementation. This is useful when:
+ * <ul>
+ *   <li>Applications need to customize network behavior (e.g., configure proxies, add custom headers)</li>
+ *   <li>Applications want to use a specific HTTP client library like Apache HttpClient or OkHttp</li>
+ *   <li>Applications need to integrate with existing network infrastructure or logging systems</li>
+ * </ul>
  * <p>
  * For more details, see https://aka.ms/msal4j-http-client
  */
 public interface IHttpClient {
 
     /**
-     * Should implement execution of outgoing HTTP request with HTTP client of choice. Adapts
-     * response returned from HTTP client to {@link IHttpResponse}
+     * Executes an outgoing HTTP request using the HTTP client implementation of choice.
+     * <p>
+     * This method should handle all the details of making the HTTP request and adapting
+     * the response to the {@link IHttpResponse} interface. The implementation should also
+     * include appropriate error handling for network-related issues.
      *
-     * @param httpRequest {@link HttpRequest}
-     * @return {@link IHttpResponse}.
-     * @throws Exception Non-recoverable exception. Recoverable exceptions should be handled by the
-     *                   IHttpClient implementation
+     * @param httpRequest The {@link HttpRequest} containing details of the request to execute,
+     *                    including URL, headers, HTTP method, and body.
+     * @return An {@link IHttpResponse} object containing the status code, headers, and body of the response.
+     * @throws Exception Non-recoverable exceptions that cannot be handled by the HTTP client implementation.
+     *                   Note that recoverable errors (e.g., retryable HTTP status codes, transient
+     *                   network issues) should be handled by the implementation itself.
      */
     IHttpResponse send(HttpRequest httpRequest) throws Exception;
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IHttpHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IHttpHelper.java
@@ -3,8 +3,25 @@
 
 package com.microsoft.aad.msal4j;
 
+/**
+ * Interface representing the HTTP helper component that handles network communications.
+ * <p>
+ * This interface abstracts the HTTP communication layer used for sending requests.
+ * It's used internally by the library to execute HTTP requests during various operations.
+ */
 interface IHttpHelper {
 
+    /**
+     * Executes an HTTP request.
+     * <p>
+     * This method handles all aspects of sending the HTTP request and processing the response,
+     * such as applying retry policies and handling errors.
+     *
+     * @param httpRequest The HTTP request to be executed
+     * @param requestContext Context information about the current request, including correlation IDs for telemetry
+     * @param serviceBundle Bundle of services that may be needed during request execution, such as retry policies
+     * @return An {@link IHttpResponse} object containing the response
+     */
     IHttpResponse executeHttpRequest(HttpRequest httpRequest,
                                      RequestContext requestContext,
                                      ServiceBundle serviceBundle);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IHttpResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IHttpResponse.java
@@ -7,22 +7,36 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * HTTP response from execution of {@link HttpRequest} in {@link IHttpClient}
+ * Represents an HTTP response returned after executing a {@link HttpRequest} through an {@link IHttpClient} implementation.
+ * This interface encapsulates all the data returned by the authentication service or other HTTP endpoints
+ * contacted during the authentication flows.
+ * <p>
+ * Custom implementations of {@link IHttpClient} must convert their native HTTP response objects to this interface.
  */
 public interface IHttpResponse {
 
     /**
-     * @return HTTP response status code.
+     * Gets the HTTP response status code.
+     *
+     * @return HTTP response status code. Common values include 200 (OK), 400 (Bad Request),
+     *         401 (Unauthorized), and 500 (Internal Server Error).
      */
     int statusCode();
 
     /**
-     * @return HTTP response headers
+     * Gets the HTTP response headers.
+     *
+     * @return A map of HTTP header names to their values. If a header appears multiple times,
+     *         its values are collected in a list. Header names are typically case-insensitive
+     *         as per HTTP specification.
      */
     Map<String, List<String>> headers();
 
     /**
-     * @return HTTP response body
+     * Gets the HTTP response body.
+     *
+     * @return The body of the HTTP response as a string. For responses from the Microsoft identity platform,
+     *         this is typically JSON content containing tokens or error information.
      */
     String body();
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IRetryPolicy.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IRetryPolicy.java
@@ -1,25 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package com.microsoft.aad.msal4j;
 
 /**
- * Interface for HTTP request retry policies
+ * Interface for HTTP request retry policies used by the library.
+ * <p>
+ * Retry policies define when and how HTTP requests should be retried in case of failures or timeouts,
+ * helping to increase reliability of network communications.
  */
  interface IRetryPolicy {
     /**
-     * Determines whether a request should be retried based on the HTTP response
+     * Determines whether a request should be retried based on the HTTP response.
+     * <p>
+     * Implementations can examine status codes, headers, or other response attributes
+     * to decide if another attempt should be made.
+     *
      * @param httpResponse The HTTP response to evaluate
      * @return true if retry should be attempted, false otherwise
      */
     boolean isRetryable(IHttpResponse httpResponse);
 
     /**
-     * Gets the number of retries to attempt based on the HTTP response
-     * @return maximum retry count
+     * Gets the maximum number of retries to attempt based on the HTTP response.
+     * <p>
+     * The implementation can return different retry counts for different types of failures.
+     *
+     * @param httpResponse The HTTP response to evaluate
+     * @return maximum retry count for this specific response
      */
     int getMaxRetryCount(IHttpResponse httpResponse);
 
     /**
-     * Gets the delay in milliseconds between retry attempts
-     * @return delay in milliseconds
+     * Gets the delay in milliseconds to wait before the next retry attempt.
+     * <p>
+     * Implementations may use different backoff strategies such as fixed, exponential,
+     * or jittered delays based on the response type or retry count.
+     *
+     * @param httpResponse The HTTP response to evaluate
+     * @return delay in milliseconds before attempting the next retry
      */
     int getRetryDelayMs(IHttpResponse httpResponse);
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ITenantProfile.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ITenantProfile.java
@@ -20,7 +20,13 @@ public interface ITenantProfile extends Serializable {
     Map<String, ?> getClaims();
 
     /**
-     * @return tenant environment
+     * Gets the environment where this tenant is hosted.
+     * <p>
+     * The environment value typically represents the hostname of the authentication service,
+     * such as "login.microsoftonline.com" for the public cloud or other domain names for
+     * sovereign clouds.
+     *
+     * @return The environment for this tenant profile
      */
     String environment();
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ITokenCacheAccessAspect.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ITokenCacheAccessAspect.java
@@ -6,11 +6,37 @@ package com.microsoft.aad.msal4j;
 /**
  * Interface representing operation of executing code before and after cache access.
  * <p>
+ * This interface enables applications to hook into the token cache access operations,
+ * allowing for serialization and persistence of the token cache. Implementing this interface
+ * allows applications to load the cache state from persistent storage before MSAL accesses it,
+ * and save changes back to persistent storage after MSAL modifies it.
+ * <p>
  * For more details, see https://aka.ms/msal4j-token-cache
  */
 public interface ITokenCacheAccessAspect {
 
+    /**
+     * Executes before the token cache is accessed by MSAL.
+     * <p>
+     * This method is called by MSAL immediately before it accesses the token cache.
+     * Applications should use this method to load the current cache state from persistent
+     * storage and update the in-memory cache by calling {@link ITokenCacheAccessContext#tokenCache()}.
+     * This ensures MSAL has access to all previously cached tokens.
+     *
+     * @param iTokenCacheAccessContext Context object providing access to the token cache and related information.
+     */
     void beforeCacheAccess(ITokenCacheAccessContext iTokenCacheAccessContext);
 
+    /**
+     * Executes after the token cache is accessed by MSAL.
+     * <p>
+     * This method is called by MSAL immediately after it accesses (and potentially modifies)
+     * the token cache. Applications should use this method to persist the current state of the
+     * cache to storage if changes were made. The {@link ITokenCacheAccessContext#hasCacheChanged()}
+     * method can be used to determine if the cache was modified during the operation.
+     *
+     * @param iTokenCacheAccessContext Context object providing access to the token cache and related information,
+     *                                 including whether the cache was modified.
+     */
     void afterCacheAccess(ITokenCacheAccessContext iTokenCacheAccessContext);
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ITokenCacheAccessContext.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ITokenCacheAccessContext.java
@@ -4,29 +4,60 @@
 package com.microsoft.aad.msal4j;
 
 /**
- * Interface representing context in which the token cache is accessed
+ * Interface representing the context in which the token cache is accessed.
+ * <p>
+ * When MSAL accesses the token cache (before or after), it provides an instance of this interface
+ * to the application through {@link ITokenCacheAccessAspect} methods. This allows the application
+ * to get information about the cache access operation being performed, such as which client and account
+ * are involved, and whether the operation modified the cache.
+ * <p>
+ * This context is particularly useful for applications implementing token cache serialization and
+ * persistence strategies, as it helps determine when the cache should be loaded from or saved to
+ * persistent storage.
  * <p>
  * For more details, see https://aka.ms/msal4j-token-cache
  */
 public interface ITokenCacheAccessContext {
 
     /**
-     * @return instance of accessed ITokenCache
+     * Gets the token cache instance being accessed.
+     * <p>
+     * This can be used to read or modify the cache entries during a cache access operation.
+     *
+     * @return The {@link ITokenCache} instance that is being accessed.
      */
     ITokenCache tokenCache();
 
     /**
-     * @return client id used for cache access
+     * Gets the client ID associated with the current cache access operation.
+     * <p>
+     * This identifies which client application (registered in Azure AD) is performing
+     * the cache access. In multi-tenant or multi-client scenarios, applications may want
+     * to partition their token cache by client ID.
+     *
+     * @return The client ID (application ID) as registered in the Azure portal.
      */
     String clientId();
 
     /**
-     * @return instance of IAccount used for cache access
+     * Gets the account associated with the current cache access operation, if any.
+     * <p>
+     * This may be null for operations that are not specific to a user account, such as
+     * client credential flow token requests.
+     *
+     * @return The {@link IAccount} instance related to this cache access, or null if
+     *         the operation is not account-specific.
      */
     IAccount account();
 
     /**
-     * @return a boolean value telling whether cache was changed
+     * Indicates whether the cache was modified during this operation.
+     * <p>
+     * This is particularly useful in the {@link ITokenCacheAccessAspect#afterCacheAccess} method
+     * to determine whether the cache should be persisted. If no changes were made to the cache,
+     * applications can avoid unnecessary write operations.
+     *
+     * @return true if the cache was modified during this operation, false otherwise.
      */
     boolean hasCacheChanged();
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IUserAssertion.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IUserAssertion.java
@@ -4,19 +4,35 @@
 package com.microsoft.aad.msal4j;
 
 /**
- * Interface representing a delegated user identity used by downstream applications in On-Behalf-Of flow
+ * Interface representing a delegated user identity used by downstream applications in the On-Behalf-Of flow.
+ * <p>
+ * The On-Behalf-Of flow is used when a service receives a token from a client application and needs to
+ * call another service on behalf of the original user. In this scenario, the received token serves as
+ * the user assertion that proves the original user's identity and authentication.
+ * <p>
+ * This interface is typically used with {@link OnBehalfOfParameters} when acquiring tokens in
+ * middle-tier applications that need to call downstream services.
  */
 public interface IUserAssertion {
 
     /**
-     * Gets the assertion.
+     * Gets the assertion token used in the On-Behalf-Of flow.
+     * <p>
+     * The assertion is typically a JWT token received from an upstream client application
+     * that represents the original user's identity and authentication.
      *
-     * @return string value
+     * @return The assertion token as a string value, usually a JWT.
      */
     String getAssertion();
 
     /**
-     * @return Base64 encoded SHA256 hash of the assertion
+     * Gets a hash of the assertion token.
+     * <p>
+     * This hash is used as a key for caching tokens acquired via the On-Behalf-Of flow,
+     * allowing the application to efficiently retrieve tokens for the same user assertion
+     * without making redundant requests to the token service.
+     *
+     * @return Base64 encoded SHA256 hash of the assertion token.
      */
     String getAssertionHash();
 }


### PR DESCRIPTION
Begins the work described in https://github.com/AzureAD/microsoft-authentication-library-for-java/issues/971

This PR fills documentation gaps and improves existing documentation to all interfaces in the library. The changes exclusively affect Javadoc comments, so there are no changes to the actual behavior of any API.

This PR is also a trial run of the new agent feature in IntelliJ's Copilot plugin:
- All of the changes were manually reviewed to ensure MSAL behavior was described accurately
- With few exceptions, the prompts produced accurate descriptions on the first try without being given any context about MSAL's actual behavior
  - For the most part, I simply told it to review all interfaces with missing/poor documentation, list them based on quality, then told it to add/improve a few filenames at a time
- The few mistakes it did make were easily corrected by a follow-up prompt describing what was wrong
  - As an example, it incorrectly implied that "scopes" API was just for Graph resources (likely because many of our tests use Graph), and I just had to tell it to give a more generic description