### PR TITLE
Add DateTimeTests coverage for past expires_on timestamps

### DIFF
--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/DateTimeTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/DateTimeTests.java
@@ -33,7 +33,7 @@ class DateTimeTests {
         long result = AcquireTokenByManagedIdentitySupplier.getExpiresOnFromManagedIdentityTimestamp(String.valueOf(pastTimestamp));
 
         assertEquals(pastTimestamp, result, "A past Unix timestamp should be returned as its absolute value");
-        assertTrue(result <= now, "A past expires_on must not be turned into a future/inflated expiry");
+        assertTrue(result < now, "A past expires_on must not be turned into a future/inflated expiry");
     }
 
     @Test

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/DateTimeTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/DateTimeTests.java
@@ -24,6 +24,19 @@ class DateTimeTests {
     }
 
     @Test
+    void parsePastUnixTimestampIsNotInflated() {
+        // A past absolute expires_on must be returned as an absolute epoch value that is
+        // still in the past, so downstream cache validation treats the token as expired.
+        // It must NOT be converted into a future/inflated expiry.
+        long now = System.currentTimeMillis() / 1000;
+        long pastTimestamp = now - 3600; // 1 hour ago
+        long result = AcquireTokenByManagedIdentitySupplier.getExpiresOnFromManagedIdentityTimestamp(String.valueOf(pastTimestamp));
+
+        assertEquals(pastTimestamp, result, "A past Unix timestamp should be returned as its absolute value");
+        assertTrue(result <= now, "A past expires_on must not be turned into a future/inflated expiry");
+    }
+
+    @Test
     void parseIso8601Format() {
         // Creates a timestamp in ISO 8601 format, with 24 hours added to it to represent a 24-hour token
         String timestamp = DateTimeFormatter.ISO_INSTANT.format(Instant.now().plus(24, ChronoUnit.HOURS));


### PR DESCRIPTION
Adds a unit test in `DateTimeTests` for `getExpiresOnFromManagedIdentityTimestamp` covering a **past Unix `expires_on`** timestamp — a case the existing tests do not cover (they exercise current, future, ISO-8601, null, empty, and invalid inputs).

Verifies that a past absolute timestamp is returned as its absolute epoch value (still in the past), and is not turned into a future/inflated expiry.