### PR TITLE
Migrate region discovery to IMDS /compute JSON endpoint

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
@@ -28,8 +28,8 @@ class AadInstanceDiscoveryProvider {
     private static final int PORT_NOT_SET = -1;
 
     // For information of the current api-version refer: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service#versioning
-    private static final String DEFAULT_API_VERSION = "2020-06-01";
-    private static final String IMDS_ENDPOINT = "http://169.254.169.254/metadata/instance/compute/location?api-version=" + DEFAULT_API_VERSION + "&format=text";
+    private static final String DEFAULT_API_VERSION = "2021-02-01";
+    private static final String IMDS_ENDPOINT = "http://169.254.169.254/metadata/instance/compute?api-version=" + DEFAULT_API_VERSION;
 
     private static final int IMDS_TIMEOUT = 2;
     private static final TimeUnit IMDS_TIMEOUT_UNIT = TimeUnit.SECONDS;
@@ -319,14 +319,17 @@ class AadInstanceDiscoveryProvider {
         try {
             LOG.info("Starting call to IMDS endpoint.");
             IHttpResponse httpResponse = future.get(IMDS_TIMEOUT, IMDS_TIMEOUT_UNIT);
-            //If call to IMDS endpoint was successful, return region from response body
+            //If call to IMDS endpoint was successful, parse the region from the JSON response body
             if (httpResponse.statusCode() == HttpStatus.HTTP_OK && !httpResponse.body().isEmpty()) {
-                LOG.info("Region retrieved from IMDS endpoint: {}", httpResponse.body());
-                currentRequest.regionSource(RegionTelemetry.REGION_SOURCE_IMDS.telemetryValue);
+                String region = parseRegionFromImdsResponse(httpResponse.body());
+                if (!StringHelper.isBlank(region)) {
+                    LOG.info("Region retrieved from IMDS endpoint: {}", region);
+                    currentRequest.regionSource(RegionTelemetry.REGION_SOURCE_IMDS.telemetryValue);
 
-                return httpResponse.body();
+                    return region;
+                }
             }
-            LOG.warn("Call to local IMDS failed with status code: {}, or response was empty", httpResponse.statusCode());
+            LOG.warn("Call to local IMDS failed with status code: {}, or response was empty or missing a region", httpResponse.statusCode());
             currentRequest.regionSource(RegionTelemetry.REGION_SOURCE_FAILED_AUTODETECT.telemetryValue);
         } catch (Exception ex) {
             // handle other exceptions
@@ -342,6 +345,30 @@ class AadInstanceDiscoveryProvider {
         }
 
         return null;
+    }
+
+    /**
+     * Parses the region from the IMDS {@code /compute} JSON response body, reading the
+     * {@code location} field. Returns {@code null} when the body is blank, the
+     * {@code location} field is missing/null, or the body is not valid JSON, so that all
+     * unusable responses funnel into the same failed-autodetection path.
+     */
+    static String parseRegionFromImdsResponse(String responseBody) {
+        if (StringHelper.isBlank(responseBody)) {
+            return null;
+        }
+
+        try {
+            ImdsComputeResponse computeResponse = JsonHelper.convertJsonStringToJsonSerializableObject(
+                    responseBody, ImdsComputeResponse::fromJson);
+
+            return computeResponse == null ? null : computeResponse.location();
+        } catch (Exception ex) {
+            //Malformed JSON: treat as an unusable response (region stays null) so the failure
+            //  is consistent with the empty/missing-location cases instead of surfacing a parse error
+            LOG.warn("Failed to parse IMDS compute response: {}", ex.getMessage());
+            return null;
+        }
     }
 
     private static void doInstanceDiscoveryAndCache(URL authorityUrl,

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
@@ -320,7 +320,7 @@ class AadInstanceDiscoveryProvider {
             LOG.info("Starting call to IMDS endpoint.");
             IHttpResponse httpResponse = future.get(IMDS_TIMEOUT, IMDS_TIMEOUT_UNIT);
             //If call to IMDS endpoint was successful, parse the region from the JSON response body
-            if (httpResponse.statusCode() == HttpStatus.HTTP_OK && !httpResponse.body().isEmpty()) {
+            if (httpResponse.statusCode() == HttpStatus.HTTP_OK) {
                 String region = parseRegionFromImdsResponse(httpResponse.body());
                 if (!StringHelper.isBlank(region)) {
                     LOG.info("Region retrieved from IMDS endpoint: {}", region);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ImdsComputeResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ImdsComputeResponse.java
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import com.azure.json.JsonReader;
+import com.azure.json.JsonSerializable;
+import com.azure.json.JsonToken;
+import com.azure.json.JsonWriter;
+
+import java.io.IOException;
+
+/**
+ * Response body returned by the IMDS compute metadata endpoint
+ * (http://169.254.169.254/metadata/instance/compute). Only the {@code location}
+ * field is used for region auto-discovery; all other fields are ignored.
+ */
+class ImdsComputeResponse implements JsonSerializable<ImdsComputeResponse> {
+
+    String location;
+
+    public ImdsComputeResponse() {
+    }
+
+    String location() {
+        return this.location;
+    }
+
+    public static ImdsComputeResponse fromJson(JsonReader jsonReader) throws IOException {
+        ImdsComputeResponse response = new ImdsComputeResponse();
+        return jsonReader.readObject(reader -> {
+            while (reader.nextToken() != JsonToken.END_OBJECT) {
+                String fieldName = reader.getFieldName();
+                reader.nextToken();
+                if ("location".equals(fieldName)) {
+                    response.location = reader.getString();
+                } else {
+                    reader.skipChildren();
+                }
+            }
+            return response;
+        });
+    }
+
+    public JsonWriter toJson(JsonWriter jsonWriter) throws IOException {
+        jsonWriter.writeStartObject();
+        jsonWriter.writeStringField("location", location);
+        jsonWriter.writeEndObject();
+        return jsonWriter;
+    }
+}

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/RegionDiscoveryTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/RegionDiscoveryTest.java
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RegionDiscoveryTest {
+
+    @Test
+    void parseRegionFromImdsResponse_validLocation_returnsRegion() {
+        String body = "{\"location\":\"centralus\",\"vmId\":\"11111111-1111-1111-1111-111111111111\"}";
+
+        assertEquals("centralus", AadInstanceDiscoveryProvider.parseRegionFromImdsResponse(body));
+    }
+
+    @Test
+    void parseRegionFromImdsResponse_locationWithExtraNestedFields_returnsRegion() {
+        //The real /compute payload contains many extra fields, including nested objects and arrays
+        String body = "{\"azEnvironment\":\"AzurePublicCloud\",\"location\":\"westus2\"," +
+                "\"tagsList\":[{\"name\":\"t\",\"value\":\"v\"}],\"storageProfile\":{\"osDisk\":{\"diskSizeGB\":\"30\"}}}";
+
+        assertEquals("westus2", AadInstanceDiscoveryProvider.parseRegionFromImdsResponse(body));
+    }
+
+    @Test
+    void parseRegionFromImdsResponse_missingLocation_returnsNull() {
+        String body = "{\"vmId\":\"11111111-1111-1111-1111-111111111111\"}";
+
+        assertNull(AadInstanceDiscoveryProvider.parseRegionFromImdsResponse(body));
+    }
+
+    @Test
+    void parseRegionFromImdsResponse_nullLocation_returnsNull() {
+        String body = "{\"location\":null}";
+
+        assertNull(AadInstanceDiscoveryProvider.parseRegionFromImdsResponse(body));
+    }
+
+    @Test
+    void parseRegionFromImdsResponse_malformedJson_returnsNull() {
+        String body = "{ this is not valid json";
+
+        assertNull(AadInstanceDiscoveryProvider.parseRegionFromImdsResponse(body));
+    }
+
+    @Test
+    void parseRegionFromImdsResponse_emptyBody_returnsNull() {
+        assertNull(AadInstanceDiscoveryProvider.parseRegionFromImdsResponse(""));
+        assertNull(AadInstanceDiscoveryProvider.parseRegionFromImdsResponse(null));
+    }
+}


### PR DESCRIPTION
## Summary

Ports [microsoft-authentication-library-for-dotnet PR #6057](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6057) to msal-java.

Migrates Azure region auto-discovery from the legacy IMDS **text** endpoint `/metadata/instance/compute/location` (`api-version=2020-06-01`, `format=text`) to the newer **JSON** endpoint `/metadata/instance/compute` (`api-version=2021-02-01`), reading the `location` field.

No public API change (the affected constants are `private`), no telemetry schema change, no feature flag. `REGION_NAME` env-var precedence, the 2s IMDS timeout, the process-wide cache, region telemetry source values, and the fallback-to-global behavior are all preserved.

## What changed

- **`AadInstanceDiscoveryProvider.java`**: `DEFAULT_API_VERSION` -> `2021-02-01`; `IMDS_ENDPOINT` drops `/location` and `&format=text`. `discoverRegion` now parses the JSON body and reads `location` instead of returning the raw response body.
- **New `ImdsComputeResponse.java`** DTO implementing `JsonSerializable` with a single `location` field (`fromJson` reads `location` and `skipChildren()` on all other fields, tolerating the large `/compute` payload), mirroring the existing `InstanceDiscoveryMetadataEntry` pattern.
- **New `parseRegionFromImdsResponse` helper**: returns `null` for blank body, missing/null `location`, or malformed JSON, so all unusable responses funnel into the existing `REGION_SOURCE_FAILED_AUTODETECT` path (matching dotnet's explicit try/catch behavior).
- **Tests** (new `RegionDiscoveryTest.java`): valid `location`, `location` among extra nested fields, missing `location`, null `location`, malformed JSON, and empty/null body.

## Note

Unlike the dotnet implementation, msal-java's `discoverRegion` has no api-version negotiation / 400-fallback path, so there is only a single success branch to update.

## Testing

- `mvn -pl msal4j-sdk test -Dtest=RegionDiscoveryTest` -> 6/6 pass.
- `AadInstanceDiscoveryTest`, `ServerTelemetryTests`, `SovereignCloudInstanceDiscoveryTest` -> 15/15 pass (no regressions).
