### PR TITLE
Do not carry authority port to default instance discovery host

### DIFF
--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryProvider.java
@@ -20,7 +20,7 @@ class AadInstanceDiscoveryProvider {
 
     private static final String DEFAULT_TRUSTED_HOST = "login.microsoftonline.com";
     private static final String AUTHORIZE_ENDPOINT_TEMPLATE = "https://{host}/{tenant}/oauth2/v2.0/authorize";
-    private static final String INSTANCE_DISCOVERY_ENDPOINT_TEMPLATE = "https://{host}:{port}/common/discovery/instance";
+    private static final String INSTANCE_DISCOVERY_ENDPOINT_TEMPLATE = "https://{host}/common/discovery/instance";
     private static final String INSTANCE_DISCOVERY_REQUEST_PARAMETERS_TEMPLATE = "?api-version=1.1&authorization_endpoint={authorizeEndpoint}";
     private static final String HOST_TEMPLATE_WITH_REGION = "{region}.login.microsoft.com";
     private static final String SOVEREIGN_HOST_TEMPLATE_WITH_REGION = "{region}.{host}";
@@ -219,19 +219,22 @@ class AadInstanceDiscoveryProvider {
                 replace("{tenant}", tenant);
     }
 
-    private static String getInstanceDiscoveryEndpoint(URL authorityUrl) {
+    static String getInstanceDiscoveryEndpoint(URL authorityUrl) {
 
         String discoveryHost = TRUSTED_HOSTS_SET.contains(authorityUrl.getHost()) ?
                 authorityUrl.getHost() :
                 DEFAULT_TRUSTED_HOST;
 
-        int port = authorityUrl.getPort() == PORT_NOT_SET ?
-                authorityUrl.getDefaultPort() :
-                authorityUrl.getPort();
+        if (discoveryHost.equalsIgnoreCase(authorityUrl.getHost())) {
+            int port = authorityUrl.getPort() == PORT_NOT_SET ?
+                    authorityUrl.getDefaultPort() :
+                    authorityUrl.getPort();
+
+            discoveryHost += ":" + port;
+        }
 
         return INSTANCE_DISCOVERY_ENDPOINT_TEMPLATE.
-                replace("{host}", discoveryHost).
-                replace("{port}", String.valueOf(port));
+                replace("{host}", discoveryHost);
     }
 
      static AadInstanceDiscoveryResponse sendInstanceDiscoveryRequest(URL authorityUrl,

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryTest.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/AadInstanceDiscoveryTest.java
@@ -137,6 +137,24 @@ class AadInstanceDiscoveryTest {
         }
     }
 
+    @Test
+    void instanceDiscoveryEndpointDoesNotCarryPortToDefaultTrustedHost() throws Exception {
+        URL authority = new URL("https://custom.example:8443/tenant");
+
+        String endpoint = AadInstanceDiscoveryProvider.getInstanceDiscoveryEndpoint(authority);
+
+        assertEquals("https://login.microsoftonline.com/common/discovery/instance", endpoint);
+    }
+
+    @Test
+    void instanceDiscoveryEndpointPreservesPortForTrustedHost() throws Exception {
+        URL authority = new URL("https://login.microsoftonline.com:8443/tenant");
+
+        String endpoint = AadInstanceDiscoveryProvider.getInstanceDiscoveryEndpoint(authority);
+
+        assertEquals("https://login.microsoftonline.com:8443/common/discovery/instance", endpoint);
+    }
+
     void assertValidResponse(InstanceDiscoveryMetadataEntry entry) {
         assertEquals(entry.preferredNetwork(), "login.microsoftonline.com");
         assertEquals(entry.preferredCache(), "login.windows.net");


### PR DESCRIPTION
## Summary

- use an authority's port for instance discovery only when discovery targets that same host
- use the default HTTPS port when an unknown authority is redirected to the default trusted host
- preserve existing custom-port behavior for trusted authority hosts
- add regression coverage for both host-selection paths

Fixes #1052

## Testing

- `mvn -pl msal4j-sdk -Dtest=AadInstanceDiscoveryTest test -q`