### PR TITLE
Improve assertion usage patterns

### DIFF
--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -114,7 +114,19 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>3.14.0</version>
+            <version>4.13.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.14.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.6.2</version>
+            <version>1.7.36</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.14.5</version>
+            <version>1.17.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.14.0</version>
+            <version>2.22.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -169,7 +169,7 @@
             <plugin>
                 <groupId>org.revapi</groupId>
                 <artifactId>revapi-maven-plugin</artifactId>
-                <version>0.15.0</version>
+                <version>0.15.1</version>
                 <configuration>
                     <analysisConfiguration>
                         <revapi.java>
@@ -183,7 +183,7 @@
                     <dependency>
                         <groupId>org.revapi</groupId>
                         <artifactId>revapi-java</artifactId>
-                        <version>0.28.1</version>
+                        <version>0.28.4</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -199,7 +199,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.5.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -213,7 +213,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.5.6</version>
                 <configuration>
                     <argLine>@{argLine} -noverify</argLine>
                     <skipTests>${skip.unit.tests}</skipTests>
@@ -222,7 +222,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.12.0</version>
                 <configuration>
                     <sourcepath>src/main/java</sourcepath>
                 </configuration>
@@ -238,7 +238,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -251,12 +251,12 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.11</version>
+                <version>4.2.3</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.15.0</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
@@ -265,7 +265,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.10</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>add-test-source</id>
@@ -284,7 +284,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.5.6</version>
                 <executions>
                     <execution>
                         <goals>
@@ -303,7 +303,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>5.2.0</version>
+                <version>6.4.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -315,7 +315,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.13</version>
                 <executions>
                     <execution>
                         <goals>
@@ -360,7 +360,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.11.0</version>
             </plugin>
         </plugins>
     </build>

--- a/msal4j-sdk/src/integrationtest/java/com/microsoft/aad/msal4j/AcquireTokenSilentIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com/microsoft/aad/msal4j/AcquireTokenSilentIT.java
@@ -107,8 +107,7 @@ class AcquireTokenSilentIT {
                 .build())
                 .get();
 
-        assertNotNull(result);
-        assertNotNull(result.accessToken());
+        IntegrationTestHelper.assertAccessTokenNotNull(result);
 
         String cachedAt = result.accessToken();
 
@@ -133,8 +132,7 @@ class AcquireTokenSilentIT {
                 .build())
                 .get();
 
-        assertNotNull(result);
-        assertNotNull(result.accessToken());
+        IntegrationTestHelper.assertAccessTokenNotNull(result);
 
         //Acquiring token for different scope, expect exception to be thrown
         assertThrows(ExecutionException.class, () -> cca.acquireTokenSilently(SilentParameters

--- a/msal4j-sdk/src/integrationtest/java/com/microsoft/aad/msal4j/ClientCredentialsIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com/microsoft/aad/msal4j/ClientCredentialsIT.java
@@ -75,8 +75,7 @@ class ClientCredentialsIT {
                         .build())
                 .get();
 
-        assertNotNull(result);
-        assertNotNull(result.accessToken());
+        IntegrationTestHelper.assertAccessTokenNotNull(result);
     }
 
     @Test
@@ -117,8 +116,7 @@ class ClientCredentialsIT {
                 .build())
                 .get();
 
-        assertNotNull(result1);
-        assertNotNull(result1.accessToken());
+        IntegrationTestHelper.assertAccessTokenNotNull(result1);
 
         IAuthenticationResult result2 = cca.acquireToken(ClientCredentialParameters
                 .builder(Collections.singleton(KEYVAULT_DEFAULT_SCOPE))
@@ -133,8 +131,7 @@ class ClientCredentialsIT {
                 .build())
                 .get();
 
-        assertNotNull(result3);
-        assertNotNull(result3.accessToken());
+        IntegrationTestHelper.assertAccessTokenNotNull(result3);
         assertNotEquals(result2.accessToken(), result3.accessToken());
     }
 
@@ -164,8 +161,7 @@ class ClientCredentialsIT {
                 .build())
                 .get();
 
-        assertNotNull(result);
-        assertNotNull(result.accessToken());
+        IntegrationTestHelper.assertAccessTokenNotNull(result);
     }
 
     private void assertAcquireTokenCommon_withParameters(AppConfig app, IClientCredential credential, IClientCredential credentialParam) throws Exception {
@@ -180,8 +176,7 @@ class ClientCredentialsIT {
                 .build())
                 .get();
 
-        assertNotNull(result);
-        assertNotNull(result.accessToken());
+        IntegrationTestHelper.assertAccessTokenNotNull(result);
     }
 
     private void assertAcquireTokenCommon_withRegion(AppConfig app, IClientCredential credential, String region, String regionalAuthority) throws Exception {
@@ -202,8 +197,7 @@ class ClientCredentialsIT {
                 .build())
                 .get();
 
-        assertNotNull(resultNoRegion);
-        assertNotNull(resultNoRegion.accessToken());
+        IntegrationTestHelper.assertAccessTokenNotNull(resultNoRegion);
         assertEquals(TestConstants.MICROSOFT_AUTHORITY_BASIC_HOST, resultNoRegion.environment());
 
         //Ensure regional tokens are properly cached and retrievable
@@ -212,17 +206,15 @@ class ClientCredentialsIT {
                 .build())
                 .get();
 
-        assertNotNull(resultRegion);
-        assertNotNull(resultRegion.accessToken());
-        assertEquals(resultRegion.environment(), regionalAuthority);
+        IntegrationTestHelper.assertAccessTokenNotNull(resultRegion);
+        assertEquals(regionalAuthority, resultRegion.environment());
 
         IAuthenticationResult resultRegionCached = ccaRegion.acquireToken(ClientCredentialParameters
                 .builder(Collections.singleton(KEYVAULT_DEFAULT_SCOPE))
                 .build())
                 .get();
 
-        assertNotNull(resultRegionCached);
-        assertNotNull(resultRegionCached.accessToken());
+        IntegrationTestHelper.assertAccessTokenNotNull(resultRegionCached);
         assertEquals(resultRegionCached.accessToken(), resultRegion.accessToken());
 
         //Tokens retrieved from regional endpoints should be interchangeable with non-regional, and vice-versa
@@ -233,8 +225,7 @@ class ClientCredentialsIT {
                 .build())
                 .get();
 
-        assertNotNull(resultNoRegion);
-        assertNotNull(resultNoRegion.accessToken());
+        IntegrationTestHelper.assertAccessTokenNotNull(resultNoRegion);
         assertEquals(resultNoRegion.accessToken(), resultRegion.accessToken());
     }
 }

--- a/msal4j-sdk/src/integrationtest/java/com/microsoft/aad/msal4j/TokenCacheIT.java
+++ b/msal4j-sdk/src/integrationtest/java/com/microsoft/aad/msal4j/TokenCacheIT.java
@@ -29,7 +29,7 @@ class TokenCacheIT {
                 build();
 
         // Check that cache is empty
-        assertEquals(pca.getAccounts().join().size(), 0);
+        assertEquals(0, pca.getAccounts().join().size());
 
         Map<String, String> extraQueryParameters = new HashMap<>();
         extraQueryParameters.put("test", "test");
@@ -43,12 +43,12 @@ class TokenCacheIT {
                 .get();
 
         // Check that cache contains one account
-        assertEquals(pca.getAccounts().join().size(), 1);
+        assertEquals(1, pca.getAccounts().join().size());
 
         pca.removeAccount(pca.getAccounts().join().iterator().next()).join();
 
         // Check that account has been removed
-        assertEquals(pca.getAccounts().join().size(), 0);
+        assertEquals(0, pca.getAccounts().join().size());
     }
 
     @Test

--- a/msal4j-sdk/src/integrationtest/java/infrastructure/SeleniumExtensions.java
+++ b/msal4j-sdk/src/integrationtest/java/infrastructure/SeleniumExtensions.java
@@ -28,14 +28,14 @@ public class SeleniumExtensions {
 
     public static WebDriver createDefaultWebDriver() {
         ChromeOptions options = new ChromeOptions();
-        options.addArguments("--headless");
+        options.addArguments("--headless=new");
         options.addArguments("--incognito");
 
         return new ChromeDriver(options);
     }
 
     public static WebElement waitForElementToBeVisibleAndEnabled(WebDriver driver, By by, Duration timeout) {
-        WebDriverWait wait = new WebDriverWait(driver, timeout.getSeconds());
+        WebDriverWait wait = new WebDriverWait(driver, timeout);
         return wait.until(ExpectedConditions.elementToBeClickable(by));
     }
 

--- a/msal4j-sdk/src/integrationtest/java/infrastructure/pageobjects/ADFSLoginPage.java
+++ b/msal4j-sdk/src/integrationtest/java/infrastructure/pageobjects/ADFSLoginPage.java
@@ -32,7 +32,7 @@ public class ADFSLoginPage {
 
     public ADFSLoginPage(WebDriver driver) {
         this.driver = driver;
-        this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT.getSeconds());
+        this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT);
     }
 
     /**

--- a/msal4j-sdk/src/integrationtest/java/infrastructure/pageobjects/AzureADLoginPage.java
+++ b/msal4j-sdk/src/integrationtest/java/infrastructure/pageobjects/AzureADLoginPage.java
@@ -43,7 +43,7 @@ public class AzureADLoginPage {
 
     public AzureADLoginPage(WebDriver driver) {
         this.driver = driver;
-        this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT.getSeconds());
+        this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT);
     }
 
     /**
@@ -103,7 +103,7 @@ public class AzureADLoginPage {
      */
     public boolean isAuthenticationComplete() {
         try {
-            WebDriverWait shortWait = new WebDriverWait(driver, SHORT_TIMEOUT.getSeconds());
+            WebDriverWait shortWait = new WebDriverWait(driver, SHORT_TIMEOUT);
             shortWait.until(ExpectedConditions.textToBePresentInElementLocated(
                     AUTH_COMPLETE_BODY, AUTH_COMPLETE_TEXT));
             LOG.info("Authentication complete page detected");
@@ -150,7 +150,7 @@ public class AzureADLoginPage {
     private void handleAreYouTryingToSignInPrompt() {
         try {
             LOG.info("Checking for 'Are you trying to sign in' prompt");
-            WebDriverWait shortWait = new WebDriverWait(driver, SHORT_TIMEOUT.getSeconds());
+            WebDriverWait shortWait = new WebDriverWait(driver, SHORT_TIMEOUT);
             shortWait.until(ExpectedConditions.elementToBeClickable(ARE_YOU_TRYING_TO_SIGN_IN_BUTTON))
                     .click();
             LOG.info("Clicked Continue on 'Are you trying to sign in' prompt");
@@ -165,7 +165,7 @@ public class AzureADLoginPage {
     private void handleStaySignedInPrompt() {
         try {
             LOG.info("Checking for 'Stay signed in' prompt");
-            WebDriverWait shortWait = new WebDriverWait(driver, SHORT_TIMEOUT.getSeconds());
+            WebDriverWait shortWait = new WebDriverWait(driver, SHORT_TIMEOUT);
             shortWait.until(ExpectedConditions.elementToBeClickable(STAY_SIGNED_IN_NO_BUTTON))
                     .click();
             LOG.info("Clicked No on 'Stay signed in' prompt");

--- a/msal4j-sdk/src/integrationtest/java/infrastructure/pageobjects/B2CLocalLoginPage.java
+++ b/msal4j-sdk/src/integrationtest/java/infrastructure/pageobjects/B2CLocalLoginPage.java
@@ -33,7 +33,7 @@ public class B2CLocalLoginPage {
 
     public B2CLocalLoginPage(WebDriver driver) {
         this.driver = driver;
-        this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT.getSeconds());
+        this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT);
     }
 
     /**

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryTest.java
@@ -138,9 +138,9 @@ class AadInstanceDiscoveryTest {
     }
 
     void assertValidResponse(InstanceDiscoveryMetadataEntry entry) {
-        assertEquals(entry.preferredNetwork(), "login.microsoftonline.com");
-        assertEquals(entry.preferredCache(), "login.windows.net");
-        assertEquals(entry.aliases().size(), 4);
+        assertEquals("login.microsoftonline.com", entry.preferredNetwork());
+        assertEquals("login.windows.net", entry.preferredCache());
+        assertEquals(4, entry.aliases().size());
         assertTrue(entry.aliases().contains("login.microsoftonline.com"));
         assertTrue(entry.aliases().contains("login.windows.net"));
         assertTrue(entry.aliases().contains("login.microsoft.com"));

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AccountTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AccountTest.java
@@ -91,22 +91,22 @@ class AccountTest {
 
         Set<IAccount> accounts = pca.getAccounts().join();
 
-        assertEquals(accounts.size(), 1);
+        assertEquals(1, accounts.size());
         IAccount account = accounts.iterator().next();
 
         Map<String, ITenantProfile> tenantProfiles = account.getTenantProfiles();
-        assertEquals(tenantProfiles.size(), 2);
+        assertEquals(2, tenantProfiles.size());
 
         assertTrue(tenantProfiles.containsKey(BLACK_FORESRT_TENANT));
         assertTrue(tenantProfiles.containsKey(WW_TENTANT));
 
         pca.removeAccount(account).join();
         accounts = pca.getAccounts().join();
-        assertEquals(accounts.size(), 0);
+        assertEquals(0, accounts.size());
 
-        assertEquals(pca.tokenCache.accounts.size(), 0);
-        assertEquals(pca.tokenCache.idTokens.size(), 0);
-        assertEquals(pca.tokenCache.refreshTokens.size(), 0);
-        assertEquals(pca.tokenCache.accessTokens.size(), 0);
+        assertEquals(0, pca.tokenCache.accounts.size());
+        assertEquals(0, pca.tokenCache.idTokens.size());
+        assertEquals(0, pca.tokenCache.refreshTokens.size());
+        assertEquals(0, pca.tokenCache.accessTokens.size());
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AuthorityTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AuthorityTest.java
@@ -19,31 +19,31 @@ class AuthorityTest {
     @Test
     void testDetectAuthorityType_AAD() throws Exception {
         URL url = new URL(TestConfiguration.AAD_TENANT_ENDPOINT);
-        assertEquals(Authority.detectAuthorityType(url), AuthorityType.AAD);
+        assertEquals(AuthorityType.AAD, Authority.detectAuthorityType(url));
     }
 
     @Test
     void testDetectAuthorityType_ADFS() throws Exception {
         URL url = new URL(TestConfiguration.ADFS_TENANT_ENDPOINT);
-        assertEquals(Authority.detectAuthorityType(url), AuthorityType.ADFS);
+        assertEquals(AuthorityType.ADFS, Authority.detectAuthorityType(url));
     }
 
     @Test
     void testDetectAuthorityType_B2C() throws Exception {
         URL url = new URL(TestConfiguration.B2C_AUTHORITY);
-        assertEquals(Authority.detectAuthorityType(url), AuthorityType.B2C);
+        assertEquals(AuthorityType.B2C, Authority.detectAuthorityType(url));
     }
 
     @ParameterizedTest
     @MethodSource("com.microsoft.aad.msal4j.AuthorityTest#ciamAuthorities")
     void testDetectAuthorityType_CIAM(URL authority) throws Exception {
-        assertEquals(Authority.detectAuthorityType(authority), AuthorityType.CIAM);
+        assertEquals(AuthorityType.CIAM, Authority.detectAuthorityType(authority));
     }
 
     @ParameterizedTest
     @MethodSource("com.microsoft.aad.msal4j.AuthorityTest#validCiamAuthoritiesAndTransformedAuthority")
     void testCiamAuthorityTransformation(URL authority, URL transformedAuthority) throws Exception {
-        assertEquals(CIAMAuthority.transformAuthority(authority), transformedAuthority);
+        assertEquals(transformedAuthority, CIAMAuthority.transformAuthority(authority));
     }
 
     @Test
@@ -100,35 +100,35 @@ class AuthorityTest {
     void testConstructor_AADAuthority() throws MalformedURLException {
         final AADAuthority aa = new AADAuthority(new URL(TestConfiguration.AAD_TENANT_ENDPOINT));
         assertNotNull(aa);
-        assertEquals(aa.authority(),
-                TestConfiguration.AAD_TENANT_ENDPOINT);
-        assertEquals(aa.host(), TestConfiguration.AAD_HOST_NAME);
-        assertEquals(aa.tokenEndpoint(),
-                TestConfiguration.AAD_TENANT_ENDPOINT + "oauth2/v2.0/token");
-        assertEquals(aa.selfSignedJwtAudience(),
-                TestConfiguration.AAD_TENANT_ENDPOINT + "oauth2/v2.0/token");
-        assertEquals(aa.tokenEndpoint(),
-                TestConfiguration.AAD_TENANT_ENDPOINT + "oauth2/v2.0/token");
-        assertEquals(aa.authorityType(), AuthorityType.AAD);
+        assertEquals(TestConfiguration.AAD_TENANT_ENDPOINT,
+                aa.authority());
+        assertEquals(TestConfiguration.AAD_HOST_NAME, aa.host());
+        assertEquals(TestConfiguration.AAD_TENANT_ENDPOINT + "oauth2/v2.0/token",
+                aa.tokenEndpoint());
+        assertEquals(TestConfiguration.AAD_TENANT_ENDPOINT + "oauth2/v2.0/token",
+                aa.selfSignedJwtAudience());
+        assertEquals(TestConfiguration.AAD_TENANT_ENDPOINT + "oauth2/v2.0/token",
+                aa.tokenEndpoint());
+        assertEquals(AuthorityType.AAD, aa.authorityType());
         assertFalse(aa.isTenantless());
-        assertEquals(aa.deviceCodeEndpoint(),
-                TestConfiguration.AAD_TENANT_ENDPOINT + "oauth2/v2.0/devicecode");
+        assertEquals(TestConfiguration.AAD_TENANT_ENDPOINT + "oauth2/v2.0/devicecode",
+                aa.deviceCodeEndpoint());
     }
 
     @Test
     void testConstructor_B2CAuthority() throws MalformedURLException {
         final B2CAuthority aa = new B2CAuthority(new URL(TestConfiguration.B2C_AUTHORITY));
         assertNotNull(aa);
-        assertEquals(aa.authority(),
-                TestConfiguration.B2C_AUTHORITY + "/");
-        assertEquals(aa.host(), TestConfiguration.B2C_HOST_NAME);
-        assertEquals(aa.selfSignedJwtAudience(),
-                TestConfiguration.B2C_AUTHORITY_ENDPOINT + "/oauth2/v2.0/token?p=" + TestConfiguration.B2C_SIGN_IN_POLICY);
-        assertEquals(aa.tokenEndpoint(),
-                TestConfiguration.B2C_AUTHORITY_ENDPOINT + "/oauth2/v2.0/token?p=" + TestConfiguration.B2C_SIGN_IN_POLICY);
-        assertEquals(aa.authorityType(), AuthorityType.B2C);
-        assertEquals(aa.tokenEndpoint(),
-                TestConfiguration.B2C_AUTHORITY_ENDPOINT + "/oauth2/v2.0/token?p=" + TestConfiguration.B2C_SIGN_IN_POLICY);
+        assertEquals(TestConfiguration.B2C_AUTHORITY + "/",
+                aa.authority());
+        assertEquals(TestConfiguration.B2C_HOST_NAME, aa.host());
+        assertEquals(TestConfiguration.B2C_AUTHORITY_ENDPOINT + "/oauth2/v2.0/token?p=" + TestConfiguration.B2C_SIGN_IN_POLICY,
+                aa.selfSignedJwtAudience());
+        assertEquals(TestConfiguration.B2C_AUTHORITY_ENDPOINT + "/oauth2/v2.0/token?p=" + TestConfiguration.B2C_SIGN_IN_POLICY,
+                aa.tokenEndpoint());
+        assertEquals(AuthorityType.B2C, aa.authorityType());
+        assertEquals(TestConfiguration.B2C_AUTHORITY_ENDPOINT + "/oauth2/v2.0/token?p=" + TestConfiguration.B2C_SIGN_IN_POLICY,
+                aa.tokenEndpoint());
         assertFalse(aa.isTenantless());
     }
 
@@ -136,15 +136,15 @@ class AuthorityTest {
     void testConstructor_ADFSAuthority() throws MalformedURLException {
         final ADFSAuthority a = new ADFSAuthority(new URL(TestConfiguration.ADFS_TENANT_ENDPOINT));
         assertNotNull(a);
-        assertEquals(a.authority(), TestConfiguration.ADFS_TENANT_ENDPOINT);
-        assertEquals(a.host(), TestConfiguration.ADFS_HOST_NAME);
-        assertEquals(a.selfSignedJwtAudience(),
-                TestConfiguration.ADFS_TENANT_ENDPOINT + ADFSAuthority.TOKEN_ENDPOINT);
+        assertEquals(TestConfiguration.ADFS_TENANT_ENDPOINT, a.authority());
+        assertEquals(TestConfiguration.ADFS_HOST_NAME, a.host());
+        assertEquals(TestConfiguration.ADFS_TENANT_ENDPOINT + ADFSAuthority.TOKEN_ENDPOINT,
+                a.selfSignedJwtAudience());
 
-        assertEquals(a.authorityType(), AuthorityType.ADFS);
+        assertEquals(AuthorityType.ADFS, a.authorityType());
 
-        assertEquals(a.tokenEndpoint(),
-                TestConfiguration.ADFS_TENANT_ENDPOINT + ADFSAuthority.TOKEN_ENDPOINT);
+        assertEquals(TestConfiguration.ADFS_TENANT_ENDPOINT + ADFSAuthority.TOKEN_ENDPOINT,
+                a.tokenEndpoint());
         assertFalse(a.isTenantless());
     }
 

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AuthorizationRequestUrlParametersTest.java
@@ -35,10 +35,10 @@ class AuthorizationRequestUrlParametersTest {
                         .extraQueryParameters(extraParameters)
                         .build();
 
-        assertEquals(parameters.responseMode(), ResponseMode.FORM_POST);
-        assertEquals(parameters.redirectUri(), redirectUri);
-        assertEquals(parameters.scopes().size(), 4);
-        assertEquals(parameters.extraQueryParameters.size(), 2);
+        assertEquals(ResponseMode.FORM_POST, parameters.responseMode());
+        assertEquals(redirectUri, parameters.redirectUri());
+        assertEquals(4, parameters.scopes().size());
+        assertEquals(2, parameters.extraQueryParameters.size());
 
         assertNull(parameters.loginHint());
         assertNull(parameters.codeChallenge());
@@ -50,8 +50,8 @@ class AuthorizationRequestUrlParametersTest {
 
         URL authorizationUrl = app.getAuthorizationRequestUrl(parameters);
 
-        assertEquals(authorizationUrl.getHost(), "login.microsoftonline.com");
-        assertEquals(authorizationUrl.getPath(), "/common/oauth2/v2.0/authorize");
+        assertEquals("login.microsoftonline.com", authorizationUrl.getHost());
+        assertEquals("/common/oauth2/v2.0/authorize", authorizationUrl.getPath());
 
         Map<String, String> queryParameters = new HashMap<>();
         String query = authorizationUrl.getQuery();
@@ -64,12 +64,12 @@ class AuthorizationRequestUrlParametersTest {
                     URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
         }
 
-        assertEquals(queryParameters.get("scope"), "openid profile offline_access scope");
-        assertEquals(queryParameters.get("response_type"), "code");
-        assertEquals(queryParameters.get("redirect_uri"), "http://localhost:8080");
-        assertEquals(queryParameters.get("client_id"), "client_id");
-        assertEquals(queryParameters.get("response_mode"), "form_post");
-        assertEquals(queryParameters.get("id_token_hint"),"test");
+        assertEquals("openid profile offline_access scope", queryParameters.get("scope"));
+        assertEquals("code", queryParameters.get("response_type"));
+        assertEquals("http://localhost:8080", queryParameters.get("redirect_uri"));
+        assertEquals("client_id", queryParameters.get("client_id"));
+        assertEquals("form_post", queryParameters.get("response_mode"));
+        assertEquals("test", queryParameters.get("id_token_hint"));
     }
 
     @Test
@@ -110,9 +110,9 @@ class AuthorizationRequestUrlParametersTest {
                         .responseMode(ResponseMode.QUERY) // This should be overridden to FORM_POST
                         .build();
 
-        assertEquals(parameters.responseMode(), ResponseMode.FORM_POST);
-        assertEquals(parameters.redirectUri(), redirectUri);
-        assertEquals(parameters.scopes().size(), 4);
+        assertEquals(ResponseMode.FORM_POST, parameters.responseMode());
+        assertEquals(redirectUri, parameters.redirectUri());
+        assertEquals(4, parameters.scopes().size());
 
         assertNull(parameters.loginHint());
         assertNull(parameters.codeChallenge());
@@ -124,8 +124,8 @@ class AuthorizationRequestUrlParametersTest {
 
         URL authorizationUrl = app.getAuthorizationRequestUrl(parameters);
 
-        assertEquals(authorizationUrl.getHost(), "login.microsoftonline.com");
-        assertEquals(authorizationUrl.getPath(), "/common/oauth2/v2.0/authorize");
+        assertEquals("login.microsoftonline.com", authorizationUrl.getHost());
+        assertEquals("/common/oauth2/v2.0/authorize", authorizationUrl.getPath());
 
         Map<String, String> queryParameters = new HashMap<>();
         String query = authorizationUrl.getQuery();
@@ -138,10 +138,10 @@ class AuthorizationRequestUrlParametersTest {
                     URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
         }
 
-        assertEquals(queryParameters.get("scope"), "openid profile offline_access scope");
-        assertEquals(queryParameters.get("response_type"), "code");
-        assertEquals(queryParameters.get("redirect_uri"), "http://localhost:8080");
-        assertEquals(queryParameters.get("client_id"), "client_id");
-        assertEquals(queryParameters.get("response_mode"), "form_post");
+        assertEquals("openid profile offline_access scope", queryParameters.get("scope"));
+        assertEquals("code", queryParameters.get("response_type"));
+        assertEquals("http://localhost:8080", queryParameters.get("redirect_uri"));
+        assertEquals("client_id", queryParameters.get("client_id"));
+        assertEquals("form_post", queryParameters.get("response_mode"));
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/HelperAndUtilityTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/HelperAndUtilityTest.java
@@ -78,7 +78,7 @@ class HelperAndUtilityTest {
         assertNotNull(convertedInternalMap, "Converted map should not be null");
         assertNotNull(methodReturnedMap, "Method returned map should not be null");
 
-        assertEquals(convertedInternalMap.size(), methodReturnedMap.size(), "Maps should have the same size");
+        assertEquals(methodReturnedMap.size(), convertedInternalMap.size(), "Maps should have the same size");
 
         for (String key : convertedInternalMap.keySet()) {
             assertTrue(methodReturnedMap.containsKey(key), "Method returned map should contain key: " + key);

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/HttpHeaderTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/HttpHeaderTest.java
@@ -40,12 +40,12 @@ class HttpHeaderTest {
 
         Map<String, String> httpHeaderMap = httpHeaders.getReadonlyHeaderMap();
 
-        assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_HEADER_NAME), HttpHeaders.PRODUCT_HEADER_VALUE);
-        assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_VERSION_HEADER_NAME), HttpHeaders.PRODUCT_VERSION_HEADER_VALUE);
-        assertEquals(httpHeaderMap.get(HttpHeaders.OS_HEADER_NAME), HttpHeaders.OS_HEADER_VALUE);
-        assertEquals(httpHeaderMap.get(HttpHeaders.APPLICATION_NAME_HEADER_NAME), "app-name");
-        assertEquals(httpHeaderMap.get(HttpHeaders.APPLICATION_VERSION_HEADER_NAME), "app-version");
-        assertEquals(httpHeaderMap.get(HttpHeaders.CORRELATION_ID_HEADER_NAME), "correlation-id");
+        assertEquals(HttpHeaders.PRODUCT_HEADER_VALUE, httpHeaderMap.get(HttpHeaders.PRODUCT_HEADER_NAME));
+        assertEquals(HttpHeaders.PRODUCT_VERSION_HEADER_VALUE, httpHeaderMap.get(HttpHeaders.PRODUCT_VERSION_HEADER_NAME));
+        assertEquals(HttpHeaders.OS_HEADER_VALUE, httpHeaderMap.get(HttpHeaders.OS_HEADER_NAME));
+        assertEquals("app-name", httpHeaderMap.get(HttpHeaders.APPLICATION_NAME_HEADER_NAME));
+        assertEquals("app-version", httpHeaderMap.get(HttpHeaders.APPLICATION_VERSION_HEADER_NAME));
+        assertEquals("correlation-id", httpHeaderMap.get(HttpHeaders.CORRELATION_ID_HEADER_NAME));
     }
 
     @Test
@@ -66,9 +66,9 @@ class HttpHeaderTest {
 
         Map<String, String> httpHeaderMap = httpHeaders.getReadonlyHeaderMap();
 
-        assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_HEADER_NAME), HttpHeaders.PRODUCT_HEADER_VALUE);
-        assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_VERSION_HEADER_NAME), HttpHeaders.PRODUCT_VERSION_HEADER_VALUE);
-        assertEquals(httpHeaderMap.get(HttpHeaders.OS_HEADER_NAME), HttpHeaders.OS_HEADER_VALUE);
+        assertEquals(HttpHeaders.PRODUCT_HEADER_VALUE, httpHeaderMap.get(HttpHeaders.PRODUCT_HEADER_NAME));
+        assertEquals(HttpHeaders.PRODUCT_VERSION_HEADER_VALUE, httpHeaderMap.get(HttpHeaders.PRODUCT_VERSION_HEADER_NAME));
+        assertEquals(HttpHeaders.OS_HEADER_VALUE, httpHeaderMap.get(HttpHeaders.OS_HEADER_NAME));
         assertNull(httpHeaderMap.get(HttpHeaders.APPLICATION_NAME_HEADER_NAME));
         assertNull(httpHeaderMap.get(HttpHeaders.APPLICATION_VERSION_HEADER_NAME));
         assertNotNull(httpHeaderMap.get(HttpHeaders.CORRELATION_ID_HEADER_NAME));
@@ -97,7 +97,7 @@ class HttpHeaderTest {
         Map<String, String> httpHeaderMap = httpHeaders.getReadonlyHeaderMap();
 
         String expectedValue = String.format(HttpHeaders.X_ANCHOR_MAILBOX_UPN_FORMAT, upn);
-        assertEquals(httpHeaderMap.get(HttpHeaders.X_ANCHOR_MAILBOX), expectedValue);
+        assertEquals(expectedValue, httpHeaderMap.get(HttpHeaders.X_ANCHOR_MAILBOX));
     }
 
     @Test
@@ -122,7 +122,7 @@ class HttpHeaderTest {
 
         Map<String, String> httpHeaderMap = httpHeaders.getReadonlyHeaderMap();
 
-        assertEquals(httpHeaderMap.get(HttpHeaders.X_ANCHOR_MAILBOX), "oid:userObjectId@userTenantId");
+        assertEquals("oid:userObjectId@userTenantId", httpHeaderMap.get(HttpHeaders.X_ANCHOR_MAILBOX));
     }
 
     @Test
@@ -158,16 +158,16 @@ class HttpHeaderTest {
         Map<String, String> httpHeaderMap = httpHeaders.getReadonlyHeaderMap();
 
         // Standard headers
-        assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_HEADER_NAME), HttpHeaders.PRODUCT_HEADER_VALUE);
-        assertEquals(httpHeaderMap.get(HttpHeaders.PRODUCT_VERSION_HEADER_NAME), HttpHeaders.PRODUCT_VERSION_HEADER_VALUE);
-        assertEquals(httpHeaderMap.get(HttpHeaders.OS_HEADER_NAME), HttpHeaders.OS_HEADER_VALUE);
-        assertEquals(httpHeaderMap.get(HttpHeaders.APPLICATION_VERSION_HEADER_NAME), "app-version");
-        assertEquals(httpHeaderMap.get(HttpHeaders.CORRELATION_ID_HEADER_NAME), "correlation-id");
+        assertEquals(HttpHeaders.PRODUCT_HEADER_VALUE, httpHeaderMap.get(HttpHeaders.PRODUCT_HEADER_NAME));
+        assertEquals(HttpHeaders.PRODUCT_VERSION_HEADER_VALUE, httpHeaderMap.get(HttpHeaders.PRODUCT_VERSION_HEADER_NAME));
+        assertEquals(HttpHeaders.OS_HEADER_VALUE, httpHeaderMap.get(HttpHeaders.OS_HEADER_NAME));
+        assertEquals("app-version", httpHeaderMap.get(HttpHeaders.APPLICATION_VERSION_HEADER_NAME));
+        assertEquals("correlation-id", httpHeaderMap.get(HttpHeaders.CORRELATION_ID_HEADER_NAME));
 
         // Overwritten standard header
-        assertEquals(httpHeaderMap.get(HttpHeaders.APPLICATION_NAME_HEADER_NAME), uniqueAppName);
+        assertEquals(uniqueAppName, httpHeaderMap.get(HttpHeaders.APPLICATION_NAME_HEADER_NAME));
 
         // Extra header
-        assertEquals(httpHeaderMap.get(uniqueHeaderKey), uniqueHeaderValue);
+        assertEquals(uniqueHeaderValue, httpHeaderMap.get(uniqueHeaderKey));
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/MexParserTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/MexParserTest.java
@@ -48,8 +48,8 @@ class MexParserTest {
         }
 
         BindingPolicy endpoint = MexParser.getWsTrustEndpointFromMexResponse(sb.toString(), false);
-        assertEquals(endpoint.getUrl(),
-                "https://msft.sts.microsoft.com/adfs/services/trust/13/usernamemixed");
+        assertEquals("https://msft.sts.microsoft.com/adfs/services/trust/13/usernamemixed",
+                endpoint.getUrl());
     }
 
     @Test
@@ -69,7 +69,7 @@ class MexParserTest {
         }
         BindingPolicy endpoint = MexParser.getWsTrustEndpointFromMexResponse(sb
                 .toString(), false);
-        assertEquals(endpoint.getUrl(), "https://msft.sts.microsoft.com/adfs/services/trust/2005/usernamemixed");
+        assertEquals("https://msft.sts.microsoft.com/adfs/services/trust/2005/usernamemixed", endpoint.getUrl());
     }
 
     @Test
@@ -89,7 +89,7 @@ class MexParserTest {
         }
         BindingPolicy endpoint = MexParser.getPolicyFromMexResponseForIntegrated(sb
                 .toString(), false);
-        assertEquals(endpoint.getUrl(),
-                "https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport");
+        assertEquals("https://msft.sts.microsoft.com/adfs/services/trust/13/windowstransport",
+                endpoint.getUrl());
     }
 }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TelemetryTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TelemetryTest.java
@@ -69,7 +69,7 @@ class TelemetryTest {
         telemetryManager.flush(reqId, clientId);
 
         // 1 Default event, 1 API event, 1 Http event
-        assertEquals(eventsReceived.size(), 3);
+        assertEquals(3, eventsReceived.size());
     }
 
     @Test
@@ -94,7 +94,7 @@ class TelemetryTest {
         telemetryManager.flush(reqId, clientId);
 
         // API event was successful, so count should be 0
-        assertEquals(eventsReceived.size(), 0);
+        assertEquals(0, eventsReceived.size());
         eventsReceived.clear();
 
         String reqId2 = telemetryManager.generateRequestId();
@@ -111,19 +111,19 @@ class TelemetryTest {
         telemetryManager.flush(reqId2, clientId);
 
         // API event failed, so count should be 3 (1 default, 1 Api, 1 http)
-        assertEquals(eventsReceived.size(), 3);
+        assertEquals(3, eventsReceived.size());
     }
 
     @Test
     void telemetryInternalApi_ScrubTenantFromUriTest() throws Exception {
-        assertEquals(Event.scrubTenant(new URI("https://login.microsoftonline.com/common/oauth2/v2.0/token")),
-                "https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token");
+        assertEquals("https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token",
+                Event.scrubTenant(new URI("https://login.microsoftonline.com/common/oauth2/v2.0/token")));
 
-        assertEquals(Event.scrubTenant(new URI("https://login.microsoftonline.com/common")),
-                "https://login.microsoftonline.com/<tenant>");
+        assertEquals("https://login.microsoftonline.com/<tenant>",
+                Event.scrubTenant(new URI("https://login.microsoftonline.com/common")));
 
-        assertEquals(Event.scrubTenant(new URI("https://login.microsoftonline.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_ROPC_Auth")),
-                "https://login.microsoftonline.com/tfp/<tenant>/B2C_1_ROPC_Auth");
+        assertEquals("https://login.microsoftonline.com/tfp/<tenant>/B2C_1_ROPC_Auth",
+                Event.scrubTenant(new URI("https://login.microsoftonline.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_ROPC_Auth")));
 
         assertNull(Event.scrubTenant(new URI("https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_ROPC_Auth")));
 
@@ -150,7 +150,7 @@ class TelemetryTest {
 
         telemetryManager.flush(reqId, clientId);
 
-        assertEquals(eventsReceived.get(0).get("event_name"), "msal.default_event");
+        assertEquals("msal.default_event", eventsReceived.get(0).get("event_name"));
     }
 
     @Test
@@ -172,7 +172,7 @@ class TelemetryTest {
         telemetryManager.stopEvent(reqId, apiEvent1);
         telemetryManager.flush(reqId, clientId);
 
-        assertEquals(eventsReceived.size(), 3);
+        assertEquals(3, eventsReceived.size());
         assertTrue(eventsReceived.stream().anyMatch(event -> event.get("event_name").equals("msal.http_event")));
     }
 
@@ -197,7 +197,7 @@ class TelemetryTest {
 
         telemetryManager.flush(reqId, clientId);
 
-        assertEquals(eventsReceived.size(), 2);
+        assertEquals(2, eventsReceived.size());
         assertFalse(eventsReceived.stream().anyMatch(event -> event.get("event_name").equals("msal.http_event")));
     }
 
@@ -217,7 +217,7 @@ class TelemetryTest {
         telemetryManager.stopEvent(reqId, apiEvent);
 
         assertNotNull(apiEvent.get("msal.tenant_id"));
-        assertNotEquals(apiEvent.get("msal.tenant_id"), tenantId);
+        assertNotEquals(tenantId, apiEvent.get("msal.tenant_id"));
     }
 
     @Test
@@ -251,7 +251,7 @@ class TelemetryTest {
         apiEvent.setWasSuccessful(true);
         telemetryManager.stopEvent(reqId, apiEvent);
 
-        assertEquals(apiEvent.get("msal.authority"), "https://login.microsoftonline.com");
+        assertEquals("https://login.microsoftonline.com", apiEvent.get("msal.authority"));
 
 
         ApiEvent apiEvent2 = new ApiEvent(false);
@@ -268,10 +268,10 @@ class TelemetryTest {
         String responseHeader = "1,0,0,,";
         XmsClientTelemetryInfo info = XmsClientTelemetryInfo.parseXmsTelemetryInfo(responseHeader);
 
-        assertEquals(info.getServerErrorCode(), "0");
-        assertEquals(info.getServerSubErrorCode(), "0");
-        assertEquals(info.getTokenAge(), "");
-        assertEquals(info.getSpeInfo(), "");
+        assertEquals("0", info.getServerErrorCode());
+        assertEquals("0", info.getServerSubErrorCode());
+        assertEquals("", info.getTokenAge());
+        assertEquals("", info.getSpeInfo());
     }
 
     @Test

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/TokenRequestExecutorTest.java
@@ -65,7 +65,7 @@ class TokenRequestExecutorTest {
             fail("Expected MsalServiceException was not thrown");
         } catch (MsalInteractionRequiredException ex) {
             assertEquals(claims.replace("\\", ""), ex.claims());
-            assertEquals(ex.reason(), InteractionRequiredExceptionReason.BASIC_ACTION);
+            assertEquals(InteractionRequiredExceptionReason.BASIC_ACTION, ex.reason());
         }
     }
 
@@ -239,7 +239,7 @@ class TokenRequestExecutorTest {
 
         assertNotNull(result.account());
         assertNotNull(result.account().homeAccountId());
-        assertEquals(result.account().username(), "idlab@msidlab4.onmicrosoft.com");
+        assertEquals("idlab@msidlab4.onmicrosoft.com", result.account().username());
 
         assertFalse(StringHelper.isBlank(result.accessToken()));
         assertFalse(StringHelper.isBlank(result.refreshToken()));

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/WSTrustRequestTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/WSTrustRequestTest.java
@@ -50,7 +50,7 @@ class WSTrustRequestTest {
         String DATA_TO_ESCAPE = "o_!as & a34~'fe<> \" a1";
         String XML_ESCAPED_DATA = "o_!as &amp; a34~&apos;fe&lt;&gt; &quot; a1";
 
-        assertEquals(WSTrustRequest.escapeXMLElementData(DATA_TO_ESCAPE), XML_ESCAPED_DATA);
+        assertEquals(XML_ESCAPED_DATA, WSTrustRequest.escapeXMLElementData(DATA_TO_ESCAPE));
         assertEquals(WSTrustRequest.escapeXMLElementData(DATA_TO_ESCAPE),
                 StringEscapeUtils.escapeXml10(DATA_TO_ESCAPE));
     }


### PR DESCRIPTION
Based on the changes/branch in this other PR of test improvements: https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/1031

This PR is meant to handle a minor but widespread code quality issue in our unit tests: JUnit's `assertEquals` method expects to be given parameters like `(expectedValue, actualValue)`, but about a quarter of the time we passed in `(actualValue, expectedValue)`

This doesn't affect the actual test behavior in any meaningful way, but can easily create confusion when looking at logs in failing pipelines. This PR should correct the order in every usage of `assertEquals`

Unrelated to that, this PR also adjusts a couple of integration test classes in order to use existing helpers for some common assertion patterns (mainly validating the existence/absence of tokens in a result).

These changes are more-or-less just stylistic and code quality issues, and will not affect the source code or current test coverage.