### PR TITLE
Version updates for 1.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Quick links:
 The library supports the following Java environments:
 - Java 8 (or higher)
 
-Current version - 1.21.0
+Current version - 1.22.0
 
 You can find the changes for each version in the [change log](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/main/msal4j-sdk/changelog.txt).
 
@@ -28,13 +28,13 @@ Find [the latest package in the Maven repository](https://mvnrepository.com/arti
 <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>msal4j</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
 </dependency>
 ```
 ### Gradle
 
 ```gradle
-implementation group: 'com.microsoft.azure', name: 'com.microsoft.aad.msal4j', version: '1.21.0'
+implementation group: 'com.microsoft.azure', name: 'com.microsoft.aad.msal4j', version: '1.22.0'
 ```
 
 ## Usage

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 1.22.0
+=============
+- Validate issuer from OIDC endpoint when using the oidcAuthority() API (#970)
+- Bump oauth2-oidc-sdk dependency to avoid CVE-2025-53864 (#975)
+
 Version 1.21.0
 =============
 - Add support for claims, client capabilities, and token revocation in Service Fabric scenarios (#929, #943)

--- a/msal4j-sdk/README.md
+++ b/msal4j-sdk/README.md
@@ -16,7 +16,7 @@ Quick links:
 The library supports the following Java environments:
 - Java 8 (or higher)
 
-Current version - 1.21.0
+Current version - 1.22.0
 
 You can find the changes for each version in the [change log](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/master/changelog.txt).
 
@@ -28,13 +28,13 @@ Find [the latest package in the Maven repository](https://mvnrepository.com/arti
 <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>msal4j</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
 </dependency>
 ```
 ### Gradle
 
 ```gradle
-compile group: 'com.microsoft.azure', name: 'msal4j', version: '1.21.0'
+compile group: 'com.microsoft.azure', name: 'msal4j', version: '1.22.0'
 ```
 
 ## Usage

--- a/msal4j-sdk/bnd.bnd
+++ b/msal4j-sdk/bnd.bnd
@@ -1,2 +1,2 @@
-Export-Package: com.microsoft.aad.msal4j;version="1.21.0"
+Export-Package: com.microsoft.aad.msal4j;version="1.22.0"
 Automatic-Module-Name: com.microsoft.aad.msal4j

--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>msal4j</artifactId>
-    <version>1.21.0</version>
+    <version>1.22.0</version>
     <packaging>jar</packaging>
     <name>msal4j</name>
     <description>


### PR DESCRIPTION
- Validate issuer from OIDC endpoint when using the oidcAuthority() API (#970)
- Bump oauth2-oidc-sdk dependency to avoid CVE-2025-53864 (#975)