### PR TITLE
Potential fix for code scanning alert no. 18: Implicit narrowing conversion in compound assignment

### DIFF
--- a/msal4j-persistence-extension/src/test/java/com/microsoft/aad/msal4jextensions/CacheLockTestBase.java
+++ b/msal4j-persistence-extension/src/test/java/com/microsoft/aad/msal4jextensions/CacheLockTestBase.java
@@ -108,7 +108,7 @@ public class CacheLockTestBase {
 
         list.sort(Comparator.comparingLong(a -> a[0]));
 
-        int sum = 0;
+        long sum = 0L;
         Long[] prev = null;
         for (Long[] interval : list) {
             Assert.assertTrue(interval[0] <= interval[1]);


### PR DESCRIPTION
Potential fix for [https://github.com/AzureAD/microsoft-authentication-library-for-java/security/code-scanning/18](https://github.com/AzureAD/microsoft-authentication-library-for-java/security/code-scanning/18)

In general, the fix is to ensure that the left-hand side of the compound assignment is at least as wide as the right-hand side expression. Here, the expression `interval[1] - interval[0]` is of type `long`, so `sum` should also be a `long` to avoid implicit narrowing when doing `sum += ...`.

The best targeted fix is:
- Change the type of `sum` from `int` to `long`.
- Ensure that subsequent uses of `sum` (specifically in the division `sum/list.size()`) perform `long` arithmetic and then rely on Java’s automatic widening when concatenating with the string; no further changes are necessary there because `sum` being `long` is acceptable and safe.

Concretely, in `msal4j-persistence-extension/src/test/java/com/microsoft/aad/msal4jextensions/CacheLockTestBase.java`, inside `validateLockUsageIntervals`:
- Update line 111 from `int sum = 0;` to `long sum = 0L;`.
No new imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
