### PR TITLE
Version updates for 1.26.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@
 - **Main Package**: `com.microsoft.aad.msal4j`
 - **Three Application Types**: `PublicClientApplication`, `ConfidentialClientApplication`, `ManagedIdentityApplication`
 - **Pattern**: Each auth flow has `*Parameters` (public API), `*Request` (internal), `*Supplier` (executor)
-- **Current Version**: 1.25.1
+- **Current Version**: 1.26.0
 
 ---
 
@@ -16,7 +16,7 @@
 
 - **Language**: Java 8+
 - **Build Tool**: Maven
-- **Current Version**: 1.25.1
+- **Current Version**: 1.26.0
 - **Artifact**: `com.microsoft.azure:msal4j`
 - **Key Protocols**: OAuth2, OpenID Connect
 
@@ -236,4 +236,3 @@ Update this file whenever you make changes that affect:
 By keeping these instructions current, you help ensure that future Copilot agents (and developers) can quickly understand and work with the MSAL Java library effectively.
 
 ---
-

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Quick links:
 The library supports the following Java environments:
 - Java 8 (or higher)
 
-Current version - 1.25.1
+Current version - 1.26.0
 
 You can find the changes for each version in the [change log](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/main/msal4j-sdk/changelog.txt).
 
@@ -28,13 +28,13 @@ Find [the latest package in the Maven repository](https://mvnrepository.com/arti
 <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>msal4j</artifactId>
-    <version>1.25.1</version>
+    <version>1.26.0</version>
 </dependency>
 ```
 ### Gradle
 
 ```gradle
-implementation group: 'com.microsoft.azure', name: 'com.microsoft.aad.msal4j', version: '1.25.1'
+implementation group: 'com.microsoft.azure', name: 'com.microsoft.aad.msal4j', version: '1.26.0'
 ```
 
 ## Usage

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,12 @@
+Version 1.26.0
+=============
+- Add Azure Arc user-assigned managed identity support with validation that the requested identity was honored (#1057)
+- Scope HTTP 5xx throttling per user in public-client flows while preserving app-wide throttling for HTTP 429 responses (#1055)
+- Harden regional authority validation and fall back to the global endpoint for invalid region values (#1051, #1056)
+- Fix instance discovery incorrectly carrying a custom authority port to the default discovery host (#1053)
+- Fix custom IMDS endpoint URLs built from AZURE_POD_IDENTITY_AUTHORITY_HOST containing a double slash (#1060)
+- Fix extended cache-key hash collisions by using length-prefixed components (#1048)
+
 Version 1.25.1
 =============
 - Add claimsFromClient API for client-originated claims on confidential-client flows (#1039)
@@ -5,7 +14,6 @@ Version 1.25.1
 - Bump Azure Arc HIMDS api-version from 2019-11-01 to 2020-06-01 (#1045)
 - Extract shared ExtendedCacheKey helper to de-duplicate cache-key plumbing (#1046)
 - Fix refreshed tokens not staying in their client-claims cache partition (#1039)
-- Fix extended cache-key hash collision by using a length-prefix encoding of the sorted components (#1047)
 
 Version 1.25.0
 =============

--- a/msal4j-sdk/README.md
+++ b/msal4j-sdk/README.md
@@ -16,7 +16,7 @@ Quick links:
 The library supports the following Java environments:
 - Java 8 (or higher)
 
-Current version - 1.25.1
+Current version - 1.26.0
 
 You can find the changes for each version in the [change log](https://github.com/AzureAD/microsoft-authentication-library-for-java/blob/master/changelog.txt).
 
@@ -28,13 +28,13 @@ Find [the latest package in the Maven repository](https://mvnrepository.com/arti
 <dependency>
     <groupId>com.microsoft.azure</groupId>
     <artifactId>msal4j</artifactId>
-    <version>1.25.1</version>
+    <version>1.26.0</version>
 </dependency>
 ```
 ### Gradle
 
 ```gradle
-compile group: 'com.microsoft.azure', name: 'msal4j', version: '1.25.1'
+compile group: 'com.microsoft.azure', name: 'msal4j', version: '1.26.0'
 ```
 
 ## Usage

--- a/msal4j-sdk/bnd.bnd
+++ b/msal4j-sdk/bnd.bnd
@@ -1,2 +1,2 @@
-Export-Package: com.microsoft.aad.msal4j;version="1.25.1"
+Export-Package: com.microsoft.aad.msal4j;version="1.26.0"
 Automatic-Module-Name: com.microsoft.aad.msal4j

--- a/msal4j-sdk/pom.xml
+++ b/msal4j-sdk/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure</groupId>
 	<artifactId>msal4j</artifactId>
-	<version>1.25.1</version>
+	<version>1.26.0</version>
 	<packaging>jar</packaging>
 	<name>msal4j</name>
 	<description>


### PR DESCRIPTION
| PR | Change |
|----|--------|
| [#1060](https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/1060) | Fix custom IMDS endpoint path construction |
| [#1057](https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/1057) | Support Azure Arc user-assigned managed identity (fail closed) |
| [#1056](https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/1056) | Harden regional authority validation |
| [#1055](https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/1055) | Scope error-class throttling per-user for public-client flows |
| [#1053](https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/1053) | Do not carry authority port to default instance discovery host |
| [#1051](https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/1051) | Validate region string format before use in URL construction |
| [#1048](https://github.com/AzureAD/microsoft-authentication-library-for-java/pull/1048) | Fix cache key hash collision with length-prefixed extended cache key components |