### PR TITLE
Use java.nio chartsets instead of nimbusds

### DIFF
--- a/msal4j-persistence-extension/src/main/java/com/microsoft/aad/msal4jextensions/PersistenceTokenCacheAccessAspect.java
+++ b/msal4j-persistence-extension/src/main/java/com/microsoft/aad/msal4jextensions/PersistenceTokenCacheAccessAspect.java
@@ -9,13 +9,13 @@ import com.microsoft.aad.msal4jextensions.persistence.CacheFileAccessor;
 import com.microsoft.aad.msal4jextensions.persistence.ICacheAccessor;
 import com.microsoft.aad.msal4jextensions.persistence.linux.KeyRingAccessor;
 import com.microsoft.aad.msal4jextensions.persistence.mac.KeyChainAccessor;
-import com.nimbusds.jose.util.StandardCharset;
 import com.sun.jna.Platform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 /**
@@ -124,7 +124,7 @@ public class PersistenceTokenCacheAccessAspect implements ITokenCacheAccessAspec
             }
             byte[] data = cacheAccessor.read();
             if (data != null) {
-                iTokenCacheAccessContext.tokenCache().deserialize(new String(data, StandardCharset.UTF_8));
+                iTokenCacheAccessContext.tokenCache().deserialize(new String(data, StandardCharsets.UTF_8));
             }
 
             updateLastSeenCacheFileModifiedTimestamp();
@@ -141,7 +141,7 @@ public class PersistenceTokenCacheAccessAspect implements ITokenCacheAccessAspec
     public void afterCacheAccess(ITokenCacheAccessContext iTokenCacheAccessContext) {
         try {
             if (isWriteAccess(iTokenCacheAccessContext)) {
-                cacheAccessor.write(iTokenCacheAccessContext.tokenCache().serialize().getBytes(StandardCharset.UTF_8));
+                cacheAccessor.write(iTokenCacheAccessContext.tokenCache().serialize().getBytes(StandardCharsets.UTF_8));
                 updateLastSeenCacheFileModifiedTimestamp();
             }
         } finally {

--- a/msal4j-persistence-extension/src/main/java/com/microsoft/aad/msal4jextensions/persistence/linux/KeyRingAccessor.java
+++ b/msal4j-persistence-extension/src/main/java/com/microsoft/aad/msal4jextensions/persistence/linux/KeyRingAccessor.java
@@ -5,7 +5,6 @@ package com.microsoft.aad.msal4jextensions.persistence.linux;
 
 import com.microsoft.aad.msal4jextensions.persistence.CacheFileAccessor;
 import com.microsoft.aad.msal4jextensions.persistence.ICacheAccessor;
-import com.nimbusds.jose.util.StandardCharset;
 import com.sun.jna.Pointer;
 
 import java.io.IOException;
@@ -57,7 +56,7 @@ public class KeyRingAccessor implements ICacheAccessor {
 
         byte[] readData = read(testAttributeValue1, testAttributeValue2);
 
-        if (readData == null || !testData.equals(new String(readData, StandardCharset.UTF_8))) {
+        if (readData == null || !testData.equals(new String(readData, StandardCharsets.UTF_8))) {
             throw new KeyRingAccessException("An error while validating KeyRing availability");
         }
 


### PR DESCRIPTION

Use java.nio.charset.StandardCharsets instead of com.nimbusds.jose.util.StandardCharset in persistence msal4extensions
Fixes: https://github.com/issues/created?issue=AzureAD%7Cmicrosoft-authentication-library-for-java%7C995