### PR TITLE
Consistently use SLF4J's recommended styles

### DIFF
--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenInteractiveIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenInteractiveIT.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutionException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AcquireTokenInteractiveIT extends SeleniumTest {
-    private final static Logger LOG = LoggerFactory.getLogger(AuthorizationCodeIT.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AcquireTokenInteractiveIT.class);
 
     private Config cfg;
 
@@ -145,7 +145,7 @@ class AcquireTokenInteractiveIT extends SeleniumTest {
             result = pca.acquireToken(parameters).get();
 
         } catch (Exception e) {
-            LOG.error("Error acquiring token with authCode: " + e.getMessage());
+            LOG.error("Error acquiring token with authCode: {}", e.getMessage());
             throw new RuntimeException("Error acquiring token with authCode: " + e.getMessage());
         }
 
@@ -236,7 +236,7 @@ class AcquireTokenInteractiveIT extends SeleniumTest {
             result = pca.acquireToken(parameters).get();
 
         } catch (Exception e) {
-            LOG.error("Error acquiring token with authCode: " + e.getMessage());
+            LOG.error("Error acquiring token with authCode: {}", e.getMessage());
             throw new RuntimeException("Error acquiring token with authCode: " + e.getMessage());
         }
         return result;
@@ -266,7 +266,7 @@ class AcquireTokenInteractiveIT extends SeleniumTest {
             result = pca.acquireToken(parameters).get();
 
         } catch (Exception e) {
-            LOG.error("Error acquiring token with authCode: " + e.getMessage());
+            LOG.error("Error acquiring token with authCode: {}", e.getMessage());
             throw new RuntimeException("Error acquiring token with authCode: " + e.getMessage());
         }
         return result;

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AuthorizationCodeIT extends SeleniumTest {
-    private final static Logger LOG = LoggerFactory.getLogger(AuthorizationCodeIT.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AuthorizationCodeIT.class);
 
     private Config cfg;
 
@@ -202,7 +202,7 @@ class AuthorizationCodeIT extends SeleniumTest {
                     .get();
 
         } catch (Exception e) {
-            LOG.error("Error acquiring token with authCode: " + e.getMessage());
+            LOG.error("Error acquiring token with authCode: {}", e.getMessage());
             throw new RuntimeException("Error acquiring token with authCode: " + e.getMessage());
         }
         return result;
@@ -219,7 +219,7 @@ class AuthorizationCodeIT extends SeleniumTest {
                     .build())
                     .get();
         } catch (Exception e) {
-            LOG.error("Error acquiring token with authCode: " + e.getMessage());
+            LOG.error("Error acquiring token with authCode: {}", e.getMessage());
             throw new RuntimeException("Error acquiring token with authCode: " + e.getMessage());
         }
         return result;

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
@@ -23,7 +23,7 @@ import java.util.function.Consumer;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class DeviceCodeIT {
-    private final static Logger LOG = LoggerFactory.getLogger(DeviceCodeIT.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DeviceCodeIT.class);
 
     private LabUserProvider labUserProvider;
     private WebDriver seleniumDriver;
@@ -152,7 +152,7 @@ class DeviceCodeIT {
             if (!isRunningLocally) {
                 SeleniumExtensions.takeScreenShot(seleniumDriver);
             }
-            LOG.error("Browser automation failed: " + e.getMessage());
+            LOG.error("Browser automation failed: {}", e.getMessage());
             throw new RuntimeException("Browser automation failed: " + e.getMessage());
         }
     }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
@@ -93,7 +93,7 @@ class AadInstanceDiscoveryProvider {
                 if (((AbstractClientApplicationBase) msalRequest.application()).azureRegion() == null
                         && ((AbstractClientApplicationBase) msalRequest.application()).autoDetectRegion()
                         && detectedRegion != null) {
-                    log.debug(String.format("Region autodetection found %s, this region will be used for future calls.", detectedRegion));
+                    log.debug("Region autodetection found {}, this region will be used for future calls.", detectedRegion);
 
                     ((AbstractClientApplicationBase) msalRequest.application()).azureRegion = detectedRegion;
                     host = getRegionalizedHost(authorityUrl.getHost(), ((AbstractClientApplicationBase) msalRequest.application()).azureRegion());
@@ -293,7 +293,7 @@ class AadInstanceDiscoveryProvider {
 
         //Check if the REGION_NAME environment variable has a value for the region
         if (System.getenv(REGION_NAME) != null) {
-            log.info(String.format("Region found in environment variable: %s",System.getenv(REGION_NAME)));
+            log.info("Region found in environment variable: {}", System.getenv(REGION_NAME));
             currentRequest.regionSource(RegionTelemetry.REGION_SOURCE_ENV_VARIABLE.telemetryValue);
 
             return System.getenv(REGION_NAME);
@@ -311,19 +311,19 @@ class AadInstanceDiscoveryProvider {
             IHttpResponse httpResponse = future.get(IMDS_TIMEOUT, IMDS_TIMEOUT_UNIT);
             //If call to IMDS endpoint was successful, return region from response body
             if (httpResponse.statusCode() == HttpStatus.HTTP_OK && !httpResponse.body().isEmpty()) {
-                log.info(String.format("Region retrieved from IMDS endpoint: %s", httpResponse.body()));
+                log.info("Region retrieved from IMDS endpoint: {}", httpResponse.body());
                 currentRequest.regionSource(RegionTelemetry.REGION_SOURCE_IMDS.telemetryValue);
 
                 return httpResponse.body();
             }
-            log.warn(String.format("Call to local IMDS failed with status code: %s, or response was empty", httpResponse.statusCode()));
+            log.warn("Call to local IMDS failed with status code: {}, or response was empty", httpResponse.statusCode());
             currentRequest.regionSource(RegionTelemetry.REGION_SOURCE_FAILED_AUTODETECT.telemetryValue);
         } catch (Exception ex) {
             // handle other exceptions
             //IMDS call failed, cannot find region
             //The IMDS endpoint is only available from within an Azure environment, so the most common cause of this
             //  exception will likely be java.net.SocketException: Network is unreachable: connect
-            log.warn(String.format("Exception during call to local IMDS endpoint: %s", ex.getMessage()));
+            log.warn("Exception during call to local IMDS endpoint: {}", ex.getMessage());
             currentRequest.regionSource(RegionTelemetry.REGION_SOURCE_FAILED_AUTODETECT.telemetryValue);
             future.cancel(true);
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
@@ -36,7 +36,7 @@ class AadInstanceDiscoveryProvider {
     static final TreeSet<String> TRUSTED_HOSTS_SET = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     static final TreeSet<String> TRUSTED_SOVEREIGN_HOSTS_SET = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
 
-    private static final Logger log = LoggerFactory.getLogger(AadInstanceDiscoveryProvider.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AadInstanceDiscoveryProvider.class);
 
     //flag to check if instance discovery has failed
     private static boolean instanceDiscoveryFailed = false;
@@ -67,7 +67,7 @@ class AadInstanceDiscoveryProvider {
         //If instanceDiscovery flag set to false OR this is a managed identity scenario, cache a basic instance metadata entry to skip this and future lookups
         if (msalRequest.application() instanceof ManagedIdentityApplication || !((AbstractClientApplicationBase) msalRequest.application()).instanceDiscovery()) {
             if (cache.get(host) == null) {
-                log.debug("Instance discovery set to false, caching a default entry.");
+                LOG.debug("Instance discovery set to false, caching a default entry.");
                 cacheInstanceDiscoveryMetadata(host);
             }
             return cache.get(host);
@@ -80,10 +80,10 @@ class AadInstanceDiscoveryProvider {
 
         //If there is no cached instance metadata, do instance discovery cache the result
         if (cache.get(host) == null) {
-            log.debug("No cached instance metadata, will attempt instance discovery.");
+            LOG.debug("No cached instance metadata, will attempt instance discovery.");
 
             if (shouldUseRegionalEndpoint(msalRequest)) {
-                log.debug("Region API used, will attempt to discover Azure region.");
+                LOG.debug("Region API used, will attempt to discover Azure region.");
 
                 //Server side telemetry requires the result from region discovery when any part of the region API is used
                 String detectedRegion = discoverRegion(msalRequest, serviceBundle);
@@ -93,7 +93,7 @@ class AadInstanceDiscoveryProvider {
                 if (((AbstractClientApplicationBase) msalRequest.application()).azureRegion() == null
                         && ((AbstractClientApplicationBase) msalRequest.application()).autoDetectRegion()
                         && detectedRegion != null) {
-                    log.debug("Region autodetection found {}, this region will be used for future calls.", detectedRegion);
+                    LOG.debug("Region autodetection found {}, this region will be used for future calls.", detectedRegion);
 
                     ((AbstractClientApplicationBase) msalRequest.application()).azureRegion = detectedRegion;
                     host = getRegionalizedHost(authorityUrl.getHost(), ((AbstractClientApplicationBase) msalRequest.application()).azureRegion());
@@ -160,7 +160,7 @@ class AadInstanceDiscoveryProvider {
             } else {
                 //Avoid unnecessary warnings when looking for cached tokens by checking if request was a silent call
                 if (msalRequest.getClass() != SilentRequest.class) {
-                    log.warn("Regional endpoints are only available for client credential flow, request will fall back to using the global endpoint. See here for more information about supported scenarios: https://aka.ms/msal4j-azure-regions");
+                    LOG.warn("Regional endpoints are only available for client credential flow, request will fall back to using the global endpoint. See here for more information about supported scenarios: https://aka.ms/msal4j-azure-regions");
                 }
                 return false;
             }
@@ -241,7 +241,7 @@ class AadInstanceDiscoveryProvider {
                 throw MsalServiceExceptionFactory.fromHttpResponse(httpResponse);
             }
             // instance discovery failed due to reasons other than an invalid authority, do not perform instance discovery again in this environment.
-            log.debug("Instance discovery failed due to an unknown error, no more instance discovery attempts will be made.");
+            LOG.debug("Instance discovery failed due to an unknown error, no more instance discovery attempts will be made.");
             cacheInstanceDiscoveryMetadata(authorityUrl.getHost());
         }
 
@@ -293,7 +293,7 @@ class AadInstanceDiscoveryProvider {
 
         //Check if the REGION_NAME environment variable has a value for the region
         if (System.getenv(REGION_NAME) != null) {
-            log.info("Region found in environment variable: {}", System.getenv(REGION_NAME));
+            LOG.info("Region found in environment variable: {}", System.getenv(REGION_NAME));
             currentRequest.regionSource(RegionTelemetry.REGION_SOURCE_ENV_VARIABLE.telemetryValue);
 
             return System.getenv(REGION_NAME);
@@ -307,23 +307,23 @@ class AadInstanceDiscoveryProvider {
         Future<IHttpResponse> future = executor.submit(() -> executeRequest(IMDS_ENDPOINT, headers, msalRequest, serviceBundle));
 
         try {
-            log.info("Starting call to IMDS endpoint.");
+            LOG.info("Starting call to IMDS endpoint.");
             IHttpResponse httpResponse = future.get(IMDS_TIMEOUT, IMDS_TIMEOUT_UNIT);
             //If call to IMDS endpoint was successful, return region from response body
             if (httpResponse.statusCode() == HttpStatus.HTTP_OK && !httpResponse.body().isEmpty()) {
-                log.info("Region retrieved from IMDS endpoint: {}", httpResponse.body());
+                LOG.info("Region retrieved from IMDS endpoint: {}", httpResponse.body());
                 currentRequest.regionSource(RegionTelemetry.REGION_SOURCE_IMDS.telemetryValue);
 
                 return httpResponse.body();
             }
-            log.warn("Call to local IMDS failed with status code: {}, or response was empty", httpResponse.statusCode());
+            LOG.warn("Call to local IMDS failed with status code: {}, or response was empty", httpResponse.statusCode());
             currentRequest.regionSource(RegionTelemetry.REGION_SOURCE_FAILED_AUTODETECT.telemetryValue);
         } catch (Exception ex) {
             // handle other exceptions
             //IMDS call failed, cannot find region
             //The IMDS endpoint is only available from within an Azure environment, so the most common cause of this
             //  exception will likely be java.net.SocketException: Network is unreachable: connect
-            log.warn("Exception during call to local IMDS endpoint: {}", ex.getMessage());
+            LOG.warn("Exception during call to local IMDS endpoint: {}", ex.getMessage());
             currentRequest.regionSource(RegionTelemetry.REGION_SOURCE_FAILED_AUTODETECT.telemetryValue);
             future.cancel(true);
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractManagedIdentitySource.java
@@ -74,9 +74,8 @@ abstract class AbstractManagedIdentitySource {
                 return getSuccessfulResponse(response);
             } else {
                 message = getMessageFromErrorResponse(response);
-                LOG.error(
-                        String.format("[Managed Identity] request failed, HttpStatusCode: %s, Error message: %s",
-                                response.statusCode(), message));
+                LOG.error("[Managed Identity] request failed, HttpStatusCode: {}, Error message: {}",
+                        response.statusCode(), message);
                 throw new MsalServiceException(message, AuthenticationErrorCode.MANAGED_IDENTITY_REQUEST_FAILED, managedIdentitySourceType);
             }
         } catch (Exception e) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByClientCredentialSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByClientCredentialSupplier.java
@@ -46,7 +46,7 @@ class AcquireTokenByClientCredentialSupplier extends AuthenticationResultSupplie
 
                 return supplier.execute();
             } catch (MsalClientException ex) {
-                LOG.debug(String.format("Cache lookup failed: %s", ex.getMessage()));
+                LOG.debug("Cache lookup failed: {}", ex.getMessage());
                 return acquireTokenByClientCredential();
             }
         }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByInteractiveFlowSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByInteractiveFlowSupplier.java
@@ -109,7 +109,7 @@ class AcquireTokenByInteractiveFlowSupplier extends AuthenticationResultSupplier
         try {
             URI updatedRedirectUrl = new URI("http://localhost:" + httpListener.port());
             interactiveRequest.interactiveRequestParameters().redirectUri(updatedRedirectUrl);
-            LOG.debug("Redirect URI updated to" + updatedRedirectUrl);
+            LOG.debug("Redirect URI updated to {}", updatedRedirectUrl);
         } catch (URISyntaxException ex) {
             throw new MsalClientException("Error updating redirect URI. Not a valid URI format",
                     AuthenticationErrorCode.INVALID_REDIRECT_URI);
@@ -204,7 +204,7 @@ class AcquireTokenByInteractiveFlowSupplier extends AuthenticationResultSupplier
             long expirationTime;
 
             if (timeFromParameters > 0) {
-                LOG.debug(String.format("Listening for authorization result. Listener will timeout after %S seconds.", timeFromParameters));
+                LOG.debug("Listening for authorization result. Listener will timeout after {} seconds.", timeFromParameters);
                 expirationTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) + timeFromParameters;
             } else {
                 LOG.warn("Listening for authorization result. Timeout configured to less than 1 second, listener will use a 1 second timeout instead.");
@@ -213,7 +213,7 @@ class AcquireTokenByInteractiveFlowSupplier extends AuthenticationResultSupplier
 
             while (result == null && !interactiveRequest.futureReference().get().isDone()) {
                 if (TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()) > expirationTime) {
-                    LOG.warn(String.format("Listener timed out after %S seconds, no authorization code was returned from the server during that time.", timeFromParameters));
+                    LOG.warn("Listener timed out after {} seconds, no authorization code was returned from the server during that time.", timeFromParameters);
                     break;
                 }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByManagedIdentitySupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByManagedIdentitySupplier.java
@@ -90,15 +90,15 @@ class AcquireTokenByManagedIdentitySupplier extends AuthenticationResultSupplier
                     return fetchNewAccessTokenAndSaveToCache(tokenRequestExecutor, CacheRefreshReason.CLAIMS);
                 }
 
-                LOG.debug(String.format("Refreshing access token. Cache refresh reason: %s", cacheRefreshReason));
+                LOG.debug("Refreshing access token. Cache refresh reason: {}", cacheRefreshReason);
                 return fetchNewAccessTokenAndSaveToCache(tokenRequestExecutor, cacheRefreshReason);
             }
         } catch (MsalClientException ex) {
             if (ex.errorCode().equals(AuthenticationErrorCode.CACHE_MISS)) {
-                LOG.debug(String.format("Cache lookup failed: %s", ex.getMessage()));
+                LOG.debug("Cache lookup failed: {}", ex.getMessage());
                 return fetchNewAccessTokenAndSaveToCache(tokenRequestExecutor, cacheRefreshReason);
             } else {
-                LOG.error(String.format("Error occurred while cache lookup: %s", ex.getMessage()));
+                LOG.error("Error occurred while cache lookup: {}", ex.getMessage());
                 throw ex;
             }
         }
@@ -108,8 +108,8 @@ class AcquireTokenByManagedIdentitySupplier extends AuthenticationResultSupplier
 
         ManagedIdentityClient managedIdentityClient = new ManagedIdentityClient(msalRequest, tokenRequestExecutor.getServiceBundle());
 
-        LOG.debug(String.format("[Managed Identity] Managed Identity source and ID type identified and set successfully, request will use Managed Identity for %s",
-                managedIdentityClient.managedIdentitySource.managedIdentitySourceType.name()));
+        LOG.debug("[Managed Identity] Managed Identity source and ID type identified and set successfully, request will use Managed Identity for {}",
+                managedIdentityClient.managedIdentitySource.managedIdentitySourceType.name());
 
         ManagedIdentityResponse managedIdentityResponse = managedIdentityClient
                 .getManagedIdentityResponse(managedIdentityParameters);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByOnBehalfOfSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByOnBehalfOfSupplier.java
@@ -46,7 +46,7 @@ class AcquireTokenByOnBehalfOfSupplier extends AuthenticationResultSupplier {
 
                 return supplier.execute();
             } catch (MsalClientException ex) {
-                LOG.debug(String.format("Cache lookup failed: %s", ex.getMessage()));
+                LOG.debug("Cache lookup failed: {}", ex.getMessage());
                 return acquireTokenOnBehalfOf();
             }
         }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenSilentSupplier.java
@@ -11,7 +11,7 @@ import java.util.Date;
 
 class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
 
-    private static final Logger log = LoggerFactory.getLogger(AcquireTokenSilentSupplier.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AcquireTokenSilentSupplier.class);
     private SilentRequest silentRequest;
     protected static final int ACCESS_TOKEN_EXPIRE_BUFFER_IN_SEC = 5 * 60;
 
@@ -78,7 +78,7 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
             throw new MsalClientException(AuthenticationErrorMessage.NO_TOKEN_IN_CACHE, AuthenticationErrorCode.CACHE_MISS);
         }
 
-        log.debug("Returning token from cache");
+        LOG.debug("Returning token from cache");
 
         return res;
     }
@@ -103,7 +103,7 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
             refreshedResult.metadata().tokenSource(TokenSource.IDENTITY_PROVIDER);
             refreshedResult.metadata().cacheRefreshReason(refreshReason);
 
-            log.info("Access token refreshed successfully.");
+            LOG.info("Access token refreshed successfully.");
             return refreshedResult;
         } catch (MsalServiceException ex) {
             //If the token refresh attempt threw a MsalServiceException but the refresh attempt was done
@@ -121,7 +121,7 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
         //If forceRefresh is true, no reason to check any other option
         if (parameters.forceRefresh()) {
             setCacheTelemetry(CacheRefreshReason.FORCE_REFRESH);
-            log.debug(String.format("Refreshing access token. Cache refresh reason: %s", CacheRefreshReason.FORCE_REFRESH));
+            LOG.debug("Refreshing access token. Cache refresh reason: {}", CacheRefreshReason.FORCE_REFRESH);
             return true;
         }
 
@@ -129,7 +129,7 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
         //  Note: these are the types of claims found in (for example) a claims challenge, and do not include client capabilities
         if (parameters.claims() != null) {
             setCacheTelemetry(CacheRefreshReason.CLAIMS);
-            log.debug(String.format("Refreshing access token. Cache refresh reason: %s", CacheRefreshReason.CLAIMS));
+            LOG.debug("Refreshing access token. Cache refresh reason: {}", CacheRefreshReason.CLAIMS);
             return true;
         }
 
@@ -138,7 +138,7 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
         //If the access token is expired or within 5 minutes of becoming expired, refresh it
         if (!StringHelper.isBlank(cachedResult.accessToken()) && cachedResult.expiresOn() < (currTimeStampSec + ACCESS_TOKEN_EXPIRE_BUFFER_IN_SEC)) {
             setCacheTelemetry(CacheRefreshReason.EXPIRED);
-            log.debug(String.format("Refreshing access token. Cache refresh reason: %s", CacheRefreshReason.EXPIRED));
+            LOG.debug("Refreshing access token. Cache refresh reason: {}", CacheRefreshReason.EXPIRED);
             return true;
         }
 
@@ -147,14 +147,14 @@ class AcquireTokenSilentSupplier extends AuthenticationResultSupplier {
                 cachedResult.refreshOn() != null && cachedResult.refreshOn() > 0 &&
                 cachedResult.refreshOn() < currTimeStampSec && cachedResult.expiresOn() >= (currTimeStampSec + ACCESS_TOKEN_EXPIRE_BUFFER_IN_SEC)){
             setCacheTelemetry(CacheRefreshReason.PROACTIVE_REFRESH);
-            log.debug(String.format("Refreshing access token. Cache refresh reason: %s", CacheRefreshReason.PROACTIVE_REFRESH));
+            LOG.debug("Refreshing access token. Cache refresh reason: {}", CacheRefreshReason.PROACTIVE_REFRESH);
             return true;
         }
 
         //If there is a refresh token but no access token, we should use the refresh token to get the access token
         if (StringHelper.isBlank(cachedResult.accessToken()) && !StringHelper.isBlank(cachedResult.refreshToken())) {
             setCacheTelemetry(CacheRefreshReason.NO_CACHED_ACCESS_TOKEN);
-            log.debug(String.format("Refreshing access token. Cache refresh reason: %s", CacheRefreshReason.NO_CACHED_ACCESS_TOKEN));
+            LOG.debug("Refreshing access token. Cache refresh reason: {}", CacheRefreshReason.NO_CACHED_ACCESS_TOKEN);
             return true;
         }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AppServiceManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AppServiceManagedIdentitySource.java
@@ -79,7 +79,7 @@ class AppServiceManagedIdentitySource extends AbstractManagedIdentitySource{
                     ManagedIdentitySourceType.APP_SERVICE);
         }
 
-        LOG.info("[Managed Identity] Environment variables validation passed for app service managed identity. Endpoint URI: {endpointUri}. Creating App Service managed identity.");
+        LOG.info("[Managed Identity] Environment variables validation passed for app service managed identity. Endpoint URI: {}. Creating App Service managed identity.", endpointUri);
         return endpointUri;
     }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
@@ -37,7 +37,7 @@ public class AuthorizationRequestUrlParameters {
 
     Map<String, String> requestParameters = new HashMap<>();
 
-    Logger log = LoggerFactory.getLogger(AuthorizationRequestUrlParameters.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AuthorizationRequestUrlParameters.class);
 
     public static Builder builder(String redirectUri,
                                   Set<String> scopes) {
@@ -157,7 +157,7 @@ public class AuthorizationRequestUrlParameters {
                 String key = entry.getKey();
                 String value = entry.getValue();
                 if(requestParameters.containsKey(key)){
-                    log.warn("A query parameter {} has been provided with values multiple times.", key);
+                    LOG.warn("A query parameter {} has been provided with values multiple times.", key);
                 }
                 requestParameters.put(key, value);
             }
@@ -243,7 +243,7 @@ public class AuthorizationRequestUrlParameters {
     }
 
     public Logger log() {
-        return this.log;
+        return LOG;
     }
 
     public static class Builder {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
@@ -52,7 +52,7 @@ class AuthorizationResponseHandler implements HttpHandler {
             authorizationResultQueue.put(result);
 
         } catch (InterruptedException ex) {
-            LOG.error("Error reading response from socket: " + ex.getMessage());
+            LOG.error("Error reading response from socket: {}", ex.getMessage());
             throw new MsalClientException(ex);
         } finally {
             httpExchange.close();

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AzureArcManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AzureArcManagedIdentitySource.java
@@ -57,7 +57,7 @@ class AzureArcManagedIdentitySource extends AbstractManagedIdentitySource{
                     ManagedIdentitySourceType.AZURE_ARC);
         }
 
-        LOG.info(String.format("[Managed Identity] Creating Azure Arc managed identity. Endpoint URI: %s", endpointUri));
+        LOG.info("[Managed Identity] Creating Azure Arc managed identity. Endpoint URI: {}", endpointUri);
         return endpointUri;
     }
 
@@ -163,14 +163,14 @@ class AzureArcManagedIdentitySource extends AbstractManagedIdentitySource{
     private void validateFile(Path path) {
         String osName = System.getProperty("os.name").toLowerCase();
         if (!(osName.contains("windows") || osName.contains("linux"))) {
-            LOG.error(String.format("[Managed Identity] Unsupported platform: %s", osName));
+            LOG.error("[Managed Identity] Unsupported platform: {}", osName);
             throw new MsalServiceException(MsalErrorMessage.MANAGED_IDENTITY_PLATFORM_NOT_SUPPORTED, MsalError.MANAGED_IDENTITY_FILE_READ_ERROR,
                     ManagedIdentitySourceType.AZURE_ARC);
         }
 
         if (isValidWindowsPath(path) || isValidLinuxPath(path)) {
             if (path.toFile().length() > MAX_FILE_SIZE_BYTES) {
-                LOG.error(String.format("[Managed Identity] File is larger than %s bytes.", MAX_FILE_SIZE_BYTES));
+                LOG.error("[Managed Identity] File is larger than {} bytes.", MAX_FILE_SIZE_BYTES);
                 throw new MsalServiceException(MsalErrorMessage.MANAGED_IDENTITY_INVALID_FILEPATH, MsalError.MANAGED_IDENTITY_FILE_READ_ERROR,
                         ManagedIdentitySourceType.AZURE_ARC);
             }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CloudShellManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CloudShellManagedIdentitySource.java
@@ -64,7 +64,7 @@ class CloudShellManagedIdentitySource extends AbstractManagedIdentitySource{
         try
         {
             URI endpointUri = new URI(msiEndpoint);
-            LOG.info("[Managed Identity] Environment variables validation passed for cloud shell managed identity. Endpoint URI: {}. Creating cloud shell managed identity.", endpointUri);
+            LOG.info("[Managed Identity] Environment variables validation passed for Cloud Shell managed identity. Endpoint URI: {}. Creating Cloud Shell managed identity.", endpointUri);
             return endpointUri;
         }
         catch (URISyntaxException ex)

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CloudShellManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CloudShellManagedIdentitySource.java
@@ -64,7 +64,7 @@ class CloudShellManagedIdentitySource extends AbstractManagedIdentitySource{
         try
         {
             URI endpointUri = new URI(msiEndpoint);
-            LOG.info(String.format("[Managed Identity] Environment variables validation passed for cloud shell managed identity. Endpoint URI: %s. Creating cloud shell managed identity.", endpointUri));
+            LOG.info("[Managed Identity] Environment variables validation passed for cloud shell managed identity. Endpoint URI: {}. Creating cloud shell managed identity.", endpointUri);
             return endpointUri;
         }
         catch (URISyntaxException ex)

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClient.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DefaultHttpClient.java
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 class DefaultHttpClient implements IHttpClient {
-    private static final  Logger LOG = LoggerFactory.getLogger(DefaultHttpClient.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultHttpClient.class);
 
     final Proxy proxy;
     final SSLSocketFactory sslSocketFactory;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpHelper.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpHelper.java
@@ -16,7 +16,7 @@ import static com.microsoft.aad.msal4j.Constants.POINT_DELIMITER;
 
 class HttpHelper implements IHttpHelper {
 
-    private static final Logger log = LoggerFactory.getLogger(HttpHelper.class);
+    private static final Logger LOG = LoggerFactory.getLogger(HttpHelper.class);
     public static final String RETRY_AFTER_HEADER = "Retry-After";
 
     private IHttpClient httpClient;
@@ -210,7 +210,7 @@ class HttpHelper implements IHttpHelper {
                         return headerValue;
                     }
                 } catch (NumberFormatException ex) {
-                    log.warn("Failed to parse value of Retry-After header - NumberFormatException");
+                    LOG.warn("Failed to parse value of Retry-After header - NumberFormatException");
                 }
             }
         }
@@ -228,7 +228,7 @@ class HttpHelper implements IHttpHelper {
             String correlationId = httpRequest.headerValue(
                     HttpHeaders.CORRELATION_ID_HEADER_NAME);
 
-            log.warn(LogHelper.createMessage("Setting URL telemetry fields failed: " +
+            LOG.warn(LogHelper.createMessage("Setting URL telemetry fields failed: " +
                             LogHelper.getPiiScrubbedDetails(ex),
                     correlationId != null ? correlationId : ""));
         }
@@ -281,7 +281,7 @@ class HttpHelper implements IHttpHelper {
                             returnedCorrelationId),
                     sentCorrelationId);
 
-            log.info(msg);
+            LOG.info(msg);
         }
     }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpListener.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpListener.java
@@ -28,7 +28,7 @@ class HttpListener {
             server.createContext("/", httpHandler);
             this.port = server.getAddress().getPort();
             server.start();
-            LOG.debug("Http listener started. Listening on port: " + port);
+            LOG.debug("Http listener started. Listening on port: {}", port);
         } catch (Exception e) {
             throw new MsalClientException(e.getMessage(),
                     AuthenticationErrorCode.UNABLE_TO_START_HTTP_LISTENER);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IMDSManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IMDSManagedIdentitySource.java
@@ -43,7 +43,7 @@ class IMDSManagedIdentitySource extends AbstractManagedIdentitySource{
         }
 
         if (!StringHelper.isNullOrBlank(environmentVariables.getEnvironmentVariable(Constants.AZURE_POD_IDENTITY_AUTHORITY_HOST))){
-            LOG.info(String.format("[Managed Identity] Environment variable AZURE_POD_IDENTITY_AUTHORITY_HOST for IMDS returned endpoint: %s", environmentVariables.getEnvironmentVariable(Constants.AZURE_POD_IDENTITY_AUTHORITY_HOST)));
+            LOG.info("[Managed Identity] Environment variable AZURE_POD_IDENTITY_AUTHORITY_HOST for IMDS returned endpoint: {}", environmentVariables.getEnvironmentVariable(Constants.AZURE_POD_IDENTITY_AUTHORITY_HOST));
             try {
                 imdsEndpoint = new URI(environmentVariables.getEnvironmentVariable(Constants.AZURE_POD_IDENTITY_AUTHORITY_HOST));
             } catch (URISyntaxException e) {
@@ -68,7 +68,7 @@ class IMDSManagedIdentitySource extends AbstractManagedIdentitySource{
             imdsEndpoint = DEFAULT_IMDS_ENDPOINT;
         }
 
-        LOG.info(String.format("[Managed Identity] Creating IMDS managed identity source. Endpoint URI: %s", imdsEndpoint));
+        LOG.info("[Managed Identity] Creating IMDS managed identity source. Endpoint URI: {}", imdsEndpoint);
     }
 
     @Override
@@ -114,7 +114,7 @@ class IMDSManagedIdentitySource extends AbstractManagedIdentitySource{
 
             message = message + " " + errorContentMessage;
 
-            LOG.error(String.format("Error message: %s Http status code: %s", message, response.statusCode()));
+            LOG.error("Error message: {} Http status code: {}", message, response.statusCode());
             throw new MsalServiceException(message, MsalError.MANAGED_IDENTITY_REQUEST_FAILED,
                     ManagedIdentitySourceType.IMDS);
         }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityClient.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityClient.java
@@ -3,14 +3,10 @@
 
 package com.microsoft.aad.msal4j;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Class to initialize a managed identity and identify the service.
  */
 class ManagedIdentityClient {
-    private static final Logger LOG = LoggerFactory.getLogger(ManagedIdentityClient.class);
 
     static ManagedIdentitySourceType getManagedIdentitySource() {
         IEnvironmentVariables environmentVariables = AbstractManagedIdentitySource.getEnvironmentVariables();

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityResponse.java
@@ -7,14 +7,10 @@ import com.azure.json.JsonReader;
 import com.azure.json.JsonSerializable;
 import com.azure.json.JsonToken;
 import com.azure.json.JsonWriter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
 class ManagedIdentityResponse implements JsonSerializable<ManagedIdentityResponse> {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ManagedIdentityResponse.class);
 
     String tokenType;
     String accessToken;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MexParser.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MexParser.java
@@ -23,7 +23,7 @@ import org.w3c.dom.NodeList;
 
 class MexParser {
 
-    private final static Logger log = LoggerFactory.getLogger(MexParser.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MexParser.class);
 
     private static final String TRANSPORT_BINDING_XPATH = "wsp:ExactlyOne/wsp:All/sp:TransportBinding";
     private static final String TRANSPORT_BINDING_2005_XPATH = "wsp:ExactlyOne/wsp:All/sp2005:TransportBinding";
@@ -84,7 +84,7 @@ class MexParser {
         Map<String, BindingPolicy> policies = policySelector.selectPolicies(xmlDocument, xPath, logPii);
 
         if (policies.isEmpty()) {
-            log.debug("No matching policies");
+            LOG.debug("No matching policies");
 
             return null;
         } else {
@@ -92,7 +92,7 @@ class MexParser {
                     xmlDocument, xPath, policies, logPii);
 
             if (bindings.isEmpty()) {
-                log.debug("No matching bindings");
+                LOG.debug("No matching bindings");
 
                 return null;
             } else {
@@ -132,7 +132,7 @@ class MexParser {
         }
 
         if (wstrust13 == null && wstrust2005 == null) {
-            log.warn("No policies found with the url");
+            LOG.warn("No policies found with the url");
 
             return null;
         }
@@ -148,7 +148,7 @@ class MexParser {
                 xmlDocument, XPathConstants.NODESET);
 
         if (portNodes.getLength() == 0) {
-            log.warn("No ports found");
+            LOG.warn("No ports found");
         } else {
             for (int i = 0; i < portNodes.getLength(); i++) {
                 Node portNode = portNodes.item(i);
@@ -175,9 +175,9 @@ class MexParser {
                                 bindingPolicy.setUrl(address.trim());
                             } else {
                                 if (logPii) {
-                                    log.warn("Skipping insecure endpoint" + ": " + address);
+                                    LOG.warn("Skipping insecure endpoint: {}", address);
                                 } else {
-                                    log.warn("Skipping insecure endpoint");
+                                    LOG.warn("Skipping insecure endpoint");
                                 }
                             }
                         } else {
@@ -242,17 +242,17 @@ class MexParser {
 
                 if (soapAction.equalsIgnoreCase(RST_SOAP_ACTION)) {
                     if (logPii) {
-                        log.debug("Found binding matching Action and Transport: " + bindingName);
+                        LOG.debug("Found binding matching Action and Transport: {}", bindingName);
                     } else {
-                        log.debug("Found binding matching Action and Transport");
+                        LOG.debug("Found binding matching Action and Transport");
                     }
 
                     return WSTrustVersion.WSTRUST13;
                 } else if (soapAction.equalsIgnoreCase(RST_SOAP_ACTION_2005)) {
                     if (logPii) {
-                        log.debug("Binding node did not match soap Action or Transport: " + bindingName);
+                        LOG.debug("Binding node did not match soap Action or Transport: {}", bindingName);
                     } else {
-                        log.debug("Binding node did not match soap Action or Transport");
+                        LOG.debug("Binding node did not match soap Action or Transport");
                     }
 
                     return WSTrustVersion.WSTRUST2005;
@@ -322,9 +322,9 @@ class MexParser {
             policyId = id.getNodeValue();
 
             if (logPii) {
-                log.debug("found matching policy id: " + policyId);
+                LOG.debug("found matching policy id: {}", policyId);
             } else {
-                log.debug("found matching policy");
+                LOG.debug("found matching policy");
             }
         } else {
             String nodeValue = "none";
@@ -333,9 +333,9 @@ class MexParser {
             }
 
             if (logPii) {
-                log.debug("potential policy did not match required transport binding: " + nodeValue);
+                LOG.debug("potential policy did not match required transport binding: {}", nodeValue);
             } else {
-                log.debug("potential policy did not match required transport binding");
+                LOG.debug("potential policy did not match required transport binding");
             }
         }
         return policyId;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MexParser.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MexParser.java
@@ -252,7 +252,7 @@ class MexParser {
                     if (logPii) {
                         LOG.debug("Binding node did not match soap Action or Transport: {}", bindingName);
                     } else {
-                        LOG.debug("Binding node did not match soap Action or Transport");
+                        LOG.debug("Binding node did not match SOAP Action or Transport");
                     }
 
                     return WSTrustVersion.WSTRUST2005;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MexParser.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MexParser.java
@@ -250,7 +250,7 @@ class MexParser {
                     return WSTrustVersion.WSTRUST13;
                 } else if (soapAction.equalsIgnoreCase(RST_SOAP_ACTION_2005)) {
                     if (logPii) {
-                        LOG.debug("Binding node did not match soap Action or Transport: {}", bindingName);
+                        LOG.debug("Binding node did not match SOAP Action or Transport: {}", bindingName);
                     } else {
                         LOG.debug("Binding node did not match SOAP Action or Transport");
                     }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ServerSideTelemetry.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ServerSideTelemetry.java
@@ -77,7 +77,7 @@ class ServerSideTelemetry {
                 SCHEMA_PIPE_DELIMITER;
 
         if (currentRequestHeader.getBytes(StandardCharsets.UTF_8).length > CURRENT_REQUEST_MAX_SIZE) {
-            log.warn("Current request telemetry header greater than 100 bytes");
+            log.warn("Current request telemetry header greater than {} bytes", CURRENT_REQUEST_MAX_SIZE);
         }
 
         return currentRequestHeader;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ServiceFabricManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ServiceFabricManagedIdentitySource.java
@@ -107,7 +107,7 @@ class ServiceFabricManagedIdentitySource extends AbstractManagedIdentitySource {
         try
         {
             URI endpointUri = new URI(msiEndpoint);
-            LOG.info(String.format("[Managed Identity] Environment variables validation passed for Service Fabric Managed Identity. Endpoint URI: %s", endpointUri));
+            LOG.info("[Managed Identity] Environment variables validation passed for Service Fabric Managed Identity. Endpoint URI: {}", endpointUri);
             return endpointUri;
         }
         catch (URISyntaxException ex)

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -11,7 +11,7 @@ import java.net.MalformedURLException;
 import java.util.*;
 
 class TokenRequestExecutor {
-    Logger log = LoggerFactory.getLogger(TokenRequestExecutor.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TokenRequestExecutor.class);
 
     final Authority requestAuthority;
     final String tenant;
@@ -29,7 +29,7 @@ class TokenRequestExecutor {
 
     AuthenticationResult executeTokenRequest() throws IOException {
 
-        log.debug("Sending token request to: {}", requestAuthority.canonicalAuthorityUrl());
+        LOG.debug("Sending token request to: {}", requestAuthority.canonicalAuthorityUrl());
         OAuthHttpRequest oAuthHttpRequest = createOauthHttpRequest();
         HttpResponse oauthHttpResponse = oAuthHttpRequest.send();
         return createAuthenticationResultFromOauthHttpResponse(oauthHttpResponse);
@@ -66,7 +66,7 @@ class TokenRequestExecutor {
         if(msalRequest.requestContext().apiParameters().extraQueryParameters() != null ){
             for(String key: msalRequest.requestContext().apiParameters().extraQueryParameters().keySet()){
                     if(params.containsKey(key)){
-                       log.warn("A query parameter {} has been provided with values multiple times.", key);
+                       LOG.warn("A query parameter {} has been provided with values multiple times.", key);
                     }
                     params.put(key, msalRequest.requestContext().apiParameters().extraQueryParameters().get(key));
             }
@@ -171,7 +171,7 @@ class TokenRequestExecutor {
     }
 
     Logger getLog() {
-        return this.log;
+        return LOG;
     }
 
     Authority getRequestAuthority() {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TokenRequestExecutor.java
@@ -122,7 +122,7 @@ class TokenRequestExecutor {
                 try {
                     authorityToUse = Authority.replaceTenant(authorityToUse, parameters.tenant());
                 } catch (MalformedURLException e) {
-                    log.warn("Could not create authority with tenant override: {}", e.getMessage());
+                    LOG.warn("Could not create authority with tenant override: {}", e.getMessage());
                 }
             }
         }


### PR DESCRIPTION
This PR refactors the logging throughout the codebase to be more consistent and efficient by following SLF4J's recommended styles.

Many classes received changes, but same two changes were made to each one:
- Ensures the Logger instance is created like `private static final Logger LOG = ...`
- Avoids unnecessary String operations by using SLF4J's parameterized string format
  - SonarQube considers this a minor issue, and will lead to a very small performance improvement

Only logging statements were affected and there were no changes to the actual messages that get logged, so the actual behavior of the library is unchanged.