### PR TITLE
Migrate OBO tests from AppWebApi/client secret to AppOBOService/certificate

### DIFF
--- a/msal4j-sdk/src/integrationtest/java/com/microsoft/aad/msal4j/OnBehalfOfIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com/microsoft/aad/msal4j/OnBehalfOfIT.java
@@ -5,6 +5,7 @@ package com.microsoft.aad.msal4j;
 
 import com.microsoft.aad.msal4j.labapi.*;
 import static com.microsoft.aad.msal4j.labapi.KeyVaultSecrets.*;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,16 +17,21 @@ import java.util.Collections;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OnBehalfOfIT {
 
+    private IClientCertificate certificate;
+
+    @BeforeAll
+    void init() throws Exception {
+        certificate = CertificateHelper.getClientCertificate();
+    }
+
     @Test
     void acquireTokenWithOBO_Managed() throws Exception {
         String accessToken = this.getAccessToken();
-        AppConfig app = LabResponseHelper.getAppConfig(APP_WEBAPI);
+        AppConfig oboService = LabResponseHelper.getAppConfig(APP_OBO_SERVICE);
         UserConfig user = LabResponseHelper.getUserConfig(USER_PUBLIC_CLOUD);
 
-        String password = KeyVaultRegistry.getMsalTeamProvider().getSecretByName(app.getClientSecret()).getValue();
-
         ConfidentialClientApplication cca =
-                ConfidentialClientApplication.builder(app.getAppId(), ClientCredentialFactory.createFromSecret(password)).
+                ConfidentialClientApplication.builder(oboService.getAppId(), certificate).
                         authority(TestConstants.MICROSOFT_AUTHORITY_HOST + user.getTenantId()).
                         build();
 
@@ -42,13 +48,11 @@ class OnBehalfOfIT {
     void acquireTokenWithOBO_testCache() throws Exception {
         String accessToken = this.getAccessToken();
 
-        AppConfig app = LabResponseHelper.getAppConfig(APP_WEBAPI);
+        AppConfig oboService = LabResponseHelper.getAppConfig(APP_OBO_SERVICE);
         UserConfig user = LabResponseHelper.getUserConfig(USER_PUBLIC_CLOUD);
 
-        String password = KeyVaultRegistry.getMsalTeamProvider().getSecretByName(app.getClientSecret()).getValue();
-
         ConfidentialClientApplication cca =
-                ConfidentialClientApplication.builder(app.getAppId(), ClientCredentialFactory.createFromSecret(password)).
+                ConfidentialClientApplication.builder(oboService.getAppId(), certificate).
                         authority(TestConstants.MICROSOFT_AUTHORITY_HOST + user.getTenantId()).
                         build();
 
@@ -125,13 +129,15 @@ class OnBehalfOfIT {
     }
 
     private String getAccessToken() throws Exception {
-
-        AppConfig app = LabResponseHelper.getAppConfig(APP_WEBAPI);
+        AppConfig oboService = LabResponseHelper.getAppConfig(APP_OBO_SERVICE);
+        AppConfig oboClient = LabResponseHelper.getAppConfig(APP_OBO_CLIENT);
         UserConfig user = LabResponseHelper.getUserConfig(USER_PUBLIC_CLOUD);
 
-        String apiReadScope = "api://" + app.getAppId() + "/access_as_user";
+        String apiReadScope = oboService.getDefaultScopes() != null
+                ? oboService.getDefaultScopes()
+                : "api://" + oboService.getAppId() + "/access_as_user";
 
-        PublicClientApplication pca = PublicClientApplication.builder(app.getAppId()).
+        PublicClientApplication pca = PublicClientApplication.builder(oboClient.getAppId()).
                 authority("https://login.microsoftonline.com/organizations").
                 build();
 

--- a/msal4j-sdk/src/integrationtest/java/com/microsoft/aad/msal4j/labapi/AppConfig.java
+++ b/msal4j-sdk/src/integrationtest/java/com/microsoft/aad/msal4j/labapi/AppConfig.java
@@ -23,6 +23,7 @@ public class AppConfig implements JsonSerializable<AppConfig> {
     private String labName;
     private String clientSecret;
     private String secretName;
+    private String defaultScopes;
 
     static AppConfig fromJson(JsonReader jsonReader) throws IOException {
         AppConfig app = new AppConfig();
@@ -56,6 +57,10 @@ public class AppConfig implements JsonSerializable<AppConfig> {
                         break;
                     case "secretName":
                         app.secretName = reader.getString();
+                        break;
+                    case "defaultscopes":
+                    case "defaultScopes":
+                        app.defaultScopes = reader.getString();
                         break;
                     default:
                         reader.skipChildren();
@@ -97,5 +102,9 @@ public class AppConfig implements JsonSerializable<AppConfig> {
 
     public String getSecretName() {
         return secretName;
+    }
+
+    public String getDefaultScopes() {
+        return defaultScopes;
     }
 }

--- a/msal4j-sdk/src/integrationtest/java/com/microsoft/aad/msal4j/labapi/KeyVaultSecrets.java
+++ b/msal4j-sdk/src/integrationtest/java/com/microsoft/aad/msal4j/labapi/KeyVaultSecrets.java
@@ -26,6 +26,10 @@ public final class KeyVaultSecrets {
     public static final String APP_WEBAPI = "App-WebAPI-Config";
     public static final String APP_S2S = "App-S2S-Config";
 
+    // OBO App Configuration Secrets (ID4SLAB1 tenant, certificate-based auth)
+    public static final String APP_OBO_SERVICE = "MSAL-APP-TodoListService-JSON";
+    public static final String APP_OBO_CLIENT = "MSAL-APP-TodoListClient-JSON";
+
     // TODO: Consolidate with others or following naming convention in key vault
     public static final String APP_B2C = "MSAL-App-B2C-JSON";
     public static final String APP_ARLINGTON = "MSAL-App-Arlington-JSON";


### PR DESCRIPTION
## Summary
Migrates OBO integration tests from old lab4 apps (AppWebApi + client secret) to ID4SLAB1 tenant apps (AppOBOService + LabAuth certificate), matching the pattern from MSAL.NET PR #6021.

## Changes
- **OnBehalfOfIT.java**: CCA uses APP_OBO_SERVICE with certificate instead of APP_WEBAPI with client secret. PCA uses APP_OBO_CLIENT instead of APP_WEBAPI.
- **KeyVaultSecrets.java**: Added APP_OBO_SERVICE and APP_OBO_CLIENT constants
- **AppConfig.java**: Added defaultScopes field for OBO scope resolution

## Key Vault Secrets Used
- \MSAL-APP-TodoListService-JSON\ - OBO service app config (CCA)
- \MSAL-APP-TodoListClient-JSON\ - OBO public client app config (PCA)
- LabAuth certificate from OS keystore (same as all other cert-based tests)

## Related
- MSAL.NET PR: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6021