### PR TITLE
Update test dependencies and build plugins

### DIFF
--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -114,7 +114,19 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>3.14.0</version>
+            <version>4.13.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.14.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.6.2</version>
+            <version>1.7.36</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.14.5</version>
+            <version>1.17.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.14.0</version>
+            <version>2.22.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -169,7 +169,7 @@
             <plugin>
                 <groupId>org.revapi</groupId>
                 <artifactId>revapi-maven-plugin</artifactId>
-                <version>0.15.0</version>
+                <version>0.15.1</version>
                 <configuration>
                     <analysisConfiguration>
                         <revapi.java>
@@ -183,7 +183,7 @@
                     <dependency>
                         <groupId>org.revapi</groupId>
                         <artifactId>revapi-java</artifactId>
-                        <version>0.28.1</version>
+                        <version>0.28.4</version>
                     </dependency>
                 </dependencies>
                 <executions>
@@ -199,7 +199,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.5.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -213,7 +213,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.5.6</version>
                 <configuration>
                     <argLine>@{argLine} -noverify</argLine>
                     <skipTests>${skip.unit.tests}</skipTests>
@@ -222,7 +222,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.12.0</version>
                 <configuration>
                     <sourcepath>src/main/java</sourcepath>
                 </configuration>
@@ -238,7 +238,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -251,12 +251,12 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.11</version>
+                <version>4.2.3</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.15.0</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
@@ -265,7 +265,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.10</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>add-test-source</id>
@@ -284,7 +284,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.5.6</version>
                 <executions>
                     <execution>
                         <goals>
@@ -303,7 +303,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>5.2.0</version>
+                <version>6.4.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -315,7 +315,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.13</version>
                 <executions>
                     <execution>
                         <goals>
@@ -360,7 +360,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.11.0</version>
             </plugin>
         </plugins>
     </build>

--- a/msal4j-sdk/src/integrationtest/java/infrastructure/SeleniumExtensions.java
+++ b/msal4j-sdk/src/integrationtest/java/infrastructure/SeleniumExtensions.java
@@ -28,14 +28,14 @@ public class SeleniumExtensions {
 
     public static WebDriver createDefaultWebDriver() {
         ChromeOptions options = new ChromeOptions();
-        options.addArguments("--headless");
+        options.addArguments("--headless=new");
         options.addArguments("--incognito");
 
         return new ChromeDriver(options);
     }
 
     public static WebElement waitForElementToBeVisibleAndEnabled(WebDriver driver, By by, Duration timeout) {
-        WebDriverWait wait = new WebDriverWait(driver, timeout.getSeconds());
+        WebDriverWait wait = new WebDriverWait(driver, timeout);
         return wait.until(ExpectedConditions.elementToBeClickable(by));
     }
 

--- a/msal4j-sdk/src/integrationtest/java/infrastructure/pageobjects/ADFSLoginPage.java
+++ b/msal4j-sdk/src/integrationtest/java/infrastructure/pageobjects/ADFSLoginPage.java
@@ -32,7 +32,7 @@ public class ADFSLoginPage {
 
     public ADFSLoginPage(WebDriver driver) {
         this.driver = driver;
-        this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT.getSeconds());
+        this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT);
     }
 
     /**

--- a/msal4j-sdk/src/integrationtest/java/infrastructure/pageobjects/AzureADLoginPage.java
+++ b/msal4j-sdk/src/integrationtest/java/infrastructure/pageobjects/AzureADLoginPage.java
@@ -43,7 +43,7 @@ public class AzureADLoginPage {
 
     public AzureADLoginPage(WebDriver driver) {
         this.driver = driver;
-        this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT.getSeconds());
+        this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT);
     }
 
     /**
@@ -103,7 +103,7 @@ public class AzureADLoginPage {
      */
     public boolean isAuthenticationComplete() {
         try {
-            WebDriverWait shortWait = new WebDriverWait(driver, SHORT_TIMEOUT.getSeconds());
+            WebDriverWait shortWait = new WebDriverWait(driver, SHORT_TIMEOUT);
             shortWait.until(ExpectedConditions.textToBePresentInElementLocated(
                     AUTH_COMPLETE_BODY, AUTH_COMPLETE_TEXT));
             LOG.info("Authentication complete page detected");
@@ -150,7 +150,7 @@ public class AzureADLoginPage {
     private void handleAreYouTryingToSignInPrompt() {
         try {
             LOG.info("Checking for 'Are you trying to sign in' prompt");
-            WebDriverWait shortWait = new WebDriverWait(driver, SHORT_TIMEOUT.getSeconds());
+            WebDriverWait shortWait = new WebDriverWait(driver, SHORT_TIMEOUT);
             shortWait.until(ExpectedConditions.elementToBeClickable(ARE_YOU_TRYING_TO_SIGN_IN_BUTTON))
                     .click();
             LOG.info("Clicked Continue on 'Are you trying to sign in' prompt");
@@ -165,7 +165,7 @@ public class AzureADLoginPage {
     private void handleStaySignedInPrompt() {
         try {
             LOG.info("Checking for 'Stay signed in' prompt");
-            WebDriverWait shortWait = new WebDriverWait(driver, SHORT_TIMEOUT.getSeconds());
+            WebDriverWait shortWait = new WebDriverWait(driver, SHORT_TIMEOUT);
             shortWait.until(ExpectedConditions.elementToBeClickable(STAY_SIGNED_IN_NO_BUTTON))
                     .click();
             LOG.info("Clicked No on 'Stay signed in' prompt");

--- a/msal4j-sdk/src/integrationtest/java/infrastructure/pageobjects/B2CLocalLoginPage.java
+++ b/msal4j-sdk/src/integrationtest/java/infrastructure/pageobjects/B2CLocalLoginPage.java
@@ -33,7 +33,7 @@ public class B2CLocalLoginPage {
 
     public B2CLocalLoginPage(WebDriver driver) {
         this.driver = driver;
-        this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT.getSeconds());
+        this.wait = new WebDriverWait(driver, DEFAULT_TIMEOUT);
     }
 
     /**


### PR DESCRIPTION
This PR updates various dependencies and plugins only used in our tests and builds, generally to the latest available version that is still compatible with Java 8.

The only breaking changes were in the Selenium update, which had some minor API changes between major versions, and the changes should not affect source code or our pipelines.