### PR TITLE
Extract shared ExtendedCacheKey helper to de-duplicate cache-key plumbing

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AuthorizationCodeParameters.java
@@ -37,12 +37,9 @@ public class AuthorizationCodeParameters implements IAcquireTokenParameters {
 
     private String clientClaims;
 
-    // Generic extended cache key components. The hash of these components isolates cache
+    // Generic extended cache key. The hash of the contributed components isolates cache
     // entries so that requests with different client-claims values do not collide.
-    private SortedMap<String, String> cacheKeyComponents;
-
-    // Memoized hash of cacheKeyComponents (computed once since parameters are immutable).
-    private String extCacheKeyHashCache;
+    private final ExtendedCacheKey extendedCacheKey;
 
     private AuthorizationCodeParameters(String authorizationCode, URI redirectUri,
                                         Set<String> scopes, ClaimsRequest claims,
@@ -60,7 +57,7 @@ public class AuthorizationCodeParameters implements IAcquireTokenParameters {
         this.clientClaims = clientClaims;
 
         // Build cache key components from any parameters that require cache isolation.
-        this.cacheKeyComponents = buildCacheKeyComponents();
+        this.extendedCacheKey = new ExtendedCacheKey(buildCacheKeyComponents());
     }
 
     private static AuthorizationCodeParametersBuilder builder() {
@@ -144,24 +141,12 @@ public class AuthorizationCodeParameters implements IAcquireTokenParameters {
     }
 
     /**
-     * Returns the extended cache key components for this request, if any.
-     * Used by {@link TokenCache} for both cache writes and reads.
-     */
-    SortedMap<String, String> cacheKeyComponents() {
-        return this.cacheKeyComponents;
-    }
-
-    /**
      * Computes the extended cache key hash from all cache key components, or an empty string when
      * there are none. The result is memoized since the parameters are immutable after construction.
      */
     @Override
     public String computeExtCacheKeyHash() {
-        if (extCacheKeyHashCache != null) {
-            return extCacheKeyHashCache;
-        }
-        extCacheKeyHashCache = StringHelper.computeExtCacheKeyHash(cacheKeyComponents);
-        return extCacheKeyHashCache;
+        return extendedCacheKey.computeHash();
     }
 
     public static class AuthorizationCodeParametersBuilder {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ClientCredentialParameters.java
@@ -34,13 +34,10 @@ public class ClientCredentialParameters implements IAcquireTokenParameters {
 
     private String clientClaims;
 
-    // Generic extended cache key components. Any optional or flow-specific parameters 
-    // that should influence token cache isolation adds an entry here. The hash of these
-    // components is used as part of the cache key in relevant scenarios entries.
-    private SortedMap<String, String> cacheKeyComponents;
-
-    // Memoized hash of cacheKeyComponents (computed once since parameters are immutable).
-    private String extCacheKeyHashCache;
+    // Generic extended cache key. Any optional or flow-specific parameters that should influence
+    // token cache isolation are contributed via buildCacheKeyComponents(); the hash of those
+    // components is used as part of the cache key in relevant scenarios.
+    private final ExtendedCacheKey extendedCacheKey;
 
     private ClientCredentialParameters(Set<String> scopes, Boolean skipCache, ClaimsRequest claims, Map<String, String> extraHttpHeaders, Map<String, String> extraQueryParameters, String tenant, IClientCredential clientCredential, String fmiPath, String clientClaims) {
         this.scopes = scopes;
@@ -54,7 +51,7 @@ public class ClientCredentialParameters implements IAcquireTokenParameters {
         this.clientClaims = clientClaims;
 
         // Build cache key components from any parameters that require cache isolation.
-        this.cacheKeyComponents = buildCacheKeyComponents();
+        this.extendedCacheKey = new ExtendedCacheKey(buildCacheKeyComponents());
     }
 
     private static ClientCredentialParametersBuilder builder() {
@@ -150,14 +147,6 @@ public class ClientCredentialParameters implements IAcquireTokenParameters {
     }
 
     /**
-     * Returns the extended cache key components for this request, if any.
-     * Used by {@link TokenCache} for both cache writes and reads.
-     */
-    SortedMap<String, String> cacheKeyComponents() {
-        return this.cacheKeyComponents;
-    }
-
-    /**
      * Computes the extended cache key hash from all cache key components.
      * Returns an empty string if no components are present.
      * <p>
@@ -166,11 +155,7 @@ public class ClientCredentialParameters implements IAcquireTokenParameters {
      */
     @Override
     public String computeExtCacheKeyHash() {
-        if (extCacheKeyHashCache != null) {
-            return extCacheKeyHashCache;
-        }
-        extCacheKeyHashCache = StringHelper.computeExtCacheKeyHash(cacheKeyComponents);
-        return extCacheKeyHashCache;
+        return extendedCacheKey.computeHash();
     }
 
     public static class ClientCredentialParametersBuilder {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ExtendedCacheKey.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ExtendedCacheKey.java
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.microsoft.aad.msal4j;
+
+import java.util.SortedMap;
+
+/**
+ * Holds the extended cache-key components contributed by a request's parameters and lazily
+ * computes their hash. Extended cache-key components (for example {@code fmi_path} or
+ * {@code client_claims}) isolate token-cache entries so that requests with different component
+ * values do not collide.
+ * <p>
+ * Shared by the {@code *Parameters} classes that expose
+ * {@link IAcquireTokenParameters#computeExtCacheKeyHash()} so the storage-and-memoization
+ * boilerplate lives in one place instead of being copied per class. The hash is memoized because
+ * the owning parameters object is immutable after construction.
+ */
+final class ExtendedCacheKey {
+
+    private final SortedMap<String, String> components;
+
+    // Memoized hash of the components (computed once since the owning parameters are immutable).
+    private String hashCache;
+
+    ExtendedCacheKey(SortedMap<String, String> components) {
+        this.components = components;
+    }
+
+    /**
+     * Computes the Base64URL-encoded SHA-256 hash of the cache-key components, or an empty string
+     * when there are none. The result is memoized.
+     */
+    String computeHash() {
+        if (hashCache == null) {
+            hashCache = StringHelper.computeExtCacheKeyHash(components);
+        }
+        return hashCache;
+    }
+}

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/OnBehalfOfParameters.java
@@ -27,12 +27,9 @@ public class OnBehalfOfParameters implements IAcquireTokenParameters {
     private String tenant;
     private String clientClaims;
 
-    // Generic extended cache key components. The hash of these components isolates cache
+    // Generic extended cache key. The hash of the contributed components isolates cache
     // entries so that requests with different client-claims values do not collide.
-    private SortedMap<String, String> cacheKeyComponents;
-
-    // Memoized hash of cacheKeyComponents (computed once since parameters are immutable).
-    private String extCacheKeyHashCache;
+    private final ExtendedCacheKey extendedCacheKey;
 
     private OnBehalfOfParameters(Set<String> scopes, Boolean skipCache, IUserAssertion userAssertion, ClaimsRequest claims, Map<String, String> extraHttpHeaders, Map<String, String> extraQueryParameters, String tenant, String clientClaims) {
         this.scopes = scopes;
@@ -46,7 +43,7 @@ public class OnBehalfOfParameters implements IAcquireTokenParameters {
         this.clientClaims = clientClaims;
 
         // Build cache key components from any parameters that require cache isolation.
-        this.cacheKeyComponents = buildCacheKeyComponents();
+        this.extendedCacheKey = new ExtendedCacheKey(buildCacheKeyComponents());
     }
 
     private static OnBehalfOfParametersBuilder builder() {
@@ -126,24 +123,12 @@ public class OnBehalfOfParameters implements IAcquireTokenParameters {
     }
 
     /**
-     * Returns the extended cache key components for this request, if any.
-     * Used by {@link TokenCache} for both cache writes and reads.
-     */
-    SortedMap<String, String> cacheKeyComponents() {
-        return this.cacheKeyComponents;
-    }
-
-    /**
      * Computes the extended cache key hash from all cache key components, or an empty string when
      * there are none. The result is memoized since the parameters are immutable after construction.
      */
     @Override
     public String computeExtCacheKeyHash() {
-        if (extCacheKeyHashCache != null) {
-            return extCacheKeyHashCache;
-        }
-        extCacheKeyHashCache = StringHelper.computeExtCacheKeyHash(cacheKeyComponents);
-        return extCacheKeyHashCache;
+        return extendedCacheKey.computeHash();
     }
 
     public static class OnBehalfOfParametersBuilder {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserFederatedIdentityCredentialParameters.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/UserFederatedIdentityCredentialParameters.java
@@ -33,12 +33,9 @@ public class UserFederatedIdentityCredentialParameters implements IAcquireTokenP
     private String tenant;
     private String clientClaims;
 
-    // Generic extended cache key components. The hash of these components isolates cache
+    // Generic extended cache key. The hash of the contributed components isolates cache
     // entries so that requests with different client-claims values do not collide.
-    private SortedMap<String, String> cacheKeyComponents;
-
-    // Memoized hash of cacheKeyComponents (computed once since parameters are immutable).
-    private String extCacheKeyHashCache;
+    private final ExtendedCacheKey extendedCacheKey;
 
     private UserFederatedIdentityCredentialParameters(
             Set<String> scopes,
@@ -63,7 +60,7 @@ public class UserFederatedIdentityCredentialParameters implements IAcquireTokenP
         this.clientClaims = clientClaims;
 
         // Build cache key components from any parameters that require cache isolation.
-        this.cacheKeyComponents = buildCacheKeyComponents();
+        this.extendedCacheKey = new ExtendedCacheKey(buildCacheKeyComponents());
     }
 
     /**
@@ -185,24 +182,12 @@ public class UserFederatedIdentityCredentialParameters implements IAcquireTokenP
     }
 
     /**
-     * Returns the extended cache key components for this request, if any.
-     * Used by {@link TokenCache} for both cache writes and reads.
-     */
-    SortedMap<String, String> cacheKeyComponents() {
-        return this.cacheKeyComponents;
-    }
-
-    /**
      * Computes the extended cache key hash from all cache key components, or an empty string when
      * there are none. The result is memoized since the parameters are immutable after construction.
      */
     @Override
     public String computeExtCacheKeyHash() {
-        if (extCacheKeyHashCache != null) {
-            return extCacheKeyHashCache;
-        }
-        extCacheKeyHashCache = StringHelper.computeExtCacheKeyHash(cacheKeyComponents);
-        return extCacheKeyHashCache;
+        return extendedCacheKey.computeHash();
     }
 
     public static class UserFederatedIdentityCredentialParametersBuilder {


### PR DESCRIPTION
Follow-up cleanup addressing review feedback on #1039. Stacked on `rginsburg/client_claims` (the #1039 branch); base auto-retargets to `dev` once #1039 merges.

The extended-cache-key storage/memoization/hash-delegation boilerplate was copy-pasted across four `*Parameters` classes: `ClientCredentialParameters`, `OnBehalfOfParameters`, `UserFederatedIdentityCredentialParameters`, and `AuthorizationCodeParameters`. This extracts it into one package-private `ExtendedCacheKey` helper (composition, not a base class -- avoids a construction-ordering hazard). Each class keeps only its distinct `buildCacheKeyComponents()` logic. Also removes the unused `cacheKeyComponents()` getter (dead code, zero callers).

Behavior-preserving: the hash algorithm (`StringHelper.computeExtCacheKeyHash`) and memoization semantics are unchanged. `ClientClaimsTest`, `FmiTest` (golden cross-SDK hash), `UserFederatedIdentityCredentialTest`, and `ManagedIdentityTests` all pass with identical counts.
