### PR TITLE
Deprecate extraQueryParameters

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeParameters.java
@@ -92,6 +92,10 @@ public class AuthorizationCodeParameters implements IAcquireTokenParameters {
         return this.extraHttpHeaders;
     }
 
+    /**
+     * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    @Deprecated
     public Map<String, String> extraQueryParameters() {
         return this.extraQueryParameters;
     }
@@ -173,7 +177,9 @@ public class AuthorizationCodeParameters implements IAcquireTokenParameters {
 
         /**
          * Adds additional query parameters to the token request
+         * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
          */
+        @Deprecated
         public AuthorizationCodeParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
             this.extraQueryParameters = extraQueryParameters;
             return this;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParameters.java
@@ -234,6 +234,10 @@ public class AuthorizationRequestUrlParameters {
         return this.instanceAware;
     }
 
+    /**
+     * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    @Deprecated
     public Map<String, String> extraQueryParameters() {
         return this.extraQueryParameters;
     }
@@ -419,7 +423,9 @@ public class AuthorizationRequestUrlParameters {
         /**
          * Query parameters that you can add to the request,
          * in addition to the list of parameters already provided.
+         * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
          */
+        @Deprecated
         public Builder extraQueryParameters(Map<String, String> val) {
             this.extraQueryParameters = val;
             return self();

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
@@ -71,6 +71,10 @@ public class ClientCredentialParameters implements IAcquireTokenParameters {
         return this.extraHttpHeaders;
     }
 
+    /**
+     * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    @Deprecated
     public Map<String, String> extraQueryParameters() {
         return this.extraQueryParameters;
     }
@@ -134,7 +138,9 @@ public class ClientCredentialParameters implements IAcquireTokenParameters {
 
         /**
          * Adds additional query parameters to the token request
+         * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
          */
+        @Deprecated
         public ClientCredentialParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
             this.extraQueryParameters = extraQueryParameters;
             return this;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/DeviceCodeFlowParameters.java
@@ -70,6 +70,10 @@ public class DeviceCodeFlowParameters implements IAcquireTokenParameters {
         return this.extraHttpHeaders;
     }
 
+    /**
+     * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    @Deprecated
     public Map<String, String> extraQueryParameters() {
         return this.extraQueryParameters;
     }
@@ -135,7 +139,9 @@ public class DeviceCodeFlowParameters implements IAcquireTokenParameters {
 
         /**
          * Adds additional query parameters to the token request
+         * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
          */
+        @Deprecated
         public DeviceCodeFlowParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
             this.extraQueryParameters = extraQueryParameters;
             return this;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IAcquireTokenParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IAcquireTokenParameters.java
@@ -62,6 +62,7 @@ interface IAcquireTokenParameters {
      * This can be useful for scenarios requiring custom parameters that aren't explicitly supported in the library.
      *
      * @return A map of additional query parameters to include with the token request, or null if no extra parameters are needed.
+     *
      * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
      */
     @Deprecated

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IAcquireTokenParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IAcquireTokenParameters.java
@@ -62,6 +62,8 @@ interface IAcquireTokenParameters {
      * This can be useful for scenarios requiring custom parameters that aren't explicitly supported in the library.
      *
      * @return A map of additional query parameters to include with the token request, or null if no extra parameters are needed.
+     * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
      */
+    @Deprecated
     Map<String, String> extraQueryParameters();
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthenticationParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/IntegratedWindowsAuthenticationParameters.java
@@ -72,6 +72,10 @@ public class IntegratedWindowsAuthenticationParameters implements IAcquireTokenP
         return this.extraHttpHeaders;
     }
 
+    /**
+     * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    @Deprecated
     public Map<String, String> extraQueryParameters() {
         return this.extraQueryParameters;
     }
@@ -129,7 +133,9 @@ public class IntegratedWindowsAuthenticationParameters implements IAcquireTokenP
 
         /**
          * Adds additional parameters to the token request
+         * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
          */
+        @Deprecated
         public IntegratedWindowsAuthenticationParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
             this.extraQueryParameters = extraQueryParameters;
             return this;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/InteractiveRequestParameters.java
@@ -113,6 +113,10 @@ public class InteractiveRequestParameters implements IAcquireTokenParameters {
         return this.extraHttpHeaders;
     }
 
+    /**
+     * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    @Deprecated
     public Map<String, String> extraQueryParameters() {
         return this.extraQueryParameters;
     }
@@ -262,7 +266,9 @@ public class InteractiveRequestParameters implements IAcquireTokenParameters {
 
         /**
          * Adds additional query parameters to the token request
+         * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
          */
+        @Deprecated
         public InteractiveRequestParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
             this.extraQueryParameters = extraQueryParameters;
             return this;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfParameters.java
@@ -76,6 +76,10 @@ public class OnBehalfOfParameters implements IAcquireTokenParameters {
         return this.extraHttpHeaders;
     }
 
+    /**
+     * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    @Deprecated
     public Map<String, String> extraQueryParameters() {
         return this.extraQueryParameters;
     }
@@ -136,7 +140,9 @@ public class OnBehalfOfParameters implements IAcquireTokenParameters {
 
         /**
          * Adds additional parameters to the token request
+         * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
          */
+        @Deprecated
         public OnBehalfOfParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
             this.extraQueryParameters = extraQueryParameters;
             return this;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RefreshTokenParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/RefreshTokenParameters.java
@@ -72,6 +72,10 @@ public class RefreshTokenParameters implements IAcquireTokenParameters {
         return this.extraHttpHeaders;
     }
 
+    /**
+     * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    @Deprecated
     public Map<String, String> extraQueryParameters() {
         return this.extraQueryParameters;
     }
@@ -133,7 +137,9 @@ public class RefreshTokenParameters implements IAcquireTokenParameters {
 
         /**
          * Adds additional parameters to the token request
+         * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
          */
+        @Deprecated
         public RefreshTokenParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
             this.extraQueryParameters = extraQueryParameters;
             return this;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/SilentParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/SilentParameters.java
@@ -119,6 +119,10 @@ public class SilentParameters implements IAcquireTokenParameters {
         return this.extraHttpHeaders;
     }
 
+    /**
+     * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    @Deprecated
     public Map<String, String> extraQueryParameters() {
         return this.extraQueryParameters;
     }
@@ -215,7 +219,9 @@ public class SilentParameters implements IAcquireTokenParameters {
 
         /**
          * Adds additional query parameters to the token request
+         * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
          */
+        @Deprecated
         public SilentParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
             this.extraQueryParameters = extraQueryParameters;
             return this;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserNamePasswordParameters.java
@@ -88,6 +88,10 @@ public class UserNamePasswordParameters implements IAcquireTokenParameters {
         return this.extraHttpHeaders;
     }
 
+    /**
+     * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
+     */
+    @Deprecated
     public Map<String, String> extraQueryParameters() {
         return this.extraQueryParameters;
     }
@@ -180,7 +184,9 @@ public class UserNamePasswordParameters implements IAcquireTokenParameters {
 
         /**
          * Adds additional query parameters to the token request
+         * @deprecated Not recommended for production scenarios. It will be removed in a future release, and the behavior may be replaced by a new API.
          */
+        @Deprecated
         public UserNamePasswordParametersBuilder extraQueryParameters(Map<String, String> extraQueryParameters) {
             this.extraQueryParameters = extraQueryParameters;
             return this;


### PR DESCRIPTION
Deprecates the extraQueryParameters API according to KR [3310905](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3310905), similar to what was done in MSAL.NET: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/5536

This API was meant for niche scenarios which the library did not explicitly cover, and not really meant for production. It can affect the contents and validity of tokens but were not used in our caching scheme which led to bad caching behavior: if the extra query parameters changed between requests we could return tokens that were not valid for the latest set of parameters.

Therefore we are deprecating the current API and, if there is a need for it, may add a new API in the future to perform similar behavior in a more robust way.