### PR TITLE
Add option to disable federated tests

### DIFF
--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -32,6 +32,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <skip.unit.tests>false</skip.unit.tests>
         <skip.integration.tests>false</skip.integration.tests>
+
+        <!-- Test category control properties. -->
+        <!-- Disable test categories by setting to 'true' in the mvn command (i.e., mvn verify -Dadfs.disabled=true)-->
+        <adfs.disabled>false</adfs.disabled>
     </properties>
 
     <dependencies>
@@ -317,6 +321,9 @@
                 </executions>
                 <configuration>
                     <skipTests>${skip.integration.tests}</skipTests>
+                    <systemPropertyVariables>
+                        <adfs.disabled>${adfs.disabled}</adfs.disabled>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenInteractiveIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenInteractiveIT.java
@@ -7,6 +7,7 @@ import labapi.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,7 @@ class AcquireTokenInteractiveIT extends SeleniumTest {
     }
 
     @Test()
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     void acquireTokenInteractive_ADFSv2019_OnPrem() {
         User user = labUserProvider.getOnPremAdfsUser(FederationProvider.ADFS_2019);
         assertAcquireTokenCommon(user, TestConstants.ADFS_AUTHORITY, TestConstants.ADFS_SCOPE);
@@ -63,6 +65,7 @@ class AcquireTokenInteractiveIT extends SeleniumTest {
 
     @ParameterizedTest
     @MethodSource("com.microsoft.aad.msal4j.EnvironmentsProvider#createData")
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     void acquireTokenInteractive_ADFSv2019_Federated(String environment) {
         cfg = new Config(environment);
 
@@ -72,6 +75,7 @@ class AcquireTokenInteractiveIT extends SeleniumTest {
 
     @ParameterizedTest
     @MethodSource("com.microsoft.aad.msal4j.EnvironmentsProvider#createData")
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     void acquireTokenInteractive_ADFSv4_Federated(String environment) {
         cfg = new Config(environment);
 

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenSilentIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenSilentIT.java
@@ -6,6 +6,7 @@ package com.microsoft.aad.msal4j;
 import labapi.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.api.BeforeAll;
@@ -100,6 +101,7 @@ class AcquireTokenSilentIT {
 
     @ParameterizedTest
     @MethodSource("com.microsoft.aad.msal4j.EnvironmentsProvider#createData")
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     void acquireTokenSilent_MultipleAccountsInCache_UseCorrectAccount(String environment) throws Exception {
         cfg = new Config(environment);
 
@@ -123,6 +125,7 @@ class AcquireTokenSilentIT {
 
     @ParameterizedTest
     @MethodSource("com.microsoft.aad.msal4j.EnvironmentsProvider#createData")
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     void acquireTokenSilent_ADFS2019(String environment) throws Exception {
         cfg = new Config(environment);
 

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
@@ -7,6 +7,7 @@ import labapi.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,7 @@ class AuthorizationCodeIT extends SeleniumTest {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     public void acquireTokenWithAuthorizationCode_ADFSv2019_OnPrem() {
         User user = labUserProvider.getOnPremAdfsUser(FederationProvider.ADFS_2019);
         assertAcquireTokenADFS2019(user);
@@ -63,6 +65,7 @@ class AuthorizationCodeIT extends SeleniumTest {
 
     @ParameterizedTest
     @MethodSource("com.microsoft.aad.msal4j.EnvironmentsProvider#createData")
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     public void acquireTokenWithAuthorizationCode_ADFSv2019_Federated(String environment) {
         cfg = new Config(environment);
 
@@ -72,6 +75,7 @@ class AuthorizationCodeIT extends SeleniumTest {
 
     @ParameterizedTest
     @MethodSource("com.microsoft.aad.msal4j.EnvironmentsProvider#createData")
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     public void acquireTokenWithAuthorizationCode_ADFSv4_Federated(String environment) {
         cfg = new Config(environment);
 

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.api.BeforeAll;
@@ -54,6 +55,7 @@ class DeviceCodeIT {
     }
 
     @Test()
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     void DeviceCodeFlowADFSv2019Test() throws Exception {
 
         User user = labUserProvider.getOnPremAdfsUser(FederationProvider.ADFS_2019);

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/TokenCacheIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/TokenCacheIT.java
@@ -7,6 +7,7 @@ import labapi.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -59,6 +60,7 @@ class TokenCacheIT {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     void twoAccountsInCache_RemoveAccountTest() throws Exception {
 
         User managedUser = labUserProvider.getDefaultUser();
@@ -108,6 +110,7 @@ class TokenCacheIT {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     void twoAccountsInCache_SameUserDifferentTenants_RemoveAccountTest() throws Exception {
 
         UserQueryParameters query = new UserQueryParameters();
@@ -172,6 +175,7 @@ class TokenCacheIT {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     void retrieveAccounts_ADFSOnPrem() throws Exception {
         UserQueryParameters query = new UserQueryParameters();
         query.parameters.put(UserQueryParameters.FEDERATION_PROVIDER, FederationProvider.ADFS_2019);

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/UsernamePasswordIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/UsernamePasswordIT.java
@@ -6,11 +6,11 @@ package com.microsoft.aad.msal4j;
 import labapi.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.api.BeforeAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -39,6 +39,7 @@ class UsernamePasswordIT {
 
     @ParameterizedTest
     @MethodSource("com.microsoft.aad.msal4j.EnvironmentsProvider#createData")
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     void acquireTokenWithUsernamePassword_ADFSv2019_Federated(String environment) throws Exception {
         cfg = new Config(environment);
 
@@ -53,6 +54,7 @@ class UsernamePasswordIT {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     void acquireTokenWithUsernamePassword_ADFSv2019_OnPrem() throws Exception {
         UserQueryParameters query = new UserQueryParameters();
         query.parameters.put(UserQueryParameters.FEDERATION_PROVIDER, FederationProvider.ADFS_2019);
@@ -65,6 +67,7 @@ class UsernamePasswordIT {
 
     @ParameterizedTest
     @MethodSource("com.microsoft.aad.msal4j.EnvironmentsProvider#createData")
+    @DisabledIfSystemProperty(named = "adfs.disabled", matches = "true")
     void acquireTokenWithUsernamePassword_ADFSv4(String environment) throws Exception {
         cfg = new Config(environment);
 


### PR DESCRIPTION
This PR adds the ability to disable federated tests at runtime. If `-Dadfs.disabled=true` is set in the `mvn` command, the tests marked by the new usages of `@DisabledIfSystemProperty` will not run.

This is meant to resolve the current failures caused by issues in our federated testing resources, and is similar to what was done in .NET: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5416 