### PR TITLE
Use more common "static final" instead of "final static"

### DIFF
--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenInteractiveIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenInteractiveIT.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutionException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AcquireTokenInteractiveIT extends SeleniumTest {
-    private static final Logger LOG = LoggerFactory.getLogger(AuthorizationCodeIT.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AcquireTokenInteractiveIT.class);
 
     private Config cfg;
 

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenInteractiveIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AcquireTokenInteractiveIT.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutionException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AcquireTokenInteractiveIT extends SeleniumTest {
-    private final static Logger LOG = LoggerFactory.getLogger(AuthorizationCodeIT.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AuthorizationCodeIT.class);
 
     private Config cfg;
 

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/AuthorizationCodeIT.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AuthorizationCodeIT extends SeleniumTest {
-    private final static Logger LOG = LoggerFactory.getLogger(AuthorizationCodeIT.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AuthorizationCodeIT.class);
 
     private Config cfg;
 

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/DeviceCodeIT.java
@@ -23,7 +23,7 @@ import java.util.function.Consumer;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class DeviceCodeIT {
-    private final static Logger LOG = LoggerFactory.getLogger(DeviceCodeIT.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DeviceCodeIT.class);
 
     private LabUserProvider labUserProvider;
     private WebDriver seleniumDriver;

--- a/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
+++ b/msal4j-sdk/src/integrationtest/java/com.microsoft.aad.msal4j/TestConstants.java
@@ -4,54 +4,54 @@
 package com.microsoft.aad.msal4j;
 
 public class TestConstants {
-    public final static String KEYVAULT_DEFAULT_SCOPE = "https://vault.azure.net/.default";
-    public final static String MSIDLAB_DEFAULT_SCOPE = "https://request.msidlab.com/.default";
-    public final static String MSIDLAB_VAULT_URL = "https://msidlabs.vault.azure.net/";
-    public final static String MSIDLAB_CLIENT_ID = "f62c5ae3-bf3a-4af5-afa8-a68b800396e9";
-    public final static String GRAPH_DEFAULT_SCOPE = "https://graph.windows.net/.default";
-    public final static String USER_READ_SCOPE = "user.read";
-    public final static String DEFAULT_SCOPE = ".default";
-    public final static String B2C_LAB_SCOPE = "https://msidlabb2c.onmicrosoft.com/msaapp/user_impersonation";
-    public final static String B2C_CONFIDENTIAL_CLIENT_APP_SECRETID = "MSIDLABB2C-MSAapp-AppSecret";
-    public final static String B2C_CONFIDENTIAL_CLIENT_LAB_APP_ID = "MSIDLABB2C-MSAapp-AppID";
+    public static final String KEYVAULT_DEFAULT_SCOPE = "https://vault.azure.net/.default";
+    public static final String MSIDLAB_DEFAULT_SCOPE = "https://request.msidlab.com/.default";
+    public static final String MSIDLAB_VAULT_URL = "https://msidlabs.vault.azure.net/";
+    public static final String MSIDLAB_CLIENT_ID = "f62c5ae3-bf3a-4af5-afa8-a68b800396e9";
+    public static final String GRAPH_DEFAULT_SCOPE = "https://graph.windows.net/.default";
+    public static final String USER_READ_SCOPE = "user.read";
+    public static final String DEFAULT_SCOPE = ".default";
+    public static final String B2C_LAB_SCOPE = "https://msidlabb2c.onmicrosoft.com/msaapp/user_impersonation";
+    public static final String B2C_CONFIDENTIAL_CLIENT_APP_SECRETID = "MSIDLABB2C-MSAapp-AppSecret";
+    public static final String B2C_CONFIDENTIAL_CLIENT_LAB_APP_ID = "MSIDLABB2C-MSAapp-AppID";
 
-    public final static String MICROSOFT_AUTHORITY_HOST = "https://login.microsoftonline.com/";
-    public final static String MICROSOFT_AUTHORITY_BASIC_HOST = "login.microsoftonline.com";
-    public final static String MICROSOFT_AUTHORITY_HOST_WITH_PORT = "https://login.microsoftonline.com:443/";
-    public final static String ARLINGTON_MICROSOFT_AUTHORITY_HOST = "https://login.microsoftonline.us/";
-    public final static String MICROSOFT_AUTHORITY_TENANT = "msidlab4.onmicrosoft.com";
-    public final static String ARLINGTON_AUTHORITY_TENANT = "arlmsidlab1.onmicrosoft.us";
+    public static final String MICROSOFT_AUTHORITY_HOST = "https://login.microsoftonline.com/";
+    public static final String MICROSOFT_AUTHORITY_BASIC_HOST = "login.microsoftonline.com";
+    public static final String MICROSOFT_AUTHORITY_HOST_WITH_PORT = "https://login.microsoftonline.com:443/";
+    public static final String ARLINGTON_MICROSOFT_AUTHORITY_HOST = "https://login.microsoftonline.us/";
+    public static final String MICROSOFT_AUTHORITY_TENANT = "msidlab4.onmicrosoft.com";
+    public static final String ARLINGTON_AUTHORITY_TENANT = "arlmsidlab1.onmicrosoft.us";
 
-    public final static String ORGANIZATIONS_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "organizations/";
-    public final static String COMMON_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "common/";
-    public final static String CONSUMERS_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "consumers/";
-    public final static String COMMON_AUTHORITY_WITH_PORT = MICROSOFT_AUTHORITY_HOST_WITH_PORT + "msidlab4.onmicrosoft.com";
-    public final static String MICROSOFT_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "microsoft.onmicrosoft.com";
-    public final static String TENANT_SPECIFIC_AUTHORITY = MICROSOFT_AUTHORITY_HOST + MICROSOFT_AUTHORITY_TENANT;
-    public final static String REGIONAL_MICROSOFT_AUTHORITY_BASIC_HOST_WESTUS = "westus.login.microsoft.com";
+    public static final String ORGANIZATIONS_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "organizations/";
+    public static final String COMMON_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "common/";
+    public static final String CONSUMERS_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "consumers/";
+    public static final String COMMON_AUTHORITY_WITH_PORT = MICROSOFT_AUTHORITY_HOST_WITH_PORT + "msidlab4.onmicrosoft.com";
+    public static final String MICROSOFT_AUTHORITY = MICROSOFT_AUTHORITY_HOST + "microsoft.onmicrosoft.com";
+    public static final String TENANT_SPECIFIC_AUTHORITY = MICROSOFT_AUTHORITY_HOST + MICROSOFT_AUTHORITY_TENANT;
+    public static final String REGIONAL_MICROSOFT_AUTHORITY_BASIC_HOST_WESTUS = "westus.login.microsoft.com";
 
-    public final static String ARLINGTON_ORGANIZATIONS_AUTHORITY = ARLINGTON_MICROSOFT_AUTHORITY_HOST + "organizations/";
-    public final static String ARLINGTON_TENANT_SPECIFIC_AUTHORITY = ARLINGTON_MICROSOFT_AUTHORITY_HOST + ARLINGTON_AUTHORITY_TENANT;
-    public final static String ARLINGTON_COMMON_AUTHORITY = ARLINGTON_MICROSOFT_AUTHORITY_HOST + "common/";
-    public final static String ARLINGTON_GRAPH_DEFAULT_SCOPE = "https://graph.microsoft.us/.default";
+    public static final String ARLINGTON_ORGANIZATIONS_AUTHORITY = ARLINGTON_MICROSOFT_AUTHORITY_HOST + "organizations/";
+    public static final String ARLINGTON_TENANT_SPECIFIC_AUTHORITY = ARLINGTON_MICROSOFT_AUTHORITY_HOST + ARLINGTON_AUTHORITY_TENANT;
+    public static final String ARLINGTON_COMMON_AUTHORITY = ARLINGTON_MICROSOFT_AUTHORITY_HOST + "common/";
+    public static final String ARLINGTON_GRAPH_DEFAULT_SCOPE = "https://graph.microsoft.us/.default";
 
-    public final static String B2C_AUTHORITY = "https://msidlabb2c.b2clogin.com/msidlabb2c.onmicrosoft.com/";
-    public final static String B2C_AUTHORITY_LEGACY_FORMAT = "https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/";
+    public static final String B2C_AUTHORITY = "https://msidlabb2c.b2clogin.com/msidlabb2c.onmicrosoft.com/";
+    public static final String B2C_AUTHORITY_LEGACY_FORMAT = "https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/";
 
-    public final static String B2C_ROPC_POLICY = "B2C_1_ROPC_Auth";
-    public final static String B2C_SIGN_IN_POLICY = "B2C_1_SignInPolicy";
-    public final static String B2C_AUTHORITY_SIGN_IN = B2C_AUTHORITY + B2C_SIGN_IN_POLICY;
-    public final static String B2C_AUTHORITY_ROPC = B2C_AUTHORITY + B2C_ROPC_POLICY;
-    public final static String B2C_READ_SCOPE = "https://msidlabb2c.onmicrosoft.com/msidlabb2capi/read";
-    public final static String B2C_MICROSOFTLOGIN_AUTHORITY = "https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/";
-    public final static String B2C_MICROSOFTLOGIN_ROPC = B2C_MICROSOFTLOGIN_AUTHORITY + B2C_ROPC_POLICY;
-    public final static String B2C_UPN = "b2clocal@msidlabb2c.onmicrosoft.com";
+    public static final String B2C_ROPC_POLICY = "B2C_1_ROPC_Auth";
+    public static final String B2C_SIGN_IN_POLICY = "B2C_1_SignInPolicy";
+    public static final String B2C_AUTHORITY_SIGN_IN = B2C_AUTHORITY + B2C_SIGN_IN_POLICY;
+    public static final String B2C_AUTHORITY_ROPC = B2C_AUTHORITY + B2C_ROPC_POLICY;
+    public static final String B2C_READ_SCOPE = "https://msidlabb2c.onmicrosoft.com/msidlabb2capi/read";
+    public static final String B2C_MICROSOFTLOGIN_AUTHORITY = "https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/";
+    public static final String B2C_MICROSOFTLOGIN_ROPC = B2C_MICROSOFTLOGIN_AUTHORITY + B2C_ROPC_POLICY;
+    public static final String B2C_UPN = "b2clocal@msidlabb2c.onmicrosoft.com";
 
-    public final static String LOCALHOST = "http://localhost:";
+    public static final String LOCALHOST = "http://localhost:";
 
-    public final static String ADFS_AUTHORITY = "https://fs.msidlab8.com/adfs/";
-    public final static String ADFS_SCOPE = USER_READ_SCOPE;
-    public final static String ADFS_APP_ID = "PublicClientId";
+    public static final String ADFS_AUTHORITY = "https://fs.msidlab8.com/adfs/";
+    public static final String ADFS_SCOPE = USER_READ_SCOPE;
+    public static final String ADFS_APP_ID = "PublicClientId";
 
-    public final static String AUTHORITY_PUBLIC_TENANT_SPECIFIC = "https://login.microsoftonline.com/" + MICROSOFT_AUTHORITY_TENANT;
+    public static final String AUTHORITY_PUBLIC_TENANT_SPECIFIC = "https://login.microsoftonline.com/" + MICROSOFT_AUTHORITY_TENANT;
 }

--- a/msal4j-sdk/src/integrationtest/java/infrastructure/SeleniumConstants.java
+++ b/msal4j-sdk/src/integrationtest/java/infrastructure/SeleniumConstants.java
@@ -9,41 +9,41 @@ package infrastructure;
 
 public class SeleniumConstants {
     //ADFS v4
-    final static String ADFSV4_WEB_PASSWORD_ID = "passwordInput";
-    final static String ADFSV4_WEB_SUBMIT_ID = "submitButton";
+    static final String ADFSV4_WEB_PASSWORD_ID = "passwordInput";
+    static final String ADFSV4_WEB_SUBMIT_ID = "submitButton";
 
-    final static String WEB_UPN_INPUT_ID = "i0116";
-    final static String WEB_PASSWORD_ID = "i0118";
-    final static String WEB_SUBMIT_ID = "idSIButton9";
+    static final String WEB_UPN_INPUT_ID = "i0116";
+    static final String WEB_PASSWORD_ID = "i0118";
+    static final String WEB_SUBMIT_ID = "idSIButton9";
 
     //ADFS2019
-    final static String ADFS2019_UPN_INPUT_ID = "userNameInput";
-    final static String ADFS2019_PASSWORD_ID = "passwordInput";
-    final static String ADFS2019_SUBMIT_ID = "submitButton";
+    static final String ADFS2019_UPN_INPUT_ID = "userNameInput";
+    static final String ADFS2019_PASSWORD_ID = "passwordInput";
+    static final String ADFS2019_SUBMIT_ID = "submitButton";
 
     //B2C Facebook
-    final static String FACEBOOK_ACCOUNT_ID = "FacebookExchange";
-    final static String FACEBOOK_USERNAME_ID = "email";
-    final static String FACEBOOK_PASSWORD_ID = "pass";
-    final static String FACEBOOK_LOGIN_BUTTON_ID = "loginbutton";
+    static final String FACEBOOK_ACCOUNT_ID = "FacebookExchange";
+    static final String FACEBOOK_USERNAME_ID = "email";
+    static final String FACEBOOK_PASSWORD_ID = "pass";
+    static final String FACEBOOK_LOGIN_BUTTON_ID = "loginbutton";
 
     //B2C Google
-    final static String GOOGLE_ACCOUNT_ID = "GoogleExchange";
-    final static String GOOGLE_USERNAME_ID = "identifierId";
-    final static String GOOGLE_NEXT_AFTER_USERNAME_BUTTON = "identifierNext";
-    final static String GOOGLE_PASSWORD_ID = "password";
-    final static String GOOGLE_NEXT_BUTTON_ID = "passwordNext";
+    static final String GOOGLE_ACCOUNT_ID = "GoogleExchange";
+    static final String GOOGLE_USERNAME_ID = "identifierId";
+    static final String GOOGLE_NEXT_AFTER_USERNAME_BUTTON = "identifierNext";
+    static final String GOOGLE_PASSWORD_ID = "password";
+    static final String GOOGLE_NEXT_BUTTON_ID = "passwordNext";
 
     // B2C Local
-    final static String B2C_LOCAL_ACCOUNT_ID = "SignInWithLogonNameExchange";
-    final static String B2C_LOCAL_USERNAME_ID = "cred_userid_inputtext";
-    final static String B2C_LOCAL_PASSWORD_ID = "cred_password_inputtext";
-    final static String B2C_LOCAL_SIGN_IN_BUTTON_ID = "cred_sign_in_button";
+    static final String B2C_LOCAL_ACCOUNT_ID = "SignInWithLogonNameExchange";
+    static final String B2C_LOCAL_USERNAME_ID = "cred_userid_inputtext";
+    static final String B2C_LOCAL_PASSWORD_ID = "cred_password_inputtext";
+    static final String B2C_LOCAL_SIGN_IN_BUTTON_ID = "cred_sign_in_button";
 
     // Stay signed in?
-    final static String STAY_SIGN_IN_NO_BUTTON_ID = "idBtn_Back";
+    static final String STAY_SIGN_IN_NO_BUTTON_ID = "idBtn_Back";
 
     // Are you trying to sign in to ...
     //Only continue if you downloaded the app from a store or website that you trust.
-    final static String ARE_YOU_TRYING_TO_SIGN_IN_TO = "idSIButton9";
+    static final String ARE_YOU_TRYING_TO_SIGN_IN_TO = "idSIButton9";
 }

--- a/msal4j-sdk/src/integrationtest/java/labapi/LabConstants.java
+++ b/msal4j-sdk/src/integrationtest/java/labapi/LabConstants.java
@@ -4,24 +4,24 @@
 package labapi;
 
 public class LabConstants {
-    public final static String LAB_USER_ENDPOINT = "https://msidlab.com/api/user";
-    public final static String LAB_USER_SECRET_ENDPOINT = "https://msidlab.com/api/LabSecret";
-    public final static String LAB_APP_ENDPOINT = "https://msidlab.com/api/App";
-    public final static String LAB_LAB_ENDPOINT = "https://msidlab.com/api/Lab";
+    public static final String LAB_USER_ENDPOINT = "https://msidlab.com/api/user";
+    public static final String LAB_USER_SECRET_ENDPOINT = "https://msidlab.com/api/LabSecret";
+    public static final String LAB_APP_ENDPOINT = "https://msidlab.com/api/App";
+    public static final String LAB_LAB_ENDPOINT = "https://msidlab.com/api/Lab";
 
-    public final static String APP_ID_KEY_VAULT_SECRET = "https://msidlabs.vault.azure.net/secrets/LabVaultAppID";
-    public final static String APP_PASSWORD_KEY_VAULT_SECRET = "https://msidlabs.vault.azure.net/secrets/LabVaultAppSecret";
-    public final static String USER_MSA_USERNAME_URL = "https://msidlabs.vault.azure.net/secrets/MSA-MSIDLAB4-UserName";
-    public final static String USER_MSA_PASSWORD_URL = "https://msidlabs.vault.azure.net/secrets/MSA-MSIDLAB4-Password";
-    public final static String OBO_APP_PASSWORD_URL = "https://msidlabs.vault.azure.net/secrets/TodoListServiceV2-OBO";
-    public final static String CIAM_KEY_VAULT_SECRET_KEY = "https://msidlabs.vault.azure.net/secrets/MSIDLABCIAM6-cc";
+    public static final String APP_ID_KEY_VAULT_SECRET = "https://msidlabs.vault.azure.net/secrets/LabVaultAppID";
+    public static final String APP_PASSWORD_KEY_VAULT_SECRET = "https://msidlabs.vault.azure.net/secrets/LabVaultAppSecret";
+    public static final String USER_MSA_USERNAME_URL = "https://msidlabs.vault.azure.net/secrets/MSA-MSIDLAB4-UserName";
+    public static final String USER_MSA_PASSWORD_URL = "https://msidlabs.vault.azure.net/secrets/MSA-MSIDLAB4-Password";
+    public static final String OBO_APP_PASSWORD_URL = "https://msidlabs.vault.azure.net/secrets/TodoListServiceV2-OBO";
+    public static final String CIAM_KEY_VAULT_SECRET_KEY = "https://msidlabs.vault.azure.net/secrets/MSIDLABCIAM6-cc";
 
-    public final static String ARLINGTON_APP_ID = "cb7faed4-b8c0-49ee-b421-f5ed16894c83";
-    public final static String ARLINGTON_OBO_APP_ID = "c0555d2d-02f2-4838-802e-3463422e571d";
+    public static final String ARLINGTON_APP_ID = "cb7faed4-b8c0-49ee-b421-f5ed16894c83";
+    public static final String ARLINGTON_OBO_APP_ID = "c0555d2d-02f2-4838-802e-3463422e571d";
 
-    public final static String MSA_APP_ID = "9668f2bd-6103-4292-9024-84fa2d1b6fb2";
+    public static final String MSA_APP_ID = "9668f2bd-6103-4292-9024-84fa2d1b6fb2";
 
-    public final static String ARLINGTON_LAB_NAME = "ARLMSIDLAB1";
-    public final static String GUEST_USER_TYPE = "Guest";
+    public static final String ARLINGTON_LAB_NAME = "ARLMSIDLAB1";
+    public static final String GUEST_USER_TYPE = "Guest";
 
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AADAuthority.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AADAuthority.java
@@ -7,15 +7,15 @@ import java.net.URL;
 
 class AADAuthority extends Authority {
 
-    private final static String TENANTLESS_TENANT_NAME = "common";
-    private final static String AUTHORIZATION_ENDPOINT = "oauth2/v2.0/authorize";
-    private final static String TOKEN_ENDPOINT = "oauth2/v2.0/token";
-    final static String DEVICE_CODE_ENDPOINT = "oauth2/v2.0/devicecode";
+    private static final String TENANTLESS_TENANT_NAME = "common";
+    private static final String AUTHORIZATION_ENDPOINT = "oauth2/v2.0/authorize";
+    private static final String TOKEN_ENDPOINT = "oauth2/v2.0/token";
+    static final String DEVICE_CODE_ENDPOINT = "oauth2/v2.0/devicecode";
 
-    private final static String AAD_AUTHORITY_FORMAT = "https://%s/%s/";
-    private final static String AAD_AUTHORIZATION_ENDPOINT_FORMAT = AAD_AUTHORITY_FORMAT + AUTHORIZATION_ENDPOINT;
-    private final static String AAD_TOKEN_ENDPOINT_FORMAT = AAD_AUTHORITY_FORMAT + TOKEN_ENDPOINT;
-    private final static String DEVICE_CODE_ENDPOINT_FORMAT = AAD_AUTHORITY_FORMAT + DEVICE_CODE_ENDPOINT;
+    private static final String AAD_AUTHORITY_FORMAT = "https://%s/%s/";
+    private static final String AAD_AUTHORIZATION_ENDPOINT_FORMAT = AAD_AUTHORITY_FORMAT + AUTHORIZATION_ENDPOINT;
+    private static final String AAD_TOKEN_ENDPOINT_FORMAT = AAD_AUTHORITY_FORMAT + TOKEN_ENDPOINT;
+    private static final String DEVICE_CODE_ENDPOINT_FORMAT = AAD_AUTHORITY_FORMAT + DEVICE_CODE_ENDPOINT;
 
     AADAuthority(final URL authorityUrl) {
         super(authorityUrl, AuthorityType.AAD);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ADFSAuthority.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ADFSAuthority.java
@@ -7,12 +7,12 @@ import java.net.URL;
 
 class ADFSAuthority extends Authority {
 
-    final static String AUTHORIZATION_ENDPOINT = "oauth2/authorize";
-    final static String TOKEN_ENDPOINT = "oauth2/token";
-    final static String DEVICE_CODE_ENDPOINT = "oauth2/devicecode";
+    static final String AUTHORIZATION_ENDPOINT = "oauth2/authorize";
+    static final String TOKEN_ENDPOINT = "oauth2/token";
+    static final String DEVICE_CODE_ENDPOINT = "oauth2/devicecode";
 
-    private final static String ADFS_AUTHORITY_FORMAT = "https://%s/%s/";
-    private final static String DEVICE_CODE_ENDPOINT_FORMAT = ADFS_AUTHORITY_FORMAT + DEVICE_CODE_ENDPOINT;
+    private static final String ADFS_AUTHORITY_FORMAT = "https://%s/%s/";
+    private static final String DEVICE_CODE_ENDPOINT_FORMAT = ADFS_AUTHORITY_FORMAT + DEVICE_CODE_ENDPOINT;
 
     ADFSAuthority(final URL authorityUrl) {
         super(authorityUrl, AuthorityType.ADFS);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByOnBehalfOfSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByOnBehalfOfSupplier.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 
 class AcquireTokenByOnBehalfOfSupplier extends AuthenticationResultSupplier {
 
-    private final static Logger LOG = LoggerFactory.getLogger(AcquireTokenByOnBehalfOfSupplier.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AcquireTokenByOnBehalfOfSupplier.class);
     private OnBehalfOfRequest onBehalfOfRequest;
 
     AcquireTokenByOnBehalfOfSupplier(ConfidentialClientApplication clientApplication,

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationErrorCode.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationErrorCode.java
@@ -12,91 +12,91 @@ public class AuthenticationErrorCode {
      * In the context of device code user has not yet authenticated via browser. For more details,
      * see https://aka.ms/msal4j-device-code
      */
-    public final static String AUTHORIZATION_PENDING = "authorization_pending";
+    public static final String AUTHORIZATION_PENDING = "authorization_pending";
 
     /**
      * In the context of device code, this error happens when the device code has expired before
      * the user signed-in on another device (this is usually after 15 min). For more details, see
      * https://aka.ms/msal4j-device-code
      */
-    public final static String CODE_EXPIRED = "code_expired";
+    public static final String CODE_EXPIRED = "code_expired";
 
     /**
      * Standard Oauth2 protocol error code. It indicates that the application needs to expose
      * the UI to the user so that user does an interactive action in order to get a new token.
      */
-    public final static String INVALID_GRANT = "invalid_grant";
+    public static final String INVALID_GRANT = "invalid_grant";
 
     /**
      * WS-Trust Endpoint not found in Metadata document
      */
-    public final static String WSTRUST_ENDPOINT_NOT_FOUND_IN_METADATA_DOCUMENT = "wstrust_endpoint_not_found";
+    public static final String WSTRUST_ENDPOINT_NOT_FOUND_IN_METADATA_DOCUMENT = "wstrust_endpoint_not_found";
 
     /**
      * WS-Trust endpoint response did not contain the required fields
      */
-    public final static String WSTRUST_INVALID_RESPONSE = "wstrust_invalid_response";
+    public static final String WSTRUST_INVALID_RESPONSE = "wstrust_invalid_response";
 
     /**
      * WS-Trust request resulted in service error
      */
-    public final static String WSTRUST_SERVICE_ERROR = "wstrust_service_error";
+    public static final String WSTRUST_SERVICE_ERROR = "wstrust_service_error";
 
     /**
      * Password is required for managed user. Will typically happen when trying to do integrated windows authentication
      * for managed users. For more information, see https://aka.ms/msal4j-iwa
      */
-    public final static String PASSWORD_REQUIRED_FOR_MANAGED_USER = "password_required_for_managed_user";
+    public static final String PASSWORD_REQUIRED_FOR_MANAGED_USER = "password_required_for_managed_user";
 
     /**
      * User realm discovery failed
      */
-    public final static String USER_REALM_DISCOVERY_FAILED = "user_realm_discovery_failed";
+    public static final String USER_REALM_DISCOVERY_FAILED = "user_realm_discovery_failed";
 
     /**
      * Not found in the cache
      */
-    public final static String CACHE_MISS = "cache_miss";
+    public static final String CACHE_MISS = "cache_miss";
 
     /**
      * Not able to parse instance discovery metadata. Ensure data is in valid JSON format, and that
      * it contains relevant fields. For more information, see https://aka.ms/msal4j-instance-discovery
      */
-    public final static String INVALID_INSTANCE_DISCOVERY_METADATA = "invalid_instance_discovery_metadata";
+    public static final String INVALID_INSTANCE_DISCOVERY_METADATA = "invalid_instance_discovery_metadata";
 
     /**
      * Unknown error occurred
      */
-    public final static String UNKNOWN = "unknown";
+    public static final String UNKNOWN = "unknown";
 
     /**
      * The current redirect URI is not a loopback URL. To use the OS browser, a loopback URL must be
      * configured both during app registration as well as when initializing the InteractiveRequestParameters
      * object. For more details, see https://aka.ms/msal4j-interactive-request
      */
-    public final static String LOOPBACK_REDIRECT_URI = "loopback_redirect_uri";
+    public static final String LOOPBACK_REDIRECT_URI = "loopback_redirect_uri";
 
     /**
      * Unable to start Http listener to the specified port. This might be because the port is busy.
      */
-    public final static String UNABLE_TO_START_HTTP_LISTENER = "unable_to_start_http_listener";
+    public static final String UNABLE_TO_START_HTTP_LISTENER = "unable_to_start_http_listener";
 
     /**
      * Authorization result response is invalid. Authorization result must contain authorization
      * code and state.
      */
-    public final static String INVALID_AUTHORIZATION_RESULT = "invalid_authorization_result";
+    public static final String INVALID_AUTHORIZATION_RESULT = "invalid_authorization_result";
 
     /**
      * Redirect URI provided to MSAL is of invalid format. Redirect URL must be a loopback URL.
      * For more details, see https://aka.ms/msal4j-interactive-request
      */
-    public final static String INVALID_REDIRECT_URI = "invalid_redirect_uri";
+    public static final String INVALID_REDIRECT_URI = "invalid_redirect_uri";
 
     /**
      * Indicates token endpoint is invalid. Ensure authority and tenant are correctly set, as this endpoint is typically created using those values.
      */
-    public final static String INVALID_ENDPOINT_URI = "invalid_endpoint_uri";
+    public static final String INVALID_ENDPOINT_URI = "invalid_endpoint_uri";
 
     /**
      * MSAL was unable to open the user-default browser. This is either because the current platform
@@ -104,29 +104,29 @@ public class AuthenticationErrorCode {
      * requests require that the client have a system default browser. For more details, see
      * https://aka.ms/msal4j-interactive-request
      */
-    public final static String DESKTOP_BROWSER_NOT_SUPPORTED = "desktop_browser_not_supported";
+    public static final String DESKTOP_BROWSER_NOT_SUPPORTED = "desktop_browser_not_supported";
 
     /**
      * Request was throttled according to instructions from STS.
      */
-    public final static String THROTTLED_REQUEST = "throttled_request";
+    public static final String THROTTLED_REQUEST = "throttled_request";
 
     /**
      * A JSON processing failure, indicating the JSON provided to MSAL is of invalid format.
      */
-    public final static String INVALID_JSON = "invalid_json";
+    public static final String INVALID_JSON = "invalid_json";
 
     /**
      * A JWT parsing failure, indicating the JWT provided to MSAL is of invalid format.
      */
-    public final static String INVALID_JWT = "invalid_jwt";
+    public static final String INVALID_JWT = "invalid_jwt";
 
     /**
      * Indicates that a Broker implementation is missing from the device, such as when an app developer
      * does not include one of our broker packages as a dependency in their project, or otherwise cannot
      * be accessed by MSAL Java
      */
-    public final static String MISSING_BROKER = "missing_broker";
+    public static final String MISSING_BROKER = "missing_broker";
 
     /**
      * Indicates that a timeout occurred during an HTTP call. If this was thrown in relation to a connection timeout error,
@@ -134,18 +134,18 @@ public class AuthenticationErrorCode {
      * If this was thrown in relation to a read timeout error, there is likely an issue in the service itself causing a
      * slow response, and this may be resolvable by increasing timeouts. For more details, see https://aka.ms/msal4j-http-client
      */
-    public final static String HTTP_TIMEOUT = "http_timeout";
+    public static final String HTTP_TIMEOUT = "http_timeout";
 
     /**
      * Indicates an error from the MSAL Java/MSALRuntime interop layer used by the Java Brokers package,
      * and will generally just be forwarding an error message from the interop layer or MSALRuntime itself
      */
-    public final static String MSALRUNTIME_INTEROP_ERROR = "interop_package_error";
+    public static final String MSALRUNTIME_INTEROP_ERROR = "interop_package_error";
 
     /**
      * Indicates an error related to the MSAL Java Brokers package
      */
-    public final static String MSALJAVA_BROKERS_ERROR = "brokers_package_error";
+    public static final String MSALJAVA_BROKERS_ERROR = "brokers_package_error";
 
     /**
      * Indicates that a request to managed identity endpoint failed, see error message for detailed reason and correlation id.

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationErrorMessage.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthenticationErrorMessage.java
@@ -8,5 +8,5 @@ public class AuthenticationErrorMessage {
     /**
      * Token not found in the cache
      */
-    public final static String NO_TOKEN_IN_CACHE = "Token not found in the cache";
+    public static final String NO_TOKEN_IN_CACHE = "Token not found in the cache";
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Authority.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Authority.java
@@ -15,8 +15,8 @@ abstract class Authority {
     private static final String B2C_PATH_SEGMENT = "tfp";
     private static final String B2C_HOST_SEGMENT = "b2clogin.com";
 
-    private final static String USER_REALM_ENDPOINT = "common/userrealm";
-    private final static String userRealmEndpointFormat = "https://%s/" + USER_REALM_ENDPOINT + "/%s?api-version=1.0";
+    private static final String USER_REALM_ENDPOINT = "common/userrealm";
+    private static final String userRealmEndpointFormat = "https://%s/" + USER_REALM_ENDPOINT + "/%s?api-version=1.0";
 
     String authority;
     final URL canonicalAuthorityUrl;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
@@ -18,13 +18,13 @@ import java.util.stream.Collectors;
 
 class AuthorizationResponseHandler implements HttpHandler {
 
-    private final static Logger LOG = LoggerFactory.getLogger(AuthorizationResponseHandler.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AuthorizationResponseHandler.class);
 
-    private final static String DEFAULT_SUCCESS_MESSAGE = "<html><head><title>Authentication Complete</title></head>" +
+    private static final String DEFAULT_SUCCESS_MESSAGE = "<html><head><title>Authentication Complete</title></head>" +
             "  <body> Authentication complete. You can close the browser and return to the application." +
             "  </body></html>";
 
-    private final static String DEFAULT_FAILURE_MESSAGE = "<html><head><title>Authentication Failed</title></head> " +
+    private static final String DEFAULT_FAILURE_MESSAGE = "<html><head><title>Authentication Failed</title></head> " +
             "<body> Authentication failed. You can return to the application. Feel free to close this browser tab. " +
             "</br></br></br></br> Error details: error {0} error_description: {1} </body> </html>";
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/B2CAuthority.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/B2CAuthority.java
@@ -7,11 +7,11 @@ import java.net.URL;
 
 class B2CAuthority extends Authority {
 
-    private final static String AUTHORIZATION_ENDPOINT = "/oauth2/v2.0/authorize";
-    private final static String TOKEN_ENDPOINT = "/oauth2/v2.0/token";
+    private static final String AUTHORIZATION_ENDPOINT = "/oauth2/v2.0/authorize";
+    private static final String TOKEN_ENDPOINT = "/oauth2/v2.0/token";
 
-    private final static String B2C_AUTHORIZATION_ENDPOINT_FORMAT = "https://%s/%s/%s" + AUTHORIZATION_ENDPOINT;
-    private final static String B2C_TOKEN_ENDPOINT_FORMAT = "https://%s/%s" + TOKEN_ENDPOINT + "?p=%s";
+    private static final String B2C_AUTHORIZATION_ENDPOINT_FORMAT = "https://%s/%s/%s" + AUTHORIZATION_ENDPOINT;
+    private static final String B2C_TOKEN_ENDPOINT_FORMAT = "https://%s/%s" + TOKEN_ENDPOINT + "?p=%s";
     private String policy;
 
     B2CAuthority(final URL authorityUrl) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DefaultEvent.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DefaultEvent.java
@@ -7,11 +7,11 @@ import java.util.Map;
 
 class DefaultEvent extends Event {
 
-    private final static String CLIENT_ID_KEY = TelemetryConstants.EVENT_NAME_PREFIX + "client_id";
-    private final static String SDK_PLATFORM_KEY = TelemetryConstants.EVENT_NAME_PREFIX + "sdk_platform";
-    private final static String SDK_VERSION_KEY = TelemetryConstants.EVENT_NAME_PREFIX + "sdk_version";
-    private final static String HTTP_EVENT_COUNT_KEY = TelemetryConstants.EVENT_NAME_PREFIX + "http_event_count";
-    private final static String CACHE_EVENT_COUNT_KEY = TelemetryConstants.EVENT_NAME_PREFIX + "cache_event_count";
+    private static final String CLIENT_ID_KEY = TelemetryConstants.EVENT_NAME_PREFIX + "client_id";
+    private static final String SDK_PLATFORM_KEY = TelemetryConstants.EVENT_NAME_PREFIX + "sdk_platform";
+    private static final String SDK_VERSION_KEY = TelemetryConstants.EVENT_NAME_PREFIX + "sdk_version";
+    private static final String HTTP_EVENT_COUNT_KEY = TelemetryConstants.EVENT_NAME_PREFIX + "http_event_count";
+    private static final String CACHE_EVENT_COUNT_KEY = TelemetryConstants.EVENT_NAME_PREFIX + "cache_event_count";
     private Map<String, Integer> eventCount;
 
     public DefaultEvent(String clientId, Map<String, Integer> eventCount) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Event.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Event.java
@@ -14,11 +14,11 @@ import java.util.Map;
 
 abstract class Event extends HashMap<String, String> {
 
-    final static String EVENT_NAME_KEY = "event_name";
-    final static String START_TIME_KEY = "start_time";
-    final static String ELAPSED_TIME_KEY = "elapsed_time";
-    private final static String TENANT_PLACEHOLDER = "<tenant>";
-    private final static String USERNAME_PLACEHOLDER = "<user>";
+    static final String EVENT_NAME_KEY = "event_name";
+    static final String START_TIME_KEY = "start_time";
+    static final String ELAPSED_TIME_KEY = "elapsed_time";
+    private static final String TENANT_PLACEHOLDER = "<tenant>";
+    private static final String USERNAME_PLACEHOLDER = "<user>";
 
     private long startTimeStamp;
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpEvent.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpEvent.java
@@ -10,18 +10,18 @@ import java.util.Locale;
 import static com.microsoft.aad.msal4j.TelemetryConstants.EVENT_NAME_PREFIX;
 
 class HttpEvent extends Event {
-    private final static String HTTP_PATH_KEY = EVENT_NAME_PREFIX + "http_path";
-    private final static String USER_AGENT_KEY = EVENT_NAME_PREFIX + "user_agent";
-    private final static String QUERY_PARAMETERS_KEY = EVENT_NAME_PREFIX + "query_parameters";
-    private final static String API_VERSION_KEY = EVENT_NAME_PREFIX + "api_version";
-    private final static String RESPONSE_CODE_KEY = EVENT_NAME_PREFIX + "response_code";
-    private final static String OAUTH_ERROR_CODE_KEY = EVENT_NAME_PREFIX + "oauth_error_code";
-    private final static String HTTP_METHOD_KEY = EVENT_NAME_PREFIX + "http_method";
-    private final static String REQUEST_ID_HEADER_KEY = EVENT_NAME_PREFIX + "request_id_header";
-    private final static String TOKEN_AGEN_KEY = EVENT_NAME_PREFIX + "token_age";
-    private final static String SPE_INFO_KEY = EVENT_NAME_PREFIX + "spe_info";
-    private final static String SERVER_ERROR_CODE_KEY = EVENT_NAME_PREFIX + "server_error_code";
-    private final static String SERVER_SUB_ERROR_CODE_KEY = EVENT_NAME_PREFIX + "server_sub_error_code";
+    private static final String HTTP_PATH_KEY = EVENT_NAME_PREFIX + "http_path";
+    private static final String USER_AGENT_KEY = EVENT_NAME_PREFIX + "user_agent";
+    private static final String QUERY_PARAMETERS_KEY = EVENT_NAME_PREFIX + "query_parameters";
+    private static final String API_VERSION_KEY = EVENT_NAME_PREFIX + "api_version";
+    private static final String RESPONSE_CODE_KEY = EVENT_NAME_PREFIX + "response_code";
+    private static final String OAUTH_ERROR_CODE_KEY = EVENT_NAME_PREFIX + "oauth_error_code";
+    private static final String HTTP_METHOD_KEY = EVENT_NAME_PREFIX + "http_method";
+    private static final String REQUEST_ID_HEADER_KEY = EVENT_NAME_PREFIX + "request_id_header";
+    private static final String TOKEN_AGEN_KEY = EVENT_NAME_PREFIX + "token_age";
+    private static final String SPE_INFO_KEY = EVENT_NAME_PREFIX + "spe_info";
+    private static final String SERVER_ERROR_CODE_KEY = EVENT_NAME_PREFIX + "server_error_code";
+    private static final String SERVER_SUB_ERROR_CODE_KEY = EVENT_NAME_PREFIX + "server_sub_error_code";
 
     HttpEvent() {
         super(TelemetryConstants.HTTP_EVENT_NAME_KEY);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpListener.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpListener.java
@@ -13,7 +13,7 @@ import java.net.InetSocketAddress;
 
 class HttpListener {
 
-    private final static Logger LOG = LoggerFactory.getLogger(HttpListener.class);
+    private static final Logger LOG = LoggerFactory.getLogger(HttpListener.class);
 
     private HttpServer server;
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IllegalArgumentExceptionMessages.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IllegalArgumentExceptionMessages.java
@@ -5,10 +5,10 @@ package com.microsoft.aad.msal4j;
 
 class IllegalArgumentExceptionMessages {
 
-    final static String AUTHORITY_URI_EMPTY_PATH_SEGMENT = "Authority Uri should not have empty path segments";
+    static final String AUTHORITY_URI_EMPTY_PATH_SEGMENT = "Authority Uri should not have empty path segments";
 
-    final static String AUTHORITY_URI_MISSING_PATH_SEGMENT = "Authority Uri must have at least one path segment. This is usually 'common' or the application's tenant id.";
+    static final String AUTHORITY_URI_MISSING_PATH_SEGMENT = "Authority Uri must have at least one path segment. This is usually 'common' or the application's tenant id.";
 
-    final static String AUTHORITY_URI_EMPTY_PATH = "Authority Uri should have at least one segment in the path";
+    static final String AUTHORITY_URI_EMPTY_PATH = "Authority Uri should have at least one segment in the path";
 
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MexParser.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MexParser.java
@@ -23,7 +23,7 @@ import org.w3c.dom.NodeList;
 
 class MexParser {
 
-    private final static Logger log = LoggerFactory.getLogger(MexParser.class);
+    private static final Logger log = LoggerFactory.getLogger(MexParser.class);
 
     private static final String TRANSPORT_BINDING_XPATH = "wsp:ExactlyOne/wsp:All/sp:TransportBinding";
     private static final String TRANSPORT_BINDING_2005_XPATH = "wsp:ExactlyOne/wsp:All/sp2005:TransportBinding";

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/NamespaceContextImpl.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/NamespaceContextImpl.java
@@ -11,7 +11,7 @@ import javax.xml.namespace.NamespaceContext;
 
 class NamespaceContextImpl implements NamespaceContext {
 
-    private final static Map<String, String> PREF_MAP = new HashMap<>();
+    private static final Map<String, String> PREF_MAP = new HashMap<>();
     static {
         PREF_MAP.put("wsdl", "http://schemas.xmlsoap.org/wsdl/");
         PREF_MAP.put("sp",

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ServerSideTelemetry.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ServerSideTelemetry.java
@@ -14,15 +14,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 class ServerSideTelemetry {
 
-    private final static Logger log = LoggerFactory.getLogger(ServerSideTelemetry.class);
+    private static final Logger log = LoggerFactory.getLogger(ServerSideTelemetry.class);
 
-    private final static String SCHEMA_VERSION = "5";
-    private final static String SCHEMA_PIPE_DELIMITER = "|";
-    private final static String SCHEMA_COMMA_DELIMITER = ",";
-    private final static String CURRENT_REQUEST_HEADER_NAME = "x-client-current-telemetry";
-    private final static String LAST_REQUEST_HEADER_NAME = "x-client-last-telemetry";
-    private final static int CURRENT_REQUEST_MAX_SIZE = 100;
-    private final static int LAST_REQUEST_MAX_SIZE = 350;
+    private static final String SCHEMA_VERSION = "5";
+    private static final String SCHEMA_PIPE_DELIMITER = "|";
+    private static final String SCHEMA_COMMA_DELIMITER = ",";
+    private static final String CURRENT_REQUEST_HEADER_NAME = "x-client-current-telemetry";
+    private static final String LAST_REQUEST_HEADER_NAME = "x-client-last-telemetry";
+    private static final int CURRENT_REQUEST_MAX_SIZE = 100;
+    private static final int LAST_REQUEST_MAX_SIZE = 350;
 
     private CurrentRequest currentRequest;
     private AtomicInteger silentSuccessfulCount = new AtomicInteger(0);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TelemetryConstants.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TelemetryConstants.java
@@ -4,9 +4,9 @@
 package com.microsoft.aad.msal4j;
 
 class TelemetryConstants {
-    final static String EVENT_NAME_PREFIX = "msal.";
-    final static String DEFAULT_EVENT_NAME_KEY = EVENT_NAME_PREFIX + "default_event";
-    final static String API_EVENT_NAME_KEY = EVENT_NAME_PREFIX + "api_event";
-    final static String HTTP_EVENT_NAME_KEY = EVENT_NAME_PREFIX + "http_event";
-    final static String CACHE_EVENT_NAME_KEY = EVENT_NAME_PREFIX + "cache_event";
+    static final String EVENT_NAME_PREFIX = "msal.";
+    static final String DEFAULT_EVENT_NAME_KEY = EVENT_NAME_PREFIX + "default_event";
+    static final String API_EVENT_NAME_KEY = EVENT_NAME_PREFIX + "api_event";
+    static final String HTTP_EVENT_NAME_KEY = EVENT_NAME_PREFIX + "http_event";
+    static final String CACHE_EVENT_NAME_KEY = EVENT_NAME_PREFIX + "cache_event";
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/WSTrustRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/WSTrustRequest.java
@@ -14,8 +14,8 @@ import java.util.UUID;
 
 class WSTrustRequest {
 
-    private final static int MAX_EXPECTED_MESSAGE_SIZE = 1024;
-    final static String DEFAULT_APPLIES_TO = "urn:federation:MicrosoftOnline";
+    private static final int MAX_EXPECTED_MESSAGE_SIZE = 1024;
+    static final String DEFAULT_APPLIES_TO = "urn:federation:MicrosoftOnline";
 
     static WSTrustResponse execute(String username,
                                    String password,

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/XmsClientTelemetryInfo.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/XmsClientTelemetryInfo.java
@@ -8,11 +8,11 @@ import java.util.regex.Pattern;
 
 class XmsClientTelemetryInfo {
 
-    private final static String EXPECTED_HEADER_VERSION = "1";
-    private final static int ERROR_CODE_INDEX = 1;
-    private final static int SUB_ERROR_CODE_INDEX = 2;
-    private final static int TOKEN_AGE_INDEX = 3;
-    private final static int SPE_INFO_INDEX = 4;
+    private static final String EXPECTED_HEADER_VERSION = "1";
+    private static final int ERROR_CODE_INDEX = 1;
+    private static final int SUB_ERROR_CODE_INDEX = 2;
+    private static final int TOKEN_AGE_INDEX = 3;
+    private static final int SPE_INFO_INDEX = 4;
 
     private String serverErrorCode;
     private String serverSubErrorCode;

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestConfiguration.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TestConfiguration.java
@@ -5,34 +5,34 @@ package com.microsoft.aad.msal4j;
 
 public final class TestConfiguration {
 
-    public final static String AAD_HOST_NAME = "login.windows.net";
-    public final static String AAD_TENANT_NAME = "aaltests.onmicrosoft.com";
-    public final static String AAD_TENANT_ENDPOINT = "https://" + AAD_HOST_NAME
+    public static final String AAD_HOST_NAME = "login.windows.net";
+    public static final String AAD_TENANT_NAME = "aaltests.onmicrosoft.com";
+    public static final String AAD_TENANT_ENDPOINT = "https://" + AAD_HOST_NAME
             + "/" + AAD_TENANT_NAME + "/";
-    public final static String AAD_CLIENT_ID = "9083ccb8-8a46-43e7-8439-1d696df984ae";
-    public final static String AAD_CLIENT_DUMMYSECRET = "client_dummysecret";
-    public final static String AAD_MEX_RESPONSE_FILE = "/mex-response.xml";
-    public final static String AAD_MEX_RESPONSE_FILE_INTEGRATED = "/mex-response-integrated.xml";
-    public final static String AAD_MEX_2005_RESPONSE_FILE = "/mex-2005-response.xml";
-    public final static String AAD_TOKEN_SUCCESS_FILE = "/token.xml";
-    public final static String AAD_DEFAULT_REDIRECT_URI = "https://non_existing_uri.windows.com/";
-    public final static String AAD_COMMON_AUTHORITY = "https://login.microsoftonline.com/common/";
+    public static final String AAD_CLIENT_ID = "9083ccb8-8a46-43e7-8439-1d696df984ae";
+    public static final String AAD_CLIENT_DUMMYSECRET = "client_dummysecret";
+    public static final String AAD_MEX_RESPONSE_FILE = "/mex-response.xml";
+    public static final String AAD_MEX_RESPONSE_FILE_INTEGRATED = "/mex-response-integrated.xml";
+    public static final String AAD_MEX_2005_RESPONSE_FILE = "/mex-2005-response.xml";
+    public static final String AAD_TOKEN_SUCCESS_FILE = "/token.xml";
+    public static final String AAD_DEFAULT_REDIRECT_URI = "https://non_existing_uri.windows.com/";
+    public static final String AAD_COMMON_AUTHORITY = "https://login.microsoftonline.com/common/";
 
-    public final static String ADFS_HOST_NAME = "fs.ade2eadfs30.com";
-    public final static String ADFS_TENANT_ENDPOINT = "https://"
+    public static final String ADFS_HOST_NAME = "fs.ade2eadfs30.com";
+    public static final String ADFS_TENANT_ENDPOINT = "https://"
             + ADFS_HOST_NAME + "/adfs/";
 
-    public final static String B2C_HOST_NAME = "msidlabb2c.b2clogin.com";
-    public final static String B2C_SIGN_IN_POLICY = "B2C_1_SignInPolicy";
-    public final static String B2C_AUTHORITY = "https://" + B2C_HOST_NAME +
+    public static final String B2C_HOST_NAME = "msidlabb2c.b2clogin.com";
+    public static final String B2C_SIGN_IN_POLICY = "B2C_1_SignInPolicy";
+    public static final String B2C_AUTHORITY = "https://" + B2C_HOST_NAME +
             "/tfp/msidlabb2c.onmicrosoft.com/" + B2C_SIGN_IN_POLICY;
 
-    public final static String B2C_AUTHORITY_ENDPOINT = "https://" + B2C_HOST_NAME +
+    public static final String B2C_AUTHORITY_ENDPOINT = "https://" + B2C_HOST_NAME +
             "/msidlabb2c.onmicrosoft.com";
-    public final static String B2C_AUTHORITY_CUSTOM_PORT = "https://login.microsoftonline.in:444/tfp/tenant/policy";
-    public final static String B2C_AUTHORITY_CUSTOM_PORT_TAIL_SLASH = "https://login.microsoftonline.in:444/tfp/tenant/policy/";
+    public static final String B2C_AUTHORITY_CUSTOM_PORT = "https://login.microsoftonline.in:444/tfp/tenant/policy";
+    public static final String B2C_AUTHORITY_CUSTOM_PORT_TAIL_SLASH = "https://login.microsoftonline.in:444/tfp/tenant/policy/";
 
-    public final static String TOKEN_ENDPOINT_OK_RESPONSE_ID_AND_ACCESS = "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6I"
+    public static final String TOKEN_ENDPOINT_OK_RESPONSE_ID_AND_ACCESS = "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6I"
             + "k5HVEZ2ZEstZnl0aEV1THdqcHdBSk9NOW4tQSJ9.eyJhdWQiOiJiN2E2NzFkOC1hNDA4LTQyZmYtODZlMC1hYWY0NDdmZDE3YzQiLCJpc3MiOiJod"
             + "HRwczovL3N0cy53aW5kb3dzLm5ldC8zMGJhYTY2Ni04ZGY4LTQ4ZTctOTdlNi03N2NmZDA5OTU5NjMvIiwiaWF0IjoxMzkzODQ0NTA0LCJuYmYiOj"
             + "EzOTM4NDQ1MDQsImV4cCI6MTM5Mzg0ODQwNCwidmVyIjoiMS4wIiwidGlkIjoiMzBiYWE2NjYtOGRmOC00OGU3LTk3ZTYtNzdjZmQwOTk1OTYzIiwi"
@@ -55,7 +55,7 @@ public final class TestConfiguration {
             "WQiOiI5ZjQ4ODBkOC04MGJhLTRjNDAtOTdiYy1mN2EyM2M3MDMwODQiLCJ1dGlkIjoiZjY0NWFkOTItZTM4ZC00ZDFhLWI1MTAtZDFiMDlhNzRhOGNhIn0\"" +
             "}";
 
-    public final static String TOKEN_ENDPOINT_OK_RESPONSE_ACCESS_ONLY = "{\"token_type\":\"Bearer\",\"expires_in\":3600," +
+    public static final String TOKEN_ENDPOINT_OK_RESPONSE_ACCESS_ONLY = "{\"token_type\":\"Bearer\",\"expires_in\":3600," +
             "\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik5HVEZ2ZEstZnl0aEV1THdqcHdBSk9NOW4tQSJ9" +
             ".eyJhdWQiOiJiN2E2NzFkOC1hNDA4LTQyZmYtODZlMC1hYWY0NDdmZDE3YzQiLCJpc3MiOiJodRwczovL3N0cy53aW5kb3dzLm5ldC8" +
             "zMGJhYTY2Ni04ZGY4LTQ4ZTctOTdlNi03N2NmZDA5OTU5NjMvIiwiaWF0IjoxMzkzODQ0NTA0LCJuYmYiOjEzOTM4NDQ1MDQsImV4cC" +
@@ -70,12 +70,12 @@ public final class TestConfiguration {
             "b3bVLLrtQaZjkQ1yn37ngJro8NR63EbHHjHTA9lRmf8KIQ\"" +
             "}";
 
-    public final static String HTTP_ERROR_RESPONSE = "{\"error\":\"invalid_request\",\"error_description\":\"AADSTS90011: Request "
+    public static final String HTTP_ERROR_RESPONSE = "{\"error\":\"invalid_request\",\"error_description\":\"AADSTS90011: Request "
             + "is ambiguous, multiple application identifiers found. Application identifiers: 'd09bb6da-4d46-4a16-880c-7885d8291fb9"
             + ", 216ef81d-f3b2-47d4-ad21-a4df49b56dee'.\r\nTrace ID: 428a1f68-767d-4a1c-ae8e-f710eeaf4e9b\r\nCorrelation ID: 1e0955"
             + "88-68e4-4bb4-a54e-71ad81e7f013\r\nTimestamp: 2014-03-11 20:19:02Z\"}";
 
-    public final static String TOKEN_ENDPOINT_INVALID_GRANT_ERROR_RESPONSE = "{\"error\":\"invalid_grant\"," +
+    public static final String TOKEN_ENDPOINT_INVALID_GRANT_ERROR_RESPONSE = "{\"error\":\"invalid_grant\"," +
             "\"error_description\":\"AADSTS65001: description\\r\\nCorrelation ID: 3a...5a\\r\\nTimestamp:2017-07-15 02:35:05Z\"," +
             "\"error_codes\":[50076]," +
             "\"timestamp\":\"2017-07-15 02:35:05Z\"," +
@@ -83,10 +83,10 @@ public final class TestConfiguration {
             "\"correlation_id\":\"3a...95a\"," +
             "\"suberror\":\"basic_action\"}";
 
-    public final static String CLAIMS_REQUEST = "{\"id_token\":{\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\",\"urn:mace:incommon:iap:bronze\"]},\"sub\":{\"essential\":true,\"value\":\"248289761001\"},\"auth_time\":{}},\"access_token\":{\"given_name\":{\"essential\":true},\"email\":null}}";
-    public final static String CLAIMS_CHALLENGE = "{\"access_token\":{\"nbf\":{\"essential\":true,\"value\":\"1701477303\"}}}";
-    public final static String CLIENT_CAPABILITIES = "{\"access_token\":{\"xms_cc\":{\"values\":[\"cp1\"]}}}";
-    public final static String MERGED_CLAIMS_AND_CAPABILITIES = "{\"access_token\":{\"nbf\":{\"value\":\"1701477303\",\"essential\":true},\"xms_cc\":{\"values\":[\"cp1\"]}}}";
-    public final static String MERGED_CLAIMS_AND_CHALLENGE = "{\"access_token\":{\"nbf\":{\"value\":\"1701477303\",\"essential\":true}}}";
-    public final static String MERGED_CLAIMS_CAPABILITIES_AND_CHALLENGE = "{\"access_token\":{\"nbf\":{\"value\":\"1701477303\",\"essential\":true},\"xms_cc\":{\"values\":[\"cp1\"]}}}";
+    public static final String CLAIMS_REQUEST = "{\"id_token\":{\"acr\":{\"values\":[\"urn:mace:incommon:iap:silver\",\"urn:mace:incommon:iap:bronze\"]},\"sub\":{\"essential\":true,\"value\":\"248289761001\"},\"auth_time\":{}},\"access_token\":{\"given_name\":{\"essential\":true},\"email\":null}}";
+    public static final String CLAIMS_CHALLENGE = "{\"access_token\":{\"nbf\":{\"essential\":true,\"value\":\"1701477303\"}}}";
+    public static final String CLIENT_CAPABILITIES = "{\"access_token\":{\"xms_cc\":{\"values\":[\"cp1\"]}}}";
+    public static final String MERGED_CLAIMS_AND_CAPABILITIES = "{\"access_token\":{\"nbf\":{\"value\":\"1701477303\",\"essential\":true},\"xms_cc\":{\"values\":[\"cp1\"]}}}";
+    public static final String MERGED_CLAIMS_AND_CHALLENGE = "{\"access_token\":{\"nbf\":{\"value\":\"1701477303\",\"essential\":true}}}";
+    public static final String MERGED_CLAIMS_CAPABILITIES_AND_CHALLENGE = "{\"access_token\":{\"nbf\":{\"value\":\"1701477303\",\"essential\":true},\"xms_cc\":{\"values\":[\"cp1\"]}}}";
 }


### PR DESCRIPTION
Certain Java conventions suggest "static final" as the ordering of keywords when making a constant, rather than "final static". 

SonarQube considered this a minor issue, and as this PR shows it was quite common in the codebase.

Although this PR affects a lot of files it's the exact same change in each one, and should not affect the behavior of the library in any way.