### PR TITLE
Version updates for 1.25.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@
 - **Main Package**: `com.microsoft.aad.msal4j`
 - **Three Application Types**: `PublicClientApplication`, `ConfidentialClientApplication`, `ManagedIdentityApplication`
 - **Pattern**: Each auth flow has `*Parameters` (public API), `*Request` (internal), `*Supplier` (executor)
-- **Current Version**: 1.25.0
+- **Current Version**: 1.25.1
 
 ---
 
@@ -16,7 +16,7 @@
 
 - **Language**: Java 8+
 - **Build Tool**: Maven
-- **Current Version**: 1.25.0
+- **Current Version**: 1.25.1
 - **Artifact**: `com.microsoft.azure:msal4j`
 - **Key Protocols**: OAuth2, OpenID Connect
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Quick links:
 The library supports the following Java environments:
 - Java 8 (or higher)
 
-Current version - 1.25.0
+Current version - 1.25.1
 
 You can find the changes for each version in the [change log](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/main/msal4j-sdk/changelog.txt).
 
@@ -28,13 +28,13 @@ Find [the latest package in the Maven repository](https://mvnrepository.com/arti
 <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>msal4j</artifactId>
-    <version>1.25.0</version>
+    <version>1.25.1</version>
 </dependency>
 ```
 ### Gradle
 
 ```gradle
-implementation group: 'com.microsoft.azure', name: 'com.microsoft.aad.msal4j', version: '1.25.0'
+implementation group: 'com.microsoft.azure', name: 'com.microsoft.aad.msal4j', version: '1.25.1'
 ```
 
 ## Usage

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+Version 1.25.1
+=============
+- Add claimsFromClient API for client-originated claims on confidential-client flows (#1039)
+- Migrate region discovery to IMDS /compute JSON endpoint (#1038)
+- Bump Azure Arc HIMDS api-version from 2019-11-01 to 2020-06-01 (#1045)
+- Extract shared ExtendedCacheKey helper to de-duplicate cache-key plumbing (#1046)
+- Fix refreshed tokens not staying in their client-claims cache partition (#1039)
+
 Version 1.25.0
 =============
 - Add Federated Managed Identity (FMI) support for client credentials flow (#1025)

--- a/msal4j-sdk/README.md
+++ b/msal4j-sdk/README.md
@@ -16,7 +16,7 @@ Quick links:
 The library supports the following Java environments:
 - Java 8 (or higher)
 
-Current version - 1.25.0
+Current version - 1.25.1
 
 You can find the changes for each version in the [change log](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/master/changelog.txt).
 
@@ -28,13 +28,13 @@ Find [the latest package in the Maven repository](https://mvnrepository.com/arti
 <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>msal4j</artifactId>
-    <version>1.25.0</version>
+    <version>1.25.1</version>
 </dependency>
 ```
 ### Gradle
 
 ```gradle
-compile group: 'com.microsoft.azure', name: 'msal4j', version: '1.25.0'
+compile group: 'com.microsoft.azure', name: 'msal4j', version: '1.25.1'
 ```
 
 ## Usage

--- a/msal4j-sdk/bnd.bnd
+++ b/msal4j-sdk/bnd.bnd
@@ -1,2 +1,2 @@
-Export-Package: com.microsoft.aad.msal4j;version="1.25.0"
+Export-Package: com.microsoft.aad.msal4j;version="1.25.1"
 Automatic-Module-Name: com.microsoft.aad.msal4j

--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure</groupId>
 	<artifactId>msal4j</artifactId>
-	<version>1.25.0</version>
+	<version>1.25.1</version>
 	<packaging>jar</packaging>
 	<name>msal4j</name>
 	<description>


### PR DESCRIPTION

| PR |  |  
|----|-------|
| #1046 | Extract shared ExtendedCacheKey helper to de-duplicate cache-key plumbing |
| #1045 | Bump Azure Arc HIMDS api-version from 2019-11-01 to 2020-06-01 |
| #1042 | Add DateTimeTests coverage for past expires_on timestamps |
| #1039 | Add claimsFromClient API for client-originated claims |
| #1038 | Migrate region discovery to IMDS /compute JSON endpoint |
| #1030 | Migrate OBO tests to lab1 |