### PR TITLE
Support Azure Arc user-assigned managed identity (fail closed)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,6 @@ Version 1.25.1
 - Add claimsFromClient API for client-originated claims on confidential-client flows (#1039)
 - Migrate region discovery to IMDS /compute JSON endpoint (#1038)
 - Bump Azure Arc HIMDS api-version from 2019-11-01 to 2020-06-01 (#1045)
-- Support Azure Arc user-assigned managed identity, forwarding the client_id/object_id/msi_res_id selector and failing closed if the token response does not confirm the requested identity (#1057)
 - Extract shared ExtendedCacheKey helper to de-duplicate cache-key plumbing (#1046)
 - Fix refreshed tokens not staying in their client-claims cache partition (#1039)
 - Fix extended cache-key hash collision by using a length-prefix encoding of the sorted components (#1047)

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version 1.25.1
 - Add claimsFromClient API for client-originated claims on confidential-client flows (#1039)
 - Migrate region discovery to IMDS /compute JSON endpoint (#1038)
 - Bump Azure Arc HIMDS api-version from 2019-11-01 to 2020-06-01 (#1045)
+- Support Azure Arc user-assigned managed identity, forwarding the client_id/object_id/msi_res_id selector and failing closed if the token response does not confirm the requested identity (#1057)
 - Extract shared ExtendedCacheKey helper to de-duplicate cache-key plumbing (#1046)
 - Fix refreshed tokens not staying in their client-claims cache partition (#1039)
 - Fix extended cache-key hash collision by using a length-prefix encoding of the sorted components (#1047)

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AzureArcManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AzureArcManagedIdentitySource.java
@@ -174,9 +174,20 @@ class AzureArcManagedIdentitySource extends AbstractManagedIdentitySource{
             case OBJECT_ID:
                 echoed = response.getObjectId();
                 break;
-            case RESOURCE_ID:
-                echoed = response.getResourceId();
+            case RESOURCE_ID: {
+                // Azure Arc returns the resource id under msi_res_id; mi_res_id is accepted as a
+                // safety net. If both aliases are present and disagree, the echo cannot be trusted,
+                // so fail closed rather than accept one alias that matches while the other contradicts it.
+                String msiResId = response.getMsiResId();
+                String miResId = response.getMiResId();
+                if (!StringHelper.isNullOrBlank(msiResId) && !StringHelper.isNullOrBlank(miResId)
+                        && !msiResId.equalsIgnoreCase(miResId)) {
+                    echoed = null;
+                } else {
+                    echoed = !StringHelper.isNullOrBlank(msiResId) ? msiResId : miResId;
+                }
                 break;
+            }
             default:
                 echoed = null;
                 break;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AzureArcManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AzureArcManagedIdentitySource.java
@@ -64,13 +64,6 @@ class AzureArcManagedIdentitySource extends AbstractManagedIdentitySource{
     private AzureArcManagedIdentitySource(URI endpoint, MsalRequest msalRequest, ServiceBundle serviceBundle){
         super(msalRequest, serviceBundle, ManagedIdentitySourceType.AZURE_ARC);
         this.MSI_ENDPOINT = endpoint;
-
-        ManagedIdentityIdType idType =
-                ((ManagedIdentityApplication) msalRequest.application()).getManagedIdentityId().getIdType();
-        if (idType != ManagedIdentityIdType.SYSTEM_ASSIGNED) {
-            throw new MsalServiceException(String.format(MsalErrorMessage.MANAGED_IDENTITY_USER_ASSIGNED_NOT_SUPPORTED, AZURE_ARC), MsalError.USER_ASSIGNED_MANAGED_IDENTITY_NOT_SUPPORTED,
-                    ManagedIdentitySourceType.AZURE_ARC);
-        }
     }
 
     @Override
@@ -85,6 +78,12 @@ class AzureArcManagedIdentitySource extends AbstractManagedIdentitySource{
         managedIdentityRequest.queryParameters = new HashMap<>();
         managedIdentityRequest.queryParameters.put("api-version", ARC_API_VERSION);
         managedIdentityRequest.queryParameters.put("resource", resource);
+
+        if (this.idType != null && this.idType != ManagedIdentityIdType.SYSTEM_ASSIGNED
+                && !StringHelper.isNullOrBlank(this.userAssignedId)) {
+            LOG.info("[Managed Identity] Adding user assigned ID to the request for Azure Arc Managed Identity.");
+            managedIdentityRequest.addUserAssignedIdToQuery(this.idType, this.userAssignedId);
+        }
     }
 
     @Override
@@ -144,10 +143,52 @@ class AzureArcManagedIdentitySource extends AbstractManagedIdentitySource{
                         managedIdentitySourceType);
             }
 
-            return  super.handleResponse(parameters, response);
+            ManagedIdentityResponse tokenResponse = super.handleResponse(parameters, response);
+            verifyUserAssignedIdentityWasHonored(tokenResponse);
+            return tokenResponse;
         }
 
-        return super.handleResponse(parameters, response);
+        ManagedIdentityResponse tokenResponse = super.handleResponse(parameters, response);
+        verifyUserAssignedIdentityWasHonored(tokenResponse);
+        return tokenResponse;
+    }
+
+    // verifyUserAssignedIdentityWasHonored fails closed when a user-assigned identity was requested but
+    // Azure Arc did not confirm it in the token response. A legacy Azure Arc agent ignores the
+    // client_id / msi_res_id / object_id selector and silently returns the machine's system-assigned
+    // identity. An agent that supports user-assigned managed identity echoes the identity it used in the
+    // token response; when that echo is missing or does not match the requested selector, MSAL must not
+    // hand back a token for a different identity than the one requested.
+    private void verifyUserAssignedIdentityWasHonored(ManagedIdentityResponse response) {
+        if (idType == null || idType == ManagedIdentityIdType.SYSTEM_ASSIGNED
+                || StringHelper.isNullOrBlank(userAssignedId)) {
+            // System-assigned: there is no requested identity to confirm.
+            return;
+        }
+
+        String echoed;
+        switch (idType) {
+            case CLIENT_ID:
+                echoed = response.getClientId();
+                break;
+            case OBJECT_ID:
+                echoed = response.getObjectId();
+                break;
+            case RESOURCE_ID:
+                echoed = response.getResourceId();
+                break;
+            default:
+                echoed = null;
+                break;
+        }
+
+        // Compare case-insensitively: client_id / object_id are GUIDs, and an ARM resource id
+        // (msi_res_id) can legitimately differ in segment casing.
+        if (StringHelper.isNullOrBlank(echoed) || !echoed.equalsIgnoreCase(userAssignedId)) {
+            LOG.error("[Managed Identity] Azure Arc did not confirm the requested user-assigned managed identity in the token response.");
+            throw new MsalServiceException(String.format(MsalErrorMessage.MANAGED_IDENTITY_USER_ASSIGNED_NOT_CONFIRMED, AZURE_ARC),
+                    MsalError.USER_ASSIGNED_MANAGED_IDENTITY_NOT_CONFIRMED, ManagedIdentitySourceType.AZURE_ARC);
+        }
     }
 
     private Optional<String> readChallengeFrom(IHttpResponse response) {

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AzureArcManagedIdentitySource.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/AzureArcManagedIdentitySource.java
@@ -174,20 +174,13 @@ class AzureArcManagedIdentitySource extends AbstractManagedIdentitySource{
             case OBJECT_ID:
                 echoed = response.getObjectId();
                 break;
-            case RESOURCE_ID: {
-                // Azure Arc returns the resource id under msi_res_id; mi_res_id is accepted as a
-                // safety net. If both aliases are present and disagree, the echo cannot be trusted,
-                // so fail closed rather than accept one alias that matches while the other contradicts it.
-                String msiResId = response.getMsiResId();
-                String miResId = response.getMiResId();
-                if (!StringHelper.isNullOrBlank(msiResId) && !StringHelper.isNullOrBlank(miResId)
-                        && !msiResId.equalsIgnoreCase(miResId)) {
-                    echoed = null;
-                } else {
-                    echoed = !StringHelper.isNullOrBlank(msiResId) ? msiResId : miResId;
-                }
+            case RESOURCE_ID:
+                // Azure Arc returns the resource id under msi_res_id; accept the mi_res_id spelling as a
+                // fallback. This matches MSAL .NET/Go/JS/Python, which prefer msi_res_id and fall back to
+                // mi_res_id.
+                echoed = !StringHelper.isNullOrBlank(response.getMsiResId())
+                        ? response.getMsiResId() : response.getMiResId();
                 break;
-            }
             default:
                 echoed = null;
                 break;

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityRequest.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityRequest.java
@@ -65,9 +65,11 @@ class ManagedIdentityRequest extends MsalRequest {
                 break;
             case RESOURCE_ID:
                 LOG.info("[Managed Identity] Adding user assigned resource id to the request.");
-                if (ManagedIdentityClient.getManagedIdentitySource() == ManagedIdentitySourceType.IMDS) {
-                    // IMDS seems to accept both mi_res_id and msi_res_id but their API only documents msi_res_id,
-                    // and using mi_res_id leads to issues in some scenarios that use the IMDS code path.
+                if (ManagedIdentityClient.getManagedIdentitySource() == ManagedIdentitySourceType.IMDS
+                        || ManagedIdentityClient.getManagedIdentitySource() == ManagedIdentitySourceType.AZURE_ARC) {
+                    // IMDS and Azure Arc only document msi_res_id; the Azure Arc agent silently ignores
+                    // mi_res_id and falls back to the system-assigned identity, so always send msi_res_id
+                    // for these sources.
                     queryParameters.put(Constants.MANAGED_IDENTITY_RESOURCE_ID_IMDS, userAssignedId);
                 } else {
                     queryParameters.put(Constants.MANAGED_IDENTITY_RESOURCE_ID, userAssignedId);

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityResponse.java
@@ -17,6 +17,8 @@ class ManagedIdentityResponse implements JsonSerializable<ManagedIdentityRespons
     String expiresOn;
     String resource;
     String clientId;
+    String objectId;
+    String resourceId;
 
     public static ManagedIdentityResponse fromJson(JsonReader jsonReader) throws IOException {
         ManagedIdentityResponse response = new ManagedIdentityResponse();
@@ -40,6 +42,13 @@ class ManagedIdentityResponse implements JsonSerializable<ManagedIdentityRespons
                     case "client_id":
                         response.clientId = reader.getString();
                         break;
+                    case "object_id":
+                        response.objectId = reader.getString();
+                        break;
+                    case "msi_res_id":
+                    case "mi_res_id":
+                        response.resourceId = reader.getString();
+                        break;
                     default:
                         reader.skipChildren();
                         break;
@@ -57,6 +66,8 @@ class ManagedIdentityResponse implements JsonSerializable<ManagedIdentityRespons
         jsonWriter.writeStringField("expires_on", expiresOn);
         jsonWriter.writeStringField("resource", resource);
         jsonWriter.writeStringField("client_id", clientId);
+        jsonWriter.writeStringField("object_id", objectId);
+        jsonWriter.writeStringField("msi_res_id", resourceId);
         jsonWriter.writeEndObject();
         return jsonWriter;
     }
@@ -79,5 +90,13 @@ class ManagedIdentityResponse implements JsonSerializable<ManagedIdentityRespons
 
     public String getClientId() {
         return this.clientId;
+    }
+
+    public String getObjectId() {
+        return this.objectId;
+    }
+
+    public String getResourceId() {
+        return this.resourceId;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityResponse.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/ManagedIdentityResponse.java
@@ -18,7 +18,8 @@ class ManagedIdentityResponse implements JsonSerializable<ManagedIdentityRespons
     String resource;
     String clientId;
     String objectId;
-    String resourceId;
+    String msiResId;
+    String miResId;
 
     public static ManagedIdentityResponse fromJson(JsonReader jsonReader) throws IOException {
         ManagedIdentityResponse response = new ManagedIdentityResponse();
@@ -46,8 +47,10 @@ class ManagedIdentityResponse implements JsonSerializable<ManagedIdentityRespons
                         response.objectId = reader.getString();
                         break;
                     case "msi_res_id":
+                        response.msiResId = reader.getString();
+                        break;
                     case "mi_res_id":
-                        response.resourceId = reader.getString();
+                        response.miResId = reader.getString();
                         break;
                     default:
                         reader.skipChildren();
@@ -67,7 +70,8 @@ class ManagedIdentityResponse implements JsonSerializable<ManagedIdentityRespons
         jsonWriter.writeStringField("resource", resource);
         jsonWriter.writeStringField("client_id", clientId);
         jsonWriter.writeStringField("object_id", objectId);
-        jsonWriter.writeStringField("msi_res_id", resourceId);
+        jsonWriter.writeStringField("msi_res_id", msiResId);
+        jsonWriter.writeStringField("mi_res_id", miResId);
         jsonWriter.writeEndObject();
         return jsonWriter;
     }
@@ -96,7 +100,11 @@ class ManagedIdentityResponse implements JsonSerializable<ManagedIdentityRespons
         return this.objectId;
     }
 
-    public String getResourceId() {
-        return this.resourceId;
+    public String getMsiResId() {
+        return this.msiResId;
+    }
+
+    public String getMiResId() {
+        return this.miResId;
     }
 }

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalError.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalError.java
@@ -18,6 +18,8 @@ public class MsalError {
      */
     public static final String USER_ASSIGNED_MANAGED_IDENTITY_NOT_SUPPORTED = "user_assigned_managed_identity_not_supported";
 
+    public static final String USER_ASSIGNED_MANAGED_IDENTITY_NOT_CONFIRMED = "user_assigned_managed_identity_not_confirmed";
+
     /**
      * Managed Identity error response was received.
      */

--- a/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalErrorMessage.java
+++ b/msal4j-sdk/src/main/java/com/microsoft/aad/msal4j/MsalErrorMessage.java
@@ -19,6 +19,8 @@ class MsalErrorMessage {
 
     public static final String MANAGED_IDENTITY_USER_ASSIGNED_NOT_SUPPORTED = "[Managed Identity] User assigned identity is not supported by the %s Managed Identity. To authenticate with the system assigned identity use ManagedIdentityApplication.builder(ManagedIdentityId.systemAssigned()).build().";
 
+    public static final String MANAGED_IDENTITY_USER_ASSIGNED_NOT_CONFIRMED = "[Managed Identity] The %s endpoint did not confirm the requested user-assigned managed identity in the token response. The agent likely does not support user-assigned managed identities and returned the system-assigned identity; MSAL will not return a token for a different identity than the one requested.";
+
     public static final String SCOPES_REQUIRED = "At least one scope needs to be requested for this authentication flow. ";
 
     public static final String DEFAULT_MESSAGE = "[Managed Identity] Service request failed.";

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTestDataProvider.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTestDataProvider.java
@@ -62,10 +62,6 @@ class ManagedIdentityTestDataProvider {
                 Arguments.of(ManagedIdentitySourceType.CLOUD_SHELL, ManagedIdentityTestConstants.CLOUDSHELL_ENDPOINT,
                         ManagedIdentityId.userAssignedClientId(ManagedIdentityTestConstants.CLIENT_ID)),
                 Arguments.of(ManagedIdentitySourceType.CLOUD_SHELL, ManagedIdentityTestConstants.CLOUDSHELL_ENDPOINT,
-                        ManagedIdentityId.userAssignedResourceId(ManagedIdentityTestConstants.RESOURCE_ID)),
-                Arguments.of(ManagedIdentitySourceType.AZURE_ARC, ManagedIdentityTestConstants.AZURE_ARC_ENDPOINT,
-                        ManagedIdentityId.userAssignedClientId(ManagedIdentityTestConstants.CLIENT_ID)),
-                Arguments.of(ManagedIdentitySourceType.AZURE_ARC, ManagedIdentityTestConstants.AZURE_ARC_ENDPOINT,
                         ManagedIdentityId.userAssignedResourceId(ManagedIdentityTestConstants.RESOURCE_ID)));
     }
 

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -12,11 +12,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.mockito.ArgumentCaptor;
 
+import java.io.IOException;
 import java.net.SocketException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -975,6 +980,156 @@ class ManagedIdentityTests {
             MsalServiceException msalException = (MsalServiceException) ex.getCause();
             assertEquals(AZURE_ARC.name(), msalException.managedIdentitySource());
             assertEquals(MsalError.USER_ASSIGNED_MANAGED_IDENTITY_NOT_CONFIRMED, msalException.errorCode());
+        }
+
+        @Test
+        void userAssigned_MissingEcho_FailsClosed() throws Exception {
+            ManagedIdentityId id = ManagedIdentityId.userAssignedClientId(ManagedIdentityTestConstants.CLIENT_ID);
+            setUpCommonTest(AZURE_ARC, ManagedIdentityTestConstants.AZURE_ARC_ENDPOINT, id);
+
+            // A legacy agent may return a token with no identity echo at all. MSAL cannot confirm the
+            // requested identity, so it must fail closed.
+            when(httpClientMock.send(expectedRequest(AZURE_ARC, ManagedIdentityTestConstants.RESOURCE, id)))
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_OK,
+                            getSuccessfulResponseWithoutEcho(ManagedIdentityTestConstants.RESOURCE)));
+
+            assertAcquireTokenFailsClosed();
+        }
+
+        @Test
+        void userAssignedResourceId_AcceptsMiResIdAlias_Honored() throws Exception {
+            ManagedIdentityId id = ManagedIdentityId.userAssignedResourceId(ManagedIdentityTestConstants.RESOURCE_ID);
+            setUpCommonTest(AZURE_ARC, ManagedIdentityTestConstants.AZURE_ARC_ENDPOINT, id);
+
+            // The response echoes the resource id only under the alternate "mi_res_id" spelling; accept it.
+            when(httpClientMock.send(expectedRequest(AZURE_ARC, ManagedIdentityTestConstants.RESOURCE, id)))
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_OK,
+                            getSuccessfulResponseWithUserAssignedId(ManagedIdentityTestConstants.RESOURCE,
+                                    Constants.MANAGED_IDENTITY_RESOURCE_ID, ManagedIdentityTestConstants.RESOURCE_ID)));
+
+            IAuthenticationResult result = acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE).get();
+
+            assertTokenFromIdentityProvider(result);
+        }
+
+        @Test
+        void userAssignedResourceId_ConflictingAliasesMsiResIdFirst_FailsClosed() throws Exception {
+            assertConflictingResourceIdAliasesFailClosed(true);
+        }
+
+        @Test
+        void userAssignedResourceId_ConflictingAliasesMiResIdFirst_FailsClosed() throws Exception {
+            assertConflictingResourceIdAliasesFailClosed(false);
+        }
+
+        // The requested resource id matches only the mi_res_id alias while the canonical msi_res_id echoes a
+        // different identity. A matching alias must not rescue a contradictory canonical echo, regardless of
+        // JSON field order, so the response must fail closed.
+        private void assertConflictingResourceIdAliasesFailClosed(boolean msiResIdFirst) throws Exception {
+            ManagedIdentityId id = ManagedIdentityId.userAssignedResourceId(ManagedIdentityTestConstants.RESOURCE_ID);
+            setUpCommonTest(AZURE_ARC, ManagedIdentityTestConstants.AZURE_ARC_ENDPOINT, id);
+
+            String conflictingMsiResId =
+                    "/subscriptions/other/resourcegroups/x/providers/Microsoft.ManagedIdentity/userAssignedIdentities/other";
+            when(httpClientMock.send(expectedRequest(AZURE_ARC, ManagedIdentityTestConstants.RESOURCE, id)))
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_OK,
+                            getSuccessfulResponseWithBothResourceIdAliases(ManagedIdentityTestConstants.RESOURCE,
+                                    conflictingMsiResId, ManagedIdentityTestConstants.RESOURCE_ID, msiResIdFirst)));
+
+            assertAcquireTokenFailsClosed();
+        }
+
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        void userAssignedResourceId_ChallengeFlow_RetainsMsiResIdOnAuthenticatedRequest_Honored() throws Exception {
+            ManagedIdentityId id = ManagedIdentityId.userAssignedResourceId(ManagedIdentityTestConstants.RESOURCE_ID);
+            setUpCommonTest(AZURE_ARC, ManagedIdentityTestConstants.AZURE_ARC_ENDPOINT, id);
+
+            Path secretFile = createArcSecretKeyFile();
+            try {
+                when(httpClientMock.send(any()))
+                        .thenReturn(challengeResponse(secretFile))
+                        .thenReturn(expectedResponse(HttpStatus.HTTP_OK,
+                                getSuccessfulResponseWithUserAssignedId(ManagedIdentityTestConstants.RESOURCE,
+                                        Constants.MANAGED_IDENTITY_RESOURCE_ID_IMDS,
+                                        ManagedIdentityTestConstants.RESOURCE_ID)));
+
+                IAuthenticationResult result = acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE).get();
+                assertTokenFromIdentityProvider(result);
+
+                // The authenticated (second) request must still carry the selector, using the msi_res_id
+                // spelling Azure Arc honors (not mi_res_id).
+                ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+                verify(httpClientMock, times(2)).send(captor.capture());
+                String authenticatedRequestUrl = captor.getAllValues().get(1).url().toString();
+                assertTrue(authenticatedRequestUrl.contains("msi_res_id="),
+                        "authenticated request should retain the msi_res_id selector");
+                assertFalse(authenticatedRequestUrl.contains("mi_res_id="),
+                        "authenticated request must not use the mi_res_id spelling");
+            } finally {
+                Files.deleteIfExists(secretFile);
+            }
+        }
+
+        @Test
+        @EnabledOnOs(OS.WINDOWS)
+        void userAssigned_ChallengeFlow_MismatchedEcho_FailsClosed() throws Exception {
+            ManagedIdentityId id = ManagedIdentityId.userAssignedClientId(ManagedIdentityTestConstants.CLIENT_ID);
+            setUpCommonTest(AZURE_ARC, ManagedIdentityTestConstants.AZURE_ARC_ENDPOINT, id);
+
+            Path secretFile = createArcSecretKeyFile();
+            try {
+                // The authenticated (second) response echoes a different client_id -> fail closed.
+                when(httpClientMock.send(any()))
+                        .thenReturn(challengeResponse(secretFile))
+                        .thenReturn(expectedResponse(HttpStatus.HTTP_OK,
+                                getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
+
+                assertAcquireTokenFailsClosed();
+            } finally {
+                Files.deleteIfExists(secretFile);
+            }
+        }
+
+        private void assertAcquireTokenFailsClosed() throws Exception {
+            CompletableFuture<IAuthenticationResult> future = acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE);
+
+            ExecutionException ex = assertThrows(ExecutionException.class, future::get);
+            assertInstanceOf(MsalServiceException.class, ex.getCause());
+            MsalServiceException msalException = (MsalServiceException) ex.getCause();
+            assertEquals(AZURE_ARC.name(), msalException.managedIdentitySource());
+            assertEquals(MsalError.USER_ASSIGNED_MANAGED_IDENTITY_NOT_CONFIRMED, msalException.errorCode());
+        }
+
+        private HttpResponse challengeResponse(Path secretFile) {
+            HttpResponse response = new HttpResponse();
+            response.statusCode(HttpStatus.HTTP_UNAUTHORIZED);
+            response.headers().put("WWW-Authenticate", singletonList("Basic realm=" + secretFile));
+            return response;
+        }
+
+        private Path createArcSecretKeyFile() throws IOException {
+            Path tokensDir = Paths.get(System.getenv("ProgramData"), "AzureConnectedMachineAgent", "Tokens");
+            Files.createDirectories(tokensDir);
+            Path secretFile = tokensDir.resolve("msal4j-uami-test.key");
+            Files.write(secretFile, "secret".getBytes(StandardCharsets.UTF_8));
+            return secretFile;
+        }
+
+        private String getSuccessfulResponseWithoutEcho(String resource) {
+            long expiresOn = (System.currentTimeMillis() / 1000) + (24 * 3600);
+            return "{\"access_token\":\"accesstoken\",\"expires_on\":\"" + expiresOn + "\",\"resource\":\""
+                    + resource + "\",\"token_type\":\"Bearer\"}";
+        }
+
+        private String getSuccessfulResponseWithBothResourceIdAliases(
+                String resource, String msiResId, String miResId, boolean msiResIdFirst) {
+            long expiresOn = (System.currentTimeMillis() / 1000) + (24 * 3600);
+            String aliases = msiResIdFirst
+                    ? "\"msi_res_id\":\"" + msiResId + "\",\"mi_res_id\":\"" + miResId + "\""
+                    : "\"mi_res_id\":\"" + miResId + "\",\"msi_res_id\":\"" + msiResId + "\"";
+            return "{\"access_token\":\"accesstoken\",\"expires_on\":\"" + expiresOn + "\",\"resource\":\""
+                    + resource + "\",\"token_type\":\"Bearer\"," + aliases + "}";
         }
 
         private String getSuccessfulResponseWithUserAssignedId(String resource, String fieldName, String value) {

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -1111,7 +1111,8 @@ class ManagedIdentityTests {
         private Path createArcSecretKeyFile() throws IOException {
             Path tokensDir = Paths.get(System.getenv("ProgramData"), "AzureConnectedMachineAgent", "Tokens");
             Files.createDirectories(tokensDir);
-            Path secretFile = tokensDir.resolve("msal4j-uami-test.key");
+            // Use a unique temp file so a test can't truncate an existing key or collide with a concurrent run.
+            Path secretFile = Files.createTempFile(tokensDir, "msal4j-uami-test-", ".key");
             Files.write(secretFile, "secret".getBytes(StandardCharsets.UTF_8));
             return secretFile;
         }

--- a/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
+++ b/msal4j-sdk/src/test/java/com/microsoft/aad/msal4j/ManagedIdentityTests.java
@@ -165,7 +165,8 @@ class ManagedIdentityTests {
                 queryParameters.put("client_id", id.getUserAssignedId());
                 break;
             case RESOURCE_ID:
-                if (ManagedIdentityClient.getManagedIdentitySource() == ManagedIdentitySourceType.IMDS) {
+                if (ManagedIdentityClient.getManagedIdentitySource() == ManagedIdentitySourceType.IMDS
+                        || ManagedIdentityClient.getManagedIdentitySource() == ManagedIdentitySourceType.AZURE_ARC) {
                     queryParameters.put(Constants.MANAGED_IDENTITY_RESOURCE_ID_IMDS, id.getUserAssignedId());
                 } else {
                     queryParameters.put(Constants.MANAGED_IDENTITY_RESOURCE_ID, id.getUserAssignedId());
@@ -904,6 +905,82 @@ class ManagedIdentityTests {
 
             assertMsalServiceException(MANAGED_IDENTITY_FILE_READ_ERROR,
                     MANAGED_IDENTITY_INVALID_FILEPATH);
+        }
+
+        @Test
+        void userAssignedClientId_Honored() throws Exception {
+            ManagedIdentityId id = ManagedIdentityId.userAssignedClientId(ManagedIdentityTestConstants.CLIENT_ID);
+            setUpCommonTest(AZURE_ARC, ManagedIdentityTestConstants.AZURE_ARC_ENDPOINT, id);
+
+            when(httpClientMock.send(expectedRequest(AZURE_ARC, ManagedIdentityTestConstants.RESOURCE, id)))
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_OK,
+                            getSuccessfulResponseWithUserAssignedId(ManagedIdentityTestConstants.RESOURCE,
+                                    "client_id", ManagedIdentityTestConstants.CLIENT_ID)));
+
+            IAuthenticationResult result = acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE).get();
+
+            assertTokenFromIdentityProvider(result);
+            verify(httpClientMock, times(1)).send(any());
+        }
+
+        @Test
+        void userAssignedObjectId_Honored() throws Exception {
+            ManagedIdentityId id = ManagedIdentityId.userAssignedObjectId(ManagedIdentityTestConstants.OBJECT_ID);
+            setUpCommonTest(AZURE_ARC, ManagedIdentityTestConstants.AZURE_ARC_ENDPOINT, id);
+
+            when(httpClientMock.send(expectedRequest(AZURE_ARC, ManagedIdentityTestConstants.RESOURCE, id)))
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_OK,
+                            getSuccessfulResponseWithUserAssignedId(ManagedIdentityTestConstants.RESOURCE,
+                                    "object_id", ManagedIdentityTestConstants.OBJECT_ID)));
+
+            IAuthenticationResult result = acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE).get();
+
+            assertTokenFromIdentityProvider(result);
+            verify(httpClientMock, times(1)).send(any());
+        }
+
+        @Test
+        void userAssignedResourceId_ForwardsMsiResIdAndHonored() throws Exception {
+            ManagedIdentityId id = ManagedIdentityId.userAssignedResourceId(ManagedIdentityTestConstants.RESOURCE_ID);
+            setUpCommonTest(AZURE_ARC, ManagedIdentityTestConstants.AZURE_ARC_ENDPOINT, id);
+
+            // expectedRequest asserts the resource id is forwarded as msi_res_id (not mi_res_id) for Azure Arc.
+            when(httpClientMock.send(expectedRequest(AZURE_ARC, ManagedIdentityTestConstants.RESOURCE, id)))
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_OK,
+                            getSuccessfulResponseWithUserAssignedId(ManagedIdentityTestConstants.RESOURCE,
+                                    Constants.MANAGED_IDENTITY_RESOURCE_ID_IMDS, ManagedIdentityTestConstants.RESOURCE_ID)));
+
+            IAuthenticationResult result = acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE).get();
+
+            assertTokenFromIdentityProvider(result);
+            verify(httpClientMock, times(1)).send(any());
+        }
+
+        @Test
+        void userAssigned_NotConfirmed_FailsClosed() throws Exception {
+            ManagedIdentityId id = ManagedIdentityId.userAssignedClientId(ManagedIdentityTestConstants.CLIENT_ID);
+            setUpCommonTest(AZURE_ARC, ManagedIdentityTestConstants.AZURE_ARC_ENDPOINT, id);
+
+            // A legacy Azure Arc agent ignores the selector and returns the system-assigned identity, so the
+            // response does not echo the requested client_id. MSAL must fail closed rather than hand back a
+            // token that may belong to a different identity than the one requested.
+            when(httpClientMock.send(expectedRequest(AZURE_ARC, ManagedIdentityTestConstants.RESOURCE, id)))
+                    .thenReturn(expectedResponse(HttpStatus.HTTP_OK,
+                            getSuccessfulResponse(ManagedIdentityTestConstants.RESOURCE)));
+
+            CompletableFuture<IAuthenticationResult> future = acquireTokenCommon(ManagedIdentityTestConstants.RESOURCE);
+
+            ExecutionException ex = assertThrows(ExecutionException.class, future::get);
+            assertInstanceOf(MsalServiceException.class, ex.getCause());
+            MsalServiceException msalException = (MsalServiceException) ex.getCause();
+            assertEquals(AZURE_ARC.name(), msalException.managedIdentitySource());
+            assertEquals(MsalError.USER_ASSIGNED_MANAGED_IDENTITY_NOT_CONFIRMED, msalException.errorCode());
+        }
+
+        private String getSuccessfulResponseWithUserAssignedId(String resource, String fieldName, String value) {
+            long expiresOn = (System.currentTimeMillis() / 1000) + (24 * 3600);
+            return "{\"access_token\":\"accesstoken\",\"expires_on\":\"" + expiresOn + "\",\"resource\":\""
+                    + resource + "\",\"token_type\":\"Bearer\",\"" + fieldName + "\":\"" + value + "\"}";
         }
 
         private void mockHttpResponse(Map<String, ? extends List<String>> responseHeaders) throws Exception {


### PR DESCRIPTION
## Summary

Adds **Azure Arc user-assigned managed identity (UAMI)** support to MSAL Java, bringing it to parity with MSAL .NET ([#6128](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/pull/6128)) and MSAL Go ([#644](https://github.com/AzureAD/microsoft-authentication-library-for-go/pull/644)).

Previously `AzureArcManagedIdentitySource` rejected any user-assigned identity at construction. Azure Arc agents that support UAMI accept a `client_id` / `object_id` / `msi_res_id` selector on the token request and echo the identity they used in the response.

## Changes

- **Forward the selector** on the Arc request (`client_id` / `object_id` / `msi_res_id`). Remove the `USER_ASSIGNED_MANAGED_IDENTITY_NOT_SUPPORTED` rejection.
- **Use `msi_res_id` (not `mi_res_id`) for Azure Arc** resource-id selection. A live Azure Connected Machine agent silently ignores `mi_res_id` and falls back to the system-assigned identity; it honors `msi_res_id`.
- **Fail closed**: after a 200, verify the echoed identity matches the requested selector (case-insensitive; `mi_res_id` accepted as a safety net). If it is missing or does not match, throw `USER_ASSIGNED_MANAGED_IDENTITY_NOT_CONFIRMED` so MSAL never returns a token for a different identity than requested. System-assigned is unaffected; genuine service errors surface as before.
- `ManagedIdentityResponse` now parses the `object_id` / `msi_res_id` / `mi_res_id` echo fields.

## Tests

`ManagedIdentityTests` (nested `AzureArc`): Arc is no longer in the "user-assigned not supported" set; added honored `client_id` / `object_id`, `msi_res_id` forwarding, and fail-closed cases. **11/11 Arc tests pass** (`mvn -pl msal4j-sdk test`).

## Note

Like the .NET/Go/JS PRs, this is gated on broad Azure Connected Machine agent support for UAMI