### PR TITLE
Version and changelog updates for 1.23.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Quick links:
 The library supports the following Java environments:
 - Java 8 (or higher)
 
-Current version - 1.30.0-beta
+Current version - 1.23.0
 
 You can find the changes for each version in the [change log](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/main/msal4j-sdk/changelog.txt).
 
@@ -28,13 +28,13 @@ Find [the latest package in the Maven repository](https://mvnrepository.com/arti
 <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>msal4j</artifactId>
-    <version>1.30.0-beta</version>
+    <version>1.23.0</version>
 </dependency>
 ```
 ### Gradle
 
 ```gradle
-implementation group: 'com.microsoft.azure', name: 'com.microsoft.aad.msal4j', version: '1.30.0-beta'
+implementation group: 'com.microsoft.azure', name: 'com.microsoft.aad.msal4j', version: '1.23.0'
 ```
 
 ## Usage

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,14 @@
-Version 1.30.0-beta
+Version 1.23.0
 =============
-- Replace org.projectlombok dependencies with implementations of generated code (#946)
-- Replace com.nimbusds dependencies with implementations of OAuth behavior (#926, #927, #928, #941, #945)
-- Replace com.fasterxml.jackson with com.azure.json for JSON behavior (#947, #948)
+- Reduced dependency footprint by removing third-party libraries (#909):
+  - Replaced org.projectlombok with direct implementations of previously generated code (#946)
+  - Replaced com.nimbusds OAuth/OIDC functionality with our own implementation (#926, #927, #928, #941, #945)
+  - Replaced com.fasterxml.jackson with com.azure.json for JSON parsing/serialization (#947, #948)
+  - Internal behavior and public APIs remain unchanged, except for those noted below
+- Minor breaking changes:
+  - Removed protected APIs that returned or used com.nimbusds.ClientAuthentication
+    - These APIs were not used by any other public MSAL API, and are unlikely to have been used by other libraries
+  - Improved JSON error handling to return more informative MsalClientException/MsalServiceException rather than generic JSON exceptions
 
 Version 1.22.0
 =============

--- a/msal4j-sdk/README.md
+++ b/msal4j-sdk/README.md
@@ -16,7 +16,7 @@ Quick links:
 The library supports the following Java environments:
 - Java 8 (or higher)
 
-Current version - 1.30.0-beta
+Current version - 1.23.0
 
 You can find the changes for each version in the [change log](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/master/changelog.txt).
 
@@ -28,13 +28,13 @@ Find [the latest package in the Maven repository](https://mvnrepository.com/arti
 <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>msal4j</artifactId>
-    <version>1.30.0-beta</version>
+    <version>1.23.0</version>
 </dependency>
 ```
 ### Gradle
 
 ```gradle
-compile group: 'com.microsoft.azure', name: 'msal4j', version: '1.30.0-beta'
+compile group: 'com.microsoft.azure', name: 'msal4j', version: '1.23.0'
 ```
 
 ## Usage

--- a/msal4j-sdk/bnd.bnd
+++ b/msal4j-sdk/bnd.bnd
@@ -1,2 +1,2 @@
-Export-Package: com.microsoft.aad.msal4j;version="1.30.0-beta"
+Export-Package: com.microsoft.aad.msal4j;version="1.23.0"
 Automatic-Module-Name: com.microsoft.aad.msal4j

--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure</groupId>
 	<artifactId>msal4j</artifactId>
-	<version>1.30.0-beta</version>
+	<version>1.23.0</version>
 	<packaging>jar</packaging>
 	<name>msal4j</name>
 	<description>


### PR DESCRIPTION
- Reduced dependency footprint by removing third-party libraries (#909):
  - Replaced org.projectlombok with direct implementations of previously generated code (#946)
  - Replaced com.nimbusds OAuth/OIDC functionality with our own implementation (#926, #927, #928, #941, #945)
  - Replaced com.fasterxml.jackson with com.azure.json for JSON parsing/serialization (#947, #948)
  - Internal behavior and public APIs remain unchanged, except for those noted below
- Minor breaking changes:
  - Removed protected APIs that returned or used com.nimbusds.ClientAuthentication
    - These APIs were not used by any other public MSAL API, and are unlikely to have been used by other libraries
  - Improved JSON error handling to return more informative MsalClientException/MsalServiceException rather than generic JSON exceptions
  
Although the changes could potentially break an application using MSAL, after several discussions we decided that it was not worth a bump to version 2.0 due them being closer to bugfixes rather than API design changes. See https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/982 for more details.