### PR TITLE
Fix minor issues found by SonarQube

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
@@ -38,8 +38,6 @@ class AadInstanceDiscoveryProvider {
 
     private static final Logger log = LoggerFactory.getLogger(AadInstanceDiscoveryProvider.class);
 
-    //flag to check if instance discovery has failed
-    private static boolean instanceDiscoveryFailed = false;
     static ConcurrentHashMap<String, InstanceDiscoveryMetadataEntry> cache = new ConcurrentHashMap<>();
 
     static {
@@ -50,8 +48,8 @@ class AadInstanceDiscoveryProvider {
                 "login.microsoftonline.us"));
 
         TRUSTED_HOSTS_SET.addAll(Arrays.asList(
+                DEFAULT_TRUSTED_HOST,
                 "login.windows.net",
-                "login.microsoftonline.com",
                 "login.microsoft.com",
                 "sts.windows.net"));
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractMsalAuthorizationGrant.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AbstractMsalAuthorizationGrant.java
@@ -4,7 +4,6 @@
 package com.microsoft.aad.msal4j;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AccountsSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AccountsSupplier.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import java.net.URL;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.function.Supplier;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByAppProviderSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByAppProviderSupplier.java
@@ -31,7 +31,7 @@ class AcquireTokenByAppProviderSupplier extends AuthenticationResultSupplier {
         }
 
         if (tokenProviderResult.getExpiresInSeconds() == 0 || tokenProviderResult.getExpiresInSeconds() < 0) {
-            handleInvalidExternalValueError(Long.valueOf(tokenProviderResult.getExpiresInSeconds()).toString());
+            handleInvalidExternalValueError(Long.toString(tokenProviderResult.getExpiresInSeconds()));
         }
 
         if (null == tokenProviderResult.getTenantId() || tokenProviderResult.getTenantId().isEmpty()) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByAuthorizationGrantSupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByAuthorizationGrantSupplier.java
@@ -6,9 +6,7 @@ package com.microsoft.aad.msal4j;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 class AcquireTokenByAuthorizationGrantSupplier extends AuthenticationResultSupplier {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByManagedIdentitySupplier.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AcquireTokenByManagedIdentitySupplier.java
@@ -104,7 +104,7 @@ class AcquireTokenByManagedIdentitySupplier extends AuthenticationResultSupplier
         }
     }
 
-    private AuthenticationResult fetchNewAccessTokenAndSaveToCache(TokenRequestExecutor tokenRequestExecutor, CacheRefreshReason cacheRefreshReason) throws Exception {
+    private AuthenticationResult fetchNewAccessTokenAndSaveToCache(TokenRequestExecutor tokenRequestExecutor, CacheRefreshReason cacheRefreshReason) {
 
         ManagedIdentityClient managedIdentityClient = new ManagedIdentityClient(msalRequest, tokenRequestExecutor.getServiceBundle());
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AppServiceManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AppServiceManagedIdentitySource.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.HashMap;
 
 class AppServiceManagedIdentitySource extends AbstractManagedIdentitySource{

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Authority.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Authority.java
@@ -111,7 +111,7 @@ abstract class Authority {
 
         final String path = authorityUrl.getPath();
 
-        if (path.length() == 0) {
+        if (path.isEmpty()) {
             throw new IllegalArgumentException(
                     IllegalArgumentExceptionMessages.AUTHORITY_URI_EMPTY_PATH);
         }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeRequest.java
@@ -3,9 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 class AuthorizationCodeRequest extends MsalRequest {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
@@ -78,7 +78,7 @@ public class AuthorizationRequestUrlParameters {
             requestParameters.put("claims", claimsParam);
         }
 
-        if (builder.claimsChallenge != null && builder.claimsChallenge.trim().length() > 0) {
+        if (builder.claimsChallenge != null && !builder.claimsChallenge.trim().isEmpty()) {
             JsonHelper.validateJsonFormat(builder.claimsChallenge);
             requestParameters.put("claims", builder.claimsChallenge);
         }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationResponseHandler.java
@@ -13,6 +13,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.BlockingQueue;
 import java.util.stream.Collectors;
 
@@ -96,7 +97,7 @@ class AuthorizationResponseHandler implements HttpHandler {
     }
 
     private void send200Response(HttpExchange httpExchange, String response) throws IOException {
-        byte[] responseBytes = response.getBytes("UTF-8");
+        byte[] responseBytes = response.getBytes(StandardCharsets.UTF_8);
         httpExchange.getResponseHeaders().set("Content-Type", "text/html; charset=UTF-8");
         httpExchange.sendResponseHeaders(HttpStatus.HTTP_OK, responseBytes.length);
         OutputStream os = httpExchange.getResponseBody();

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCertificate.java
@@ -56,7 +56,7 @@ final class ClientCertificate implements IClientCertificate {
     }
 
     static ClientCertificate create(InputStream pkcs12Certificate, String password)
-            throws KeyStoreException, NoSuchProviderException, NoSuchAlgorithmException,
+            throws KeyStoreException, NoSuchAlgorithmException,
             CertificateException, IOException, UnrecoverableKeyException {
         // treat null password as default one - empty string
         if (password == null) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCredentialFactory.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCredentialFactory.java
@@ -73,7 +73,7 @@ public class ClientCredentialFactory {
      * @return {@link ClientCertificate}
      */
     public static IClientCertificate createFromCertificateChain(PrivateKey key, List<X509Certificate> publicKeyCertificateChain) {
-        if (key == null || publicKeyCertificateChain == null || publicKeyCertificateChain.size() == 0) {
+        if (key == null || publicKeyCertificateChain == null || publicKeyCertificateChain.isEmpty()) {
             throw new IllegalArgumentException("null or empty input parameter");
         }
         return new ClientCertificate(key, publicKeyCertificateChain);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCredentialRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCredentialRequest.java
@@ -3,9 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CloudShellManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/CloudShellManagedIdentitySource.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.HashMap;
 
 class CloudShellManagedIdentitySource extends AbstractManagedIdentitySource{

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Constants.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Constants.java
@@ -36,5 +36,4 @@ final class Constants {
         add(ManagedIdentitySourceType.SERVICE_FABRIC);
     }};
 
-    static final String REFRESH_REASON_LOG_MESSAGE = "Refreshing access token. Cache refresh reason: %s";
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Constants.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Constants.java
@@ -36,4 +36,5 @@ final class Constants {
         add(ManagedIdentitySourceType.SERVICE_FABRIC);
     }};
 
+    static final String REFRESH_REASON_LOG_MESSAGE = "Refreshing access token. Cache refresh reason: %s";
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Event.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/Event.java
@@ -4,11 +4,7 @@
 package com.microsoft.aad.msal4j;
 
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/HttpResponse.java
@@ -3,10 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import com.azure.json.JsonProviders;
-import com.azure.json.JsonReader;
-
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IApplicationBase.java
@@ -4,9 +4,7 @@
 package com.microsoft.aad.msal4j;
 
 import javax.net.ssl.SSLSocketFactory;
-import java.net.MalformedURLException;
 import java.net.Proxy;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Base interface representing a client application that can acquire tokens from the Microsoft identity platform.

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IClientApplicationBase.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IClientApplicationBase.java
@@ -3,9 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
-import javax.net.ssl.SSLSocketFactory;
 import java.net.MalformedURLException;
-import java.net.Proxy;
 import java.net.URL;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IMDSManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IMDSManagedIdentitySource.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.HashMap;
 
 class IMDSManagedIdentitySource extends AbstractManagedIdentitySource{

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthorizationGrant.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthorizationGrant.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityApplication.java
@@ -88,7 +88,6 @@ public class ManagedIdentityApplication extends AbstractApplicationBase implemen
 
     public static class Builder extends AbstractApplicationBase.Builder<Builder> {
 
-        private String resource;
         private ManagedIdentityId managedIdentityId;
         private List<String> clientCapabilities;
 
@@ -99,8 +98,16 @@ public class ManagedIdentityApplication extends AbstractApplicationBase implemen
             this.managedIdentityId = managedIdentityId;
         }
 
+        /**
+         * @deprecated This method has no effect as the resource field is not used in the ManagedIdentityApplication itself.
+         * Use {@link ManagedIdentityParameters#builder(String)} to set the resource when calling
+         * {@link ManagedIdentityApplication#acquireTokenForManagedIdentity(ManagedIdentityParameters)}.
+         *
+         * @param resource Resource to access (unused)
+         * @return instance of Builder of ManagedIdentityApplication
+         */
+        @Deprecated
         public Builder resource(String resource) {
-            this.resource = resource;
             return self();
         }
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityClient.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityClient.java
@@ -10,7 +10,6 @@ import org.slf4j.LoggerFactory;
  * Class to initialize a managed identity and identify the service.
  */
 class ManagedIdentityClient {
-    private static final Logger LOG = LoggerFactory.getLogger(ManagedIdentityClient.class);
 
     static ManagedIdentitySourceType getManagedIdentitySource() {
         IEnvironmentVariables environmentVariables = AbstractManagedIdentitySource.getEnvironmentVariables();

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityRequest.java
@@ -10,7 +10,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -98,7 +97,7 @@ class ManagedIdentityRequest extends MsalRequest {
                 // Add client capabilities as a comma separated string for all the values in client capabilities
                 String clientCapabilities = String.join(",", managedIdentityApplication.getClientCapabilities());
 
-                queryParameters.put(Constants.CLIENT_CAPABILITY_REQUEST_PARAM, clientCapabilities.toString());
+                queryParameters.put(Constants.CLIENT_CAPABILITY_REQUEST_PARAM, clientCapabilities);
             }
 
             // Pass the token revocation parameter if the claims are present and there is a token to revoke

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityResponse.java
@@ -14,8 +14,6 @@ import java.io.IOException;
 
 class ManagedIdentityResponse implements JsonSerializable<ManagedIdentityResponse> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ManagedIdentityResponse.class);
-
     String tokenType;
     String accessToken;
     String expiresOn;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MexParser.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MexParser.java
@@ -10,7 +10,6 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import java.io.ByteArrayInputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.Map.Entry;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfRequest.java
@@ -3,9 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 class OnBehalfOfRequest extends MsalRequest {
 

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/PublicClientApplication.java
@@ -214,13 +214,12 @@ public class PublicClientApplication extends AbstractClientApplicationBase imple
 
         //Check if broker-only parameters are being used when a broker is not enabled. If they are, either throw an
         // exception saying a broker is required, or provide a clear log message saying the parameter will be ignored
-        if (!brokerEnabled) {
-            if (parameters.proofOfPossession() != null) {
+        if (!brokerEnabled && parameters.proofOfPossession() != null) {
                 throw new MsalClientException(
                         "InteractiveRequestParameters.proofOfPossession should not be used when broker is not available, see https://aka.ms/msal4j-pop for more information",
                         AuthenticationErrorCode.MSALJAVA_BROKERS_ERROR );
             }
-        }
+
 
         return brokerEnabled;
     }
@@ -233,13 +232,12 @@ public class PublicClientApplication extends AbstractClientApplicationBase imple
 
         //Check if broker-only parameters are being used when a broker is not enabled. If they are, either throw an
         // exception saying a broker is required, or provide a clear log message saying the parameter will be ignored
-        if (!brokerEnabled) {
-            if (parameters.proofOfPossession() != null) {
+        if (!brokerEnabled && parameters.proofOfPossession() != null) {
                 throw new MsalClientException(
                         "UserNamePasswordParameters.proofOfPossession should not be used when broker is not available, see https://aka.ms/msal4j-pop for more information",
                         AuthenticationErrorCode.MSALJAVA_BROKERS_ERROR );
             }
-        }
+
 
         return brokerEnabled;
     }
@@ -252,13 +250,12 @@ public class PublicClientApplication extends AbstractClientApplicationBase imple
 
         //Check if broker-only parameters are being used when a broker is not enabled. If they are, either throw an
         // exception saying a broker is required, or provide a clear log message saying the parameter will be ignored
-        if (!brokerEnabled) {
-            if (parameters.proofOfPossession() != null) {
+        if (!brokerEnabled && parameters.proofOfPossession() != null) {
                 throw new MsalClientException(
                         "UserNamePasswordParameters.proofOfPossession should not be used when broker is not available, see https://aka.ms/msal4j-pop for more information",
                         AuthenticationErrorCode.MSALJAVA_BROKERS_ERROR );
             }
-        }
+
 
         return brokerEnabled;
     }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RefreshTokenRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RefreshTokenRequest.java
@@ -3,9 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RemoveAccountRunnable.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RemoveAccountRunnable.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.aad.msal4j;
 
-import java.util.Set;
 import java.util.concurrent.CompletionException;
 
 class RemoveAccountRunnable implements Runnable {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ServiceFabricManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ServiceFabricManagedIdentitySource.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.HashMap;
 
 class ServiceFabricManagedIdentitySource extends AbstractManagedIdentitySource {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TelemetryManager.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/TelemetryManager.java
@@ -87,7 +87,7 @@ class TelemetryManager implements ITelemetryManager, ITelemetry {
 
         List<Event> eventsToFlush = completedEvents.remove(requestId);
         Map<String, Integer> eventCountToFlush = eventCount.remove(requestId);
-        eventCountToFlush = !(eventCountToFlush == null) ?
+        eventCountToFlush = eventCountToFlush != null ?
                 eventCountToFlush :
                 new ConcurrentHashMap<>();
 
@@ -96,7 +96,7 @@ class TelemetryManager implements ITelemetryManager, ITelemetry {
         if (onlySendFailureTelemetry && eventsToFlush.stream().anyMatch(isSuccessfulPredicate)) {
             eventsToFlush.clear();
         }
-        if (eventsToFlush.size() <= 0) {
+        if (eventsToFlush.isEmpty()) {
             return;
         }
         eventsToFlush.add(0, new DefaultEvent(clientId, eventCountToFlush));

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordRequest.java
@@ -3,9 +3,7 @@
 
 package com.microsoft.aad.msal4j;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 class UserNamePasswordRequest extends MsalRequest {


### PR DESCRIPTION
This PR fixes various small issues found during an analysis by SonarQube. It doesn't fix all of the issues identified by SonarQube, but these are all issues that should have zero risk of changing any actual behavior of the library.

A few dozen files received changes, but the majority of them just had unused imports removed. As for the other classes, they had equally minor changes:
- `AadInstanceDiscoveryProvider`: removed unused parameter, and replace a String with an existing constant
- `AcquireTokenByAppProviderSupplier`: avoid creating unnecessary temp String when logging a Long value
- `AcquireTokenByManagedIdentitySupplier`, `ClientCertificate`: remove reference to an exception that is never actually thrown in a method
- `Authority`, `AuthorizationRequestUrlParameters`, `ClientCredentialFactory`, `TelemetryManager`: use `.isEmpty()` to check if something is empty instead of `... == 0`
- `AuthorizationResponseHandler`: reference a standard enum rather than use a String
- `ManagedIdentityApplication`: deprecate a builder API which was not actually doing anything
- `ManagedIdentityRequest`: remove unnecessary `toString()` call
- `ManagedIdentityClient`, `ManagedIdentityResponse`: remove unused logger
- `PublicClientApplication`: refactor unnecessarily nested if statements to be on one line